### PR TITLE
feat: 도메인 JSON CLI 추가

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,3 @@
 
 [features]
-codex_hooks = true
+hooks = true

--- a/apps/cluefin-cli/README.md
+++ b/apps/cluefin-cli/README.md
@@ -1,409 +1,158 @@
 # Cluefin CLI
 
-기술적 지표, 터미널 차트 및 **머신러닝 기반 가격 예측**을 제공하는 한국 주식 시장 분석용 강력한 명령줄 인터페이스입니다.
+`cluefin-cli`는 한국 금융시장 데이터를 도메인 단위로 조회하는 사용자용 CLI입니다. AI Agent와 자동화에서 안정적으로 소비할 수 있도록 모든 신규 도메인 명령은 `--json` 출력을 지원합니다.
 
-![CLI Demo](https://img.shields.io/badge/CLI-Korean%20Stock%20Analysis-blue)
-![Python](https://img.shields.io/badge/Python-3.10%2B-green)
-![ML](https://img.shields.io/badge/ML-LightGBM%20%2B%20SHAP-orange)
-![License](https://img.shields.io/badge/License-MIT-yellow)
+## 설치
 
-## ✨ 주요 기능
-
-### **포괄적 주식 분석**
-- 실시간 한국 주식 데이터 분석 (KOSPI, KOSDAQ)
-- 외국인 거래량 분석 (매수/매도 흐름)
-- 시장 지수 모니터링 (KOSPI, KOSDAQ)
-- 다중 기간 분석 (1개월, 3개월, 6개월, 1년)
-- DART 공시 기반 펀더멘털 데이터 (배당, 재무지표, 주요 주주)
-
-### **기술적 지표**
-- **RSI (상대강도지수)** - 과매수/과매도 상황을 위한 모멘텀 오실레이터
-- **MACD (이동평균수렴확산)** - 추세 추종 모멘텀 지표
-- **이동평균선** - SMA(5, 20, 50) 및 EMA(12, 26)
-- **볼린저 밴드** - 변동성 및 추세 분석
-- **스토캐스틱 오실레이터** - 종가와 가격대를 비교하는 모멘텀 지표
-- **지지/저항 레벨** - 주요 가격대 식별
-
-### **터미널 시각화**
-- 터미널에서 직접 렌더링되는 아름다운 ASCII 차트
-- 이동평균선 오버레이가 포함된 가격 차트
-- 거래량 분석 차트
-- 과매수/과매도 구간이 포함된 RSI 오실레이터 시각화
-- MACD 히스토그램 및 시그널 라인 차트
-- 색상으로 구분된 데이터가 포함된 풍부한 형식의 테이블
-
-
-### **🤖 머신러닝 예측**
-- **LightGBM 기반 분류** - 익일 가격 움직임에 대한 이진 예측
-- **150개 이상의 기술적 지표** - cluefin-ta를 사용한 향상된 피처 엔지니어링
-- **SHAP 모델 해석가능성** - 예측을 주도하는 피처 이해
-- **피처 중요도 분석** - 가격 움직임에 영향을 미치는 주요 요소 식별
-- **시계열 교차검증** - 시계열 데이터를 위한 적절한 검증
-- **성능 메트릭** - 정확도, 정밀도, 재현율, F1-score, AUC
-
-## 🚀 빠른 시작
-
-### 사전 요구사항
-- Python 3.10 이상
-- uv 패키지 매니저
-- **LightGBM 시스템 의존성** (ML 기능용)
-
-### 설치
-
-1. **저장소 클론 및 워크스페이스 설정:**
-```bash
-git clone https://github.com/kgcrom/cluefin
-cd cluefin
-uv venv --python 3.10
-```
-
-2. **시스템 의존성 설치:**
-```bash
-# macOS
-brew install lightgbm
-```
-
-3. **모든 워크스페이스 의존성 설치:**
 ```bash
 uv sync --all-packages
 ```
 
-4. **환경 설정 (선택사항):**
+API 조회에는 `.env`에 Kiwoom, KIS, DART 인증 정보를 설정해야 합니다.
+
 ```bash
 cp apps/cluefin-cli/.env.sample .env
-# .env 파일에 API 키 설정 (KIWOOM_APP_KEY, KIWOOM_SECRET_KEY, KIWOOM_ENV, DART_AUTH_KEY)
 ```
 
-### 기본 사용법
+## JSON 출력
+
+JSON 모드는 stdout에 banner, progress, Rich table이 섞이지 않는 envelope를 출력합니다.
+
+성공 envelope:
+
+```json
+{
+  "ok": true,
+  "command": "chart",
+  "source": "kiwoom",
+  "params": {},
+  "data": {},
+  "warnings": [],
+  "meta": {}
+}
+```
+
+실패 envelope:
+
+```json
+{
+  "ok": false,
+  "command": "chart",
+  "error": {
+    "type": "ValueError",
+    "message": "missing credentials"
+  },
+  "warnings": [],
+  "meta": {}
+}
+```
+
+## 도메인 명령
+
+### `statements`
+
+재무제표, 재무지표, 배당, 주요주주, XBRL 데이터를 조회합니다.
 
 ```bash
-# 기본 주식 분석
+cluefin-cli statements 005930 --json
+cluefin-cli statements 005930 --source all --year 2024 --report annual --include-xbrl --statement-type BS --json
+```
+
+주요 옵션:
+
+- `--source auto|dart|kis|all`
+- `--year YYYY`
+- `--report annual|q1|half|q3`
+- `--include-xbrl`
+- `--statement-type BS|IS|CIS|CF|SCE`
+
+### `chart`
+
+Kiwoom 또는 KIS OHLCV를 공통 DTO로 정규화하고, 필요하면 `cluefin-ta` 기반 지표를 포함합니다.
+
+```bash
+cluefin-cli chart 005930 --indicators --json
+cluefin-cli chart 005930 --source kis --interval daily --days 120 --json
+```
+
+주요 옵션:
+
+- `--source auto|kiwoom|kis`
+- `--interval daily|minute`
+- `--days INTEGER`
+- `--volume`
+- `--indicators`
+- `--render`
+
+### `news`
+
+KIS 시장 공시/뉴스 제목과 DART 공시 검색 결과를 조회합니다.
+
+```bash
+cluefin-cli news 005930 --source all --json
+cluefin-cli news --query 실적 --days 14 --json
+```
+
+주요 옵션:
+
+- `--source auto|kis|dart|all`
+- `--days INTEGER`
+- `--query TEXT`
+
+### `trading-flow`
+
+Kiwoom/KIS 투자자별 수급 데이터를 공통 DTO로 정규화합니다.
+
+```bash
+cluefin-cli trading-flow 005930 --json
+cluefin-cli trading-flow 005930 --source all --start-date 20240101 --end-date 20241231 --json
+```
+
+주요 옵션:
+
+- `--source auto|kiwoom|kis|all`
+- `--start-date YYYYMMDD`
+- `--end-date YYYYMMDD`
+
+날짜를 지정하지 않으면 최근 1년을 기본 범위로 사용합니다.
+
+### `market`
+
+시장/업종/랭킹/테마성 데이터를 대표 시나리오 중심으로 조회합니다.
+
+```bash
+cluefin-cli market volume --json
+cluefin-cli market ranking --json
+cluefin-cli market theme --json
+cluefin-cli market sector --json
+```
+
+공통 옵션:
+
+- `--source auto|kis|kiwoom|all`
+- `--limit INTEGER`
+
+기본 source:
+
+- `volume`: KIS
+- `ranking`: KIS
+- `theme`: Kiwoom
+- `sector`: KIS
+
+## Deprecated Commands
+
+기존 명령은 호환성을 위해 아직 등록되어 있지만 deprecation 예정입니다. 신규 자동화와 Agent 연동은 위 도메인 명령을 사용하세요.
+
+```bash
 cluefin-cli ta 005930
-
-# 터미널 차트 포함
-cluefin-cli ta 005930 --chart
-
-# 🤖 ML 예측 포함
-cluefin-cli ta 005930 --ml-predict
-
-# 📊 기본 피처 중요도 포함
-cluefin-cli ta 005930 --ml-predict --feature-importance
-
-# 🔍 상세 SHAP 분석 포함
-cluefin-cli ta 005930 --ml-predict --shap-analysis
-
-# 🚀 전체 분석 (모든 기능)
-cluefin-cli ta 005930 --chart --ml-predict --shap-analysis
-
-# 📘 펀더멘털 분석 (DART)
 cluefin-cli fa 005930
-
-# 📘 2023 사업보고서 기준 펀더멘털 분석 (상위 3명 주주)
-cluefin-cli fa 005930 --year 2023 --report annual --max-shareholders 3
+cluefin-cli xbrl 005930
 ```
 
-## 명령어 참조
-
-### `ta` 명령어
-
-포괄적인 기술적 지표 및 시장 데이터로 한국 주식을 분석합니다.
+## 개발 검증
 
 ```bash
-cluefin-cli ta [OPTIONS] STOCK_CODE
+uv run pytest apps/cluefin-cli/tests -v
+uv run ruff format . --check
+uv run ruff check .
 ```
-
-#### 인수
-- `STOCK_CODE` - 한국 주식 코드 (예: 삼성전자는 `005930`)
-
-#### 옵션
-- `-c, --chart` - 터미널에서 대화형 차트 표시
-- `-m, --ml-predict` - ML 기반 가격 예측 포함 🤖
-- `-f, --feature-importance` - 기본 피처 중요도 표시 (--ml-predict 필요) 📊
-- `-s, --shap-analysis` - 설명이 포함된 상세 SHAP 분석 표시 (--ml-predict 필요) 🔍
-- `--help` - 명령어 도움말 표시
-
-#### 예제
-
-```bash
-# 삼성전자 기본 분석
-cluefin-cli ta 005930
-
-# SK하이닉스 차트 포함
-cluefin-cli ta 000660 --chart
-
-# 삼성전자 ML 예측 포함
-cluefin-cli ta 005930 --ml-predict
-
-# LG화학 ML + 기본 피처 중요도
-cluefin-cli ta 051910 --ml-predict --feature-importance
-
-# 삼성바이오로직스 ML + 상세 SHAP 분석
-cluefin-cli ta 207940 --ml-predict --shap-analysis
-
-# LG에너지솔루션 - 전체 분석
-cluefin-cli ta 373220 --chart --ml-predict --shap-analysis
-```
-
-### `fa` 명령어
-
-DART 공시 데이터를 기반으로 기업의 펀더멘털 정보를 조회합니다.
-
-```bash
-cluefin-cli fa [OPTIONS] STOCK_CODE
-```
-
-#### 인수
-- `STOCK_CODE` - 한국 주식 코드 (예: 삼성전자는 `005930`)
-
-#### 옵션
-- `--year` - 조회할 사업연도 (기본값: 전년도)
-- `--report` - 공시 보고서 구분 (`annual`, `q1`, `half`, `q3`)
-- `--max-shareholders` - 출력할 주요 주주 수 (기본값: 5)
-- `--help` - 명령어 도움말 표시
-
-#### 예제
-
-```bash
-# 2023 사업보고서를 기준으로 삼성전자 기본적 분석
-cluefin-cli fa 005930 --year 2023 --report annual
-
-# 상위 3명의 주요 주주만 확인
-cluefin-cli fa 005930 --max-shareholders 3
-```
-
-## 📈 지원 종목
-
-CLI는 KOSPI와 KOSDAQ에서 거래되는 모든 한국 주식을 지원합니다. 다음은 인기 종목 예시입니다:
-
-| 종목 코드 | 회사명 | 시장 |
-|----------|--------|------|
-| `005930` | 삼성전자 | KOSPI |
-| `000660` | SK하이닉스 | KOSPI |
-| `035420` | NAVER | KOSPI |
-| `051910` | LG화학 | KOSPI |
-| `207940` | 삼성바이오로직스 | KOSPI |
-| `373220` | LG에너지솔루션 | KOSPI |
-
-## 설정
-
-### 환경 변수
-
-**워크스페이스 루트** 디렉토리에 `.env` 파일을 생성하세요:
-
-```env
-# 키움증권 API (실시간 한국 주식 데이터용)
-KIWOOM_APP_KEY=your_app_key_here
-KIWOOM_SECRET_KEY=your_secret_key_here
-KIWOOM_ENV=prod # 옵션: prod | dev(기본값)
-
-# 금융감독원 DART API
-DART_AUTH_KEY=your_dart_auth_key_here
-
-# ML 모델 설정 (선택사항)
-ML_MODEL_PATH=models/
-ML_CACHE_DIR=.ml_cache/
-```
-
-### API 연동
-
-CLI는 `cluefin-openapi` 패키지를 통해 한국 금융 API와 연동됩니다:
-
-1. **키움증권 API**: 실시간 주식 데이터, 주문, 계좌 정보를 위한 OAuth2 스타일 인증
-2. **금융감독원(DART)**: 기업 공시, 정기 보고서, 배당, 주주 데이터
-
-**참고**: API 키 없이도 데모용 목업 데이터를 사용하여 제한된 기능으로 CLI를 사용할 수 있습니다.
-
-## 출력 예시
-
-### 기본 분석 출력
-
-Stock Information - 005930
-
-| Metric        | Value            |
-|---------------|------------------|
-| Current Price | 64,775          |
-| Change        | -1,300 (-1.97%) |
-| Volume        | 7,544,353        |
-
-Technical Indicators
-
-| Indicator | Value    | Signal     |
-|-----------|----------|------------|
-| RSI (14)  | 57.60    | Neutral    |
-| MACD      | 429.71   | Bullish    |
-| SMA (20)  | 63,110  | Above MA20 |
-
-### 🤖 ML 예측 출력
-
-```
-==================================================
-🎯 ML Prediction Results
-┌─────────────────────────────────────────────────┐
-│ Signal: 📈 BUY (67.3%)                         │
-│ Confidence: 67.3%                              │
-│ Up Probability: 67.3%                          │
-│ Down Probability: 32.7%                        │
-└─────────────────────────────────────────────────┘
-
-📊 Model Performance
-┌─────────────────────────────────────────────────┐
-│ Validation Accuracy: 64.2%                     │
-│ Validation F1-Score: 0.638                     │
-│ Validation AUC: 0.721                          │
-└─────────────────────────────────────────────────┘
-```
-
-### 🔍 SHAP 분석 출력
-
-```
-🔍 Top 15 Feature Importance (SHAP)
-┌──────┬─────────────────────┬────────────┬────────────┬────────────┐
-│ Rank │ Feature             │ Importance │ Mean SHAP  │ Impact     │
-├──────┼─────────────────────┼────────────┼────────────┼────────────┤
-│  1   │ rsi_14             │   0.0234   │  +0.0156   │ 📈 UP     │
-│  2   │ macd_signal        │   0.0198   │  -0.0087   │ 📉 DOWN   │
-│  3   │ bb_position        │   0.0167   │  +0.0123   │ 📈 UP     │
-│  4   │ volume_ratio       │   0.0142   │  +0.0089   │ 📈 UP     │
-│  5   │ sma_20             │   0.0134   │  -0.0067   │ 📉 DOWN   │
-└──────┴─────────────────────┴────────────┴────────────┴────────────┘
-```
-
-### 차트 시각화
-`--chart` 옵션은 터미널에서 직접 아름다운 ASCII 차트를 표시합니다:
-- 이동평균선이 포함된 가격 차트
-- 거래량 분석
-- 주요 레벨이 포함된 RSI 오실레이터
-- 시그널 라인과 히스토그램이 포함된 MACD
-
-
-## 개발
-
-### 프로젝트 구조
-```
-apps/cluefin-cli/
-├── src/cluefin_cli/              # 메인 애플리케이션 코드
-│   ├── commands/                 # CLI 명령어 구현
-│   │   ├── analysis/             # 기술적 분석 모듈
-│   │   │   └── indicators.py     # 기술적 지표 계산
-│   │   ├── technical_analysis.py # 메인 TA 명령어 (Click 기반)
-│   │   ├── fundamental_analysis.py # 펀더멘털 분석 명령어
-│   │   └── import_cmd.py         # 데이터 임포트 명령어
-│   ├── config/                   # 애플리케이션 설정
-│   │   └── settings.py           # Pydantic 설정 관리
-│   ├── data/                     # 데이터 레이어 추상화
-│   │   ├── duckdb_manager.py     # DuckDB 데이터베이스 관리
-│   │   ├── fetcher.py            # cluefin-openapi에서 데이터 조회
-│   │   ├── importer.py           # 주식 차트 데이터 임포터
-│   │   ├── industry_importer.py  # 업종 코드 임포터
-│   │   └── industry_chart_importer.py # 업종 차트 데이터 임포터
-│   ├── display/                  # 터미널 시각화
-│   │   └── charts.py             # ASCII 차트 렌더링 (plotext)
-│   ├── ml/                       # 🤖 머신러닝 파이프라인
-│   │   ├── diagnostics.py        # 모델 성능 평가
-│   │   ├── explainer.py          # SHAP 기반 모델 해석가능성
-│   │   ├── feature_engineering.py  # cluefin-ta 피처 생성 (150+ 지표)
-│   │   ├── models.py             # LightGBM 분류기 구현
-│   │   └── predictor.py          # 완전한 ML 예측 파이프라인
-│   ├── utils/                    # 공유 유틸리티
-│   │   └── formatters.py         # 한국 통화 및 텍스트 포맷팅
-│   └── main.py                   # CLI 진입점 및 Click 앱
-├── tests/unit/                   # 단위 테스트 모음
-│   ├── commands/                 # 명령어 테스트
-│   └── ml/                       # ML 파이프라인 및 모델 테스트
-├── pyproject.toml               # 패키지 의존성 및 설정
-└── README.md                    # 이 문서
-```
-
-### 새 기능 추가
-
-1. **새 기술적 지표**: `src/cluefin_cli/commands/analysis/indicators.py` 또는 `src/cluefin_cli/ml/feature_engineering.py`에 추가
-2. **차트 유형**: `src/cluefin_cli/display/charts.py` 확장
-3. **데이터 소스**: `src/cluefin_cli/data/fetcher.py` 수정
-4. **CLI 명령어**: `src/cluefin_cli/commands/`에 새 명령어 추가
-5. **ML 모델**: `src/cluefin_cli/ml/models.py` 확장 또는 새 모델 클래스 추가
-6. **SHAP 시각화**: `src/cluefin_cli/ml/explainer.py` 개선
-7. **유틸리티 함수**: `src/cluefin_cli/utils/formatters.py`에 추가
-
-### 테스트 실행
-
-```bash
-# 워크스페이스 루트 디렉토리에서
-cd cluefin
-
-# 모든 CLI 테스트 실행
-uv run pytest apps/cluefin-cli/tests/ -v
-
-# 단위 테스트만 실행 (통합 테스트 제외)
-uv run pytest -m "not integration"
-
-# 특정 테스트 모듈 실행
-uv run pytest apps/cluefin-cli/tests/unit/ml/test_ml_pipeline.py -v
-
-# 코드 품질 검사
-uv run ruff check . --fix
-uv run ruff format .
-
-# 실제 예제로 ML 파이프라인 테스트
-cluefin-cli ta 005930 --ml-predict --shap-analysis
-```
-
-### 🤖 ML 모델 아키텍처
-
-ML 예측 시스템은 정교한 파이프라인을 사용합니다:
-
-1. **피처 엔지니어링** (150+ 피처)
-   - cluefin-ta 기술적 지표 (RSI, MACD, 볼린저 밴드 등)
-   - 커스텀 가격 기반 피처 (비율, 변동성, 모멘텀)
-   - 시간적 패턴을 위한 래그 피처
-   - 거래량 기반 지표
-
-2. **모델 학습**
-   - **LightGBM 분류기**: 상승/하락 이진 예측
-   - **시계열 분할**: 데이터 누수 방지
-   - **조기 중단**: 과적합 방지
-   - **교차 검증**: 적절한 시간 순서 유지
-
-3. **모델 해석**
-   - **SHAP TreeExplainer**: 피처 중요도
-   - **개별 예측 설명**
-   - **전역 피처 순위**
-   - **방향성 영향 분석** (긍정/부정 기여도)
-
-### ML 성능 가이드라인
-
-- **정확도 > 60%**: 좋은 예측 성능
-- **AUC > 0.7**: 상승/하락 움직임 간 우수한 구별력
-- **F1-Score > 0.6**: 균형 잡힌 정밀도와 재현율
-- **최소 30일**: 학습에 필요한 과거 데이터
-- **권장 100일 이상**: 신뢰할 수 있는 모델 성능을 위해
-
-**⚠️ 중요**: 주가 예측은 본질적으로 불확실합니다. ML 예측을 투자 결정 시 여러 요소 중 하나로 활용하세요.
-
-## 기여하기
-
-1. 저장소 포크
-2. 피처 브랜치 생성 (`git checkout -b feature/amazing-feature`)
-3. 변경사항 커밋 (`git commit -m 'Add amazing feature'`)
-4. 브랜치에 푸시 (`git push origin feature/amazing-feature`)
-5. Pull Request 열기
-
-## 라이선스
-
-이 프로젝트는 MIT 라이선스에 따라 라이선스가 부여됩니다. 자세한 내용은 [LICENSE](../../LICENSE) 파일을 참조하세요.
-
-## 지원
-
-- **문서**: 메인 [Cluefin 문서](../../README.md) 확인
-- **이슈**: [GitHub Issues](https://github.com/kgcrom/cluefin/issues)에서 버그 신고 또는 기능 요청
-- **토론**: [GitHub Discussions](https://github.com/kgcrom/cluefin/discussions)에서 커뮤니티 토론 참여
-
-## 관련 프로젝트
-
-- **[cluefin-openapi](../../packages/cluefin-openapi/)** - 한국 금융 API 클라이언트
-- **[cluefin-ta](../../packages/cluefin-ta/)** - 순수 Python 기술적 분석 라이브러리
-
----
-
-**한국 금융 시장을 위해 정성을 담아 만들었습니다**
-
-*"Clearly Looking U Entered Financial Information"*

--- a/apps/cluefin-cli/src/cluefin_cli/command_metadata.py
+++ b/apps/cluefin-cli/src/cluefin_cli/command_metadata.py
@@ -1,0 +1,208 @@
+"""Static command metadata for AI-friendly CLI discovery."""
+
+from __future__ import annotations
+
+from typing import Any
+
+DOMAIN_COMMANDS: list[dict[str, Any]] = [
+    {
+        "name": "statements",
+        "summary": "Fetch financial statements, metrics, dividends, shareholders, and optional DART XBRL data.",
+        "usage": "cluefin-cli statements STOCK_CODE [OPTIONS]",
+        "arguments": [
+            {
+                "name": "stock_code",
+                "required": True,
+                "description": "Korean stock code, for example 005930.",
+            }
+        ],
+        "options": [
+            {
+                "name": "--source",
+                "type": "choice",
+                "choices": ["auto", "dart", "kis", "all"],
+                "default": "auto",
+                "description": "Data provider selection. auto prefers DART and uses KIS only when explicitly requested.",
+            },
+            {"name": "--year", "type": "string", "default": "previous_year", "description": "Business year YYYY."},
+            {
+                "name": "--report",
+                "type": "choice",
+                "choices": ["annual", "q1", "half", "q3"],
+                "default": "annual",
+                "description": "DART report period.",
+            },
+            {
+                "name": "--include-xbrl",
+                "type": "boolean",
+                "default": False,
+                "description": "Include DART XBRL statement extraction when available.",
+            },
+            {
+                "name": "--statement-type",
+                "type": "choice",
+                "choices": ["BS", "IS", "CIS", "CF", "SCE"],
+                "default": None,
+                "description": "Filter XBRL statement type.",
+            },
+            {"name": "--json", "type": "boolean", "default": False, "description": "Emit JSON data envelope."},
+        ],
+        "examples": [
+            "cluefin-cli statements 005930 --json",
+            "cluefin-cli statements 005930 --source all --year 2024 --report annual --include-xbrl --json",
+        ],
+        "returns": ["StatementSnapshot"],
+    },
+    {
+        "name": "chart",
+        "summary": "Fetch normalized OHLCV chart data and optional cluefin-ta indicators.",
+        "usage": "cluefin-cli chart STOCK_CODE [OPTIONS]",
+        "arguments": [
+            {
+                "name": "stock_code",
+                "required": True,
+                "description": "Korean stock code, for example 005930.",
+            }
+        ],
+        "options": [
+            {
+                "name": "--source",
+                "type": "choice",
+                "choices": ["auto", "kiwoom", "kis"],
+                "default": "auto",
+                "description": "Data provider selection. auto tries Kiwoom and falls back to KIS.",
+            },
+            {
+                "name": "--interval",
+                "type": "choice",
+                "choices": ["daily", "minute"],
+                "default": "daily",
+                "description": "Chart interval.",
+            },
+            {"name": "--days", "type": "integer", "default": 300, "description": "Maximum number of OHLCV points."},
+            {
+                "name": "--volume",
+                "type": "boolean",
+                "default": False,
+                "description": "Include volume column in table output.",
+            },
+            {
+                "name": "--indicators",
+                "type": "boolean",
+                "default": False,
+                "description": "Calculate SMA, RSI, and MACD indicators.",
+            },
+            {
+                "name": "--render",
+                "type": "boolean",
+                "default": False,
+                "description": "Render terminal chart in non-JSON mode.",
+            },
+            {"name": "--json", "type": "boolean", "default": False, "description": "Emit JSON data envelope."},
+        ],
+        "examples": [
+            "cluefin-cli chart 005930 --indicators --json",
+            "cluefin-cli chart 005930 --source kis --interval daily --days 120 --json",
+        ],
+        "returns": ["OhlcvSeries"],
+    },
+    {
+        "name": "news",
+        "summary": "Fetch KIS market announcement headlines and DART disclosure search results.",
+        "usage": "cluefin-cli news [STOCK_CODE] [OPTIONS]",
+        "arguments": [
+            {
+                "name": "stock_code",
+                "required": False,
+                "description": "Optional Korean stock code, for example 005930.",
+            }
+        ],
+        "options": [
+            {
+                "name": "--source",
+                "type": "choice",
+                "choices": ["auto", "kis", "dart", "all"],
+                "default": "auto",
+                "description": "Data provider selection. auto uses KIS headline data.",
+            },
+            {"name": "--days", "type": "integer", "default": 7, "description": "Lookback window in days."},
+            {"name": "--query", "type": "string", "default": None, "description": "Search text for provider query."},
+            {"name": "--json", "type": "boolean", "default": False, "description": "Emit JSON data envelope."},
+        ],
+        "examples": [
+            "cluefin-cli news 005930 --source all --json",
+            "cluefin-cli news --query 실적 --days 14 --json",
+        ],
+        "returns": ["NewsHeadline", "DisclosureHeadline"],
+    },
+    {
+        "name": "trading-flow",
+        "summary": "Fetch normalized investor trading flow by stock.",
+        "usage": "cluefin-cli trading-flow STOCK_CODE [OPTIONS]",
+        "arguments": [
+            {
+                "name": "stock_code",
+                "required": True,
+                "description": "Korean stock code, for example 005930.",
+            }
+        ],
+        "options": [
+            {
+                "name": "--source",
+                "type": "choice",
+                "choices": ["auto", "kiwoom", "kis", "all"],
+                "default": "auto",
+                "description": "Data provider selection. auto tries Kiwoom and falls back to KIS.",
+            },
+            {
+                "name": "--start-date",
+                "type": "string",
+                "default": "one_year_before_end_date",
+                "description": "Start date YYYYMMDD.",
+            },
+            {"name": "--end-date", "type": "string", "default": "today", "description": "End date YYYYMMDD."},
+            {"name": "--json", "type": "boolean", "default": False, "description": "Emit JSON data envelope."},
+        ],
+        "examples": [
+            "cluefin-cli trading-flow 005930 --json",
+            "cluefin-cli trading-flow 005930 --source all --start-date 20240101 --end-date 20241231 --json",
+        ],
+        "returns": ["TradingFlowSnapshot"],
+    },
+    {
+        "name": "market",
+        "summary": "Fetch market scanner data grouped by representative scenarios.",
+        "usage": "cluefin-cli market SUBCOMMAND [OPTIONS]",
+        "subcommands": [
+            {"name": "volume", "summary": "Trading volume rank.", "default_source": "kis"},
+            {"name": "ranking", "summary": "Price fluctuation rank.", "default_source": "kis"},
+            {"name": "theme", "summary": "Theme group rank.", "default_source": "kiwoom"},
+            {"name": "sector", "summary": "Sector quote/rank data.", "default_source": "kis"},
+        ],
+        "options": [
+            {
+                "name": "--source",
+                "type": "choice",
+                "choices": ["auto", "kis", "kiwoom", "all"],
+                "default": "auto",
+                "description": "Data provider selection.",
+            },
+            {"name": "--limit", "type": "integer", "default": 20, "description": "Maximum number of items."},
+            {"name": "--json", "type": "boolean", "default": False, "description": "Emit JSON data envelope."},
+        ],
+        "examples": [
+            "cluefin-cli market volume --json",
+            "cluefin-cli market ranking --json",
+            "cluefin-cli market theme --json",
+            "cluefin-cli market sector --json",
+        ],
+        "returns": ["MarketRankItem"],
+    },
+]
+
+
+def describe_commands(command_name: str | None = None) -> list[dict[str, Any]]:
+    """Return metadata for all domain commands or one selected command."""
+    if command_name is None:
+        return DOMAIN_COMMANDS
+    return [item for item in DOMAIN_COMMANDS if item["name"] == command_name]

--- a/apps/cluefin-cli/src/cluefin_cli/commands/chart.py
+++ b/apps/cluefin-cli/src/cluefin_cli/commands/chart.py
@@ -1,0 +1,117 @@
+"""Domain command for OHLCV chart data."""
+
+from __future__ import annotations
+
+import click
+import pandas as pd
+from loguru import logger
+from rich.console import Console
+from rich.table import Table
+
+from cluefin_cli.display.charts import ChartRenderer
+from cluefin_cli.domains.chart import ChartService
+from cluefin_cli.domains.models import OhlcvSeries
+from cluefin_cli.output import error_envelope, success_envelope, write_json
+
+console = Console()
+
+
+@click.command(name="chart")
+@click.pass_context
+@click.argument("stock_code")
+@click.option("--source", type=click.Choice(["auto", "kiwoom", "kis"]), default="auto", show_default=True)
+@click.option("--interval", type=click.Choice(["daily", "minute"]), default="daily", show_default=True)
+@click.option("--days", type=click.IntRange(1, 2000), default=300, show_default=True)
+@click.option("--volume", is_flag=True, help="Include volume rows in table output")
+@click.option("--indicators", is_flag=True, help="Calculate technical indicators")
+@click.option("--render", "render_chart", is_flag=True, help="Render a terminal chart in non-JSON mode")
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON output")
+def chart_command(
+    ctx: click.Context,
+    stock_code: str,
+    source: str,
+    interval: str,
+    days: int,
+    volume: bool,
+    indicators: bool,
+    render_chart: bool,
+    json_output: bool,
+) -> None:
+    """Fetch normalized OHLCV chart data."""
+    use_json = json_output or bool(ctx.obj and ctx.obj.get("json"))
+    params = {
+        "stock_code": stock_code,
+        "source": source,
+        "interval": interval,
+        "days": days,
+        "volume": volume,
+        "indicators": indicators,
+        "render": render_chart,
+    }
+    try:
+        series = ChartService().fetch(
+            stock_code=stock_code, source=source, interval=interval, days=days, indicators=indicators
+        )
+    except Exception as exc:
+        if use_json:
+            write_json(error_envelope(command="chart", error_type=type(exc).__name__, message=str(exc)))
+            raise click.exceptions.Exit(1) from exc
+        console.print(f"[red]Error fetching chart data: {exc}[/red]")
+        logger.exception("Chart command failed")
+        raise click.exceptions.Exit(1) from exc
+
+    if use_json:
+        write_json(success_envelope(command="chart", source=series.source, params=params, data=series))
+        return
+
+    _display_chart_table(series, include_volume=volume)
+    if render_chart:
+        ChartRenderer().render_stock_chart(_series_to_frame(series))
+
+
+def _display_chart_table(series: OhlcvSeries, *, include_volume: bool) -> None:
+    table = Table(title=f"Chart {series.stock_code} ({series.source}, {series.interval})")
+    table.add_column("Timestamp")
+    table.add_column("Open", justify="right")
+    table.add_column("High", justify="right")
+    table.add_column("Low", justify="right")
+    table.add_column("Close", justify="right")
+    if include_volume:
+        table.add_column("Volume", justify="right")
+    for point in series.points[-20:]:
+        row = [
+            point.timestamp,
+            _fmt(point.open),
+            _fmt(point.high),
+            _fmt(point.low),
+            _fmt(point.close),
+        ]
+        if include_volume:
+            row.append(_fmt(point.volume))
+        table.add_row(*row)
+    console.print(table)
+
+
+def _series_to_frame(series: OhlcvSeries) -> pd.DataFrame:
+    rows = [
+        {
+            "date": pd.to_datetime(point.timestamp[:8], errors="coerce"),
+            "open": point.open,
+            "high": point.high,
+            "low": point.low,
+            "close": point.close,
+            "volume": point.volume,
+        }
+        for point in series.points
+    ]
+    frame = pd.DataFrame(rows)
+    if frame.empty:
+        return frame
+    frame.set_index("date", inplace=True)
+    return frame
+
+
+def _fmt(value: float | None) -> str:
+    if value is None:
+        return "-"
+    return f"{value:,.2f}"

--- a/apps/cluefin-cli/src/cluefin_cli/commands/describe.py
+++ b/apps/cluefin-cli/src/cluefin_cli/commands/describe.py
@@ -1,0 +1,56 @@
+"""AI-friendly command discovery."""
+
+from __future__ import annotations
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+from cluefin_cli.command_metadata import describe_commands
+from cluefin_cli.output import error_envelope, success_envelope, write_json
+
+console = Console()
+
+
+@click.command(name="describe")
+@click.pass_context
+@click.argument(
+    "command_name",
+    required=False,
+    type=click.Choice(["statements", "chart", "news", "trading-flow", "market"]),
+)
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON command metadata")
+def describe_command(ctx: click.Context, command_name: str | None, json_output: bool) -> None:
+    """Describe domain commands without calling provider APIs."""
+    use_json = json_output or bool(ctx.obj and ctx.obj.get("json"))
+    commands = describe_commands(command_name)
+    if command_name and not commands:
+        if use_json:
+            write_json(
+                error_envelope(
+                    command="describe",
+                    error_type="CommandNotFound",
+                    message=f"Unknown command: {command_name}",
+                )
+            )
+            raise click.exceptions.Exit(1)
+        raise click.ClickException(f"Unknown command: {command_name}")
+
+    if use_json:
+        write_json(
+            success_envelope(
+                command="describe",
+                source=None,
+                params={"command": command_name},
+                data={"commands": commands},
+            )
+        )
+        return
+
+    table = Table(title="Cluefin CLI Domain Commands")
+    table.add_column("Command")
+    table.add_column("Summary")
+    table.add_column("Usage")
+    for item in commands:
+        table.add_row(item["name"], item["summary"], item["usage"])
+    console.print(table)

--- a/apps/cluefin-cli/src/cluefin_cli/commands/fundamental_analysis.py
+++ b/apps/cluefin-cli/src/cluefin_cli/commands/fundamental_analysis.py
@@ -51,7 +51,7 @@ REPORT_CHOICES = {
     help="Number of top shareholders to display.",
 )
 def fundamental_analysis(stock_code: str, year: str, report: str, max_shareholders: int) -> None:
-    """Run fundamental analysis for a given stock code using DART OpenAPI data."""
+    """DEPRECATED: use the `statements` domain command instead."""
     report_key = report.lower()
     report_code, report_description = REPORT_CHOICES[report_key]
 

--- a/apps/cluefin-cli/src/cluefin_cli/commands/market.py
+++ b/apps/cluefin-cli/src/cluefin_cli/commands/market.py
@@ -1,0 +1,74 @@
+"""Domain command group for market scanner data."""
+
+from __future__ import annotations
+
+import click
+from loguru import logger
+from rich.console import Console
+from rich.table import Table
+
+from cluefin_cli.domains.market import MarketCategory, MarketService
+from cluefin_cli.domains.models import MarketRankItem
+from cluefin_cli.output import error_envelope, success_envelope, write_json
+
+console = Console()
+
+
+@click.group(name="market")
+def market_command() -> None:
+    """Fetch domain-oriented market scanner data."""
+
+
+def _market_subcommand(category: MarketCategory) -> click.Command:
+    @click.command(name=category)
+    @click.pass_context
+    @click.option("--source", type=click.Choice(["auto", "kis", "kiwoom", "all"]), default="auto", show_default=True)
+    @click.option("--limit", type=click.IntRange(1, 100), default=20, show_default=True)
+    @click.option("--json", "json_output", is_flag=True, help="Emit JSON output")
+    def command(ctx: click.Context, source: str, limit: int, json_output: bool) -> None:
+        use_json = json_output or bool(ctx.obj and ctx.obj.get("json"))
+        params = {"category": category, "source": source, "limit": limit}
+        try:
+            items = MarketService().fetch(category=category, source=source, limit=limit)
+        except Exception as exc:
+            if use_json:
+                write_json(
+                    error_envelope(command=f"market {category}", error_type=type(exc).__name__, message=str(exc))
+                )
+                raise click.exceptions.Exit(1) from exc
+            console.print(f"[red]Error fetching market {category}: {exc}[/red]")
+            logger.exception("Market command failed")
+            raise click.exceptions.Exit(1) from exc
+
+        if use_json:
+            write_json(
+                success_envelope(command=f"market {category}", source=source, params=params, data={"items": items})
+            )
+            return
+        _display_table(category=category, items=items)
+
+    return command
+
+
+def _display_table(*, category: str, items: list[MarketRankItem]) -> None:
+    table = Table(title=f"Market {category}")
+    table.add_column("Source")
+    table.add_column("Rank", justify="right")
+    table.add_column("Code")
+    table.add_column("Name")
+    table.add_column("Value", justify="right")
+    table.add_column("Change", justify="right")
+    for item in items:
+        table.add_row(
+            item.source,
+            str(item.rank or "-"),
+            item.stock_code or "-",
+            item.stock_name or "-",
+            str(item.value if item.value is not None else "-"),
+            str(item.change_rate if item.change_rate is not None else "-"),
+        )
+    console.print(table)
+
+
+for _category in ["volume", "ranking", "theme", "sector"]:
+    market_command.add_command(_market_subcommand(_category))

--- a/apps/cluefin-cli/src/cluefin_cli/commands/news.py
+++ b/apps/cluefin-cli/src/cluefin_cli/commands/news.py
@@ -1,0 +1,56 @@
+"""Domain command for news and disclosures."""
+
+from __future__ import annotations
+
+import click
+from loguru import logger
+from rich.console import Console
+from rich.table import Table
+
+from cluefin_cli.domains.news import NewsService
+from cluefin_cli.output import error_envelope, success_envelope, write_json
+
+console = Console()
+
+
+@click.command(name="news")
+@click.pass_context
+@click.argument("stock_code", required=False)
+@click.option("--source", type=click.Choice(["auto", "kis", "dart", "all"]), default="auto", show_default=True)
+@click.option("--days", type=click.IntRange(1, 365), default=7, show_default=True)
+@click.option("--query")
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON output")
+def news_command(
+    ctx: click.Context,
+    stock_code: str | None,
+    source: str,
+    days: int,
+    query: str | None,
+    json_output: bool,
+) -> None:
+    """Fetch domain-oriented market news and disclosures."""
+    use_json = json_output or bool(ctx.obj and ctx.obj.get("json"))
+    params = {"stock_code": stock_code, "source": source, "days": days, "query": query}
+    try:
+        data = NewsService().fetch(**params)
+    except Exception as exc:
+        if use_json:
+            write_json(error_envelope(command="news", error_type=type(exc).__name__, message=str(exc)))
+            raise click.exceptions.Exit(1) from exc
+        console.print(f"[red]Error fetching news: {exc}[/red]")
+        logger.exception("News command failed")
+        raise click.exceptions.Exit(1) from exc
+
+    if use_json:
+        write_json(success_envelope(command="news", source=source, params=params, data=data))
+        return
+
+    table = Table(title="News")
+    table.add_column("Source")
+    table.add_column("Title")
+    table.add_column("Published")
+    for item in data["news"]:
+        table.add_row(item.source, item.title, item.published_at or "-")
+    for item in data["disclosures"]:
+        table.add_row(item.source, item.report_name, item.rcept_date or "-")
+    console.print(table)

--- a/apps/cluefin-cli/src/cluefin_cli/commands/statements.py
+++ b/apps/cluefin-cli/src/cluefin_cli/commands/statements.py
@@ -1,0 +1,71 @@
+"""Domain command for statements data."""
+
+from __future__ import annotations
+
+import click
+from loguru import logger
+from rich.console import Console
+from rich.table import Table
+
+from cluefin_cli.domains.statements import REPORT_CODE_MAP, StatementsService, default_business_year
+from cluefin_cli.output import error_envelope, success_envelope, write_json
+
+console = Console()
+
+
+@click.command(name="statements")
+@click.pass_context
+@click.argument("stock_code")
+@click.option("--source", type=click.Choice(["auto", "dart", "kis", "all"]), default="auto", show_default=True)
+@click.option("--year", default=default_business_year(), show_default=True)
+@click.option("--report", type=click.Choice(list(REPORT_CODE_MAP.keys())), default="annual", show_default=True)
+@click.option("--include-xbrl", is_flag=True)
+@click.option("--statement-type", type=click.Choice(["BS", "IS", "CIS", "CF", "SCE"], case_sensitive=False))
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON output")
+def statements_command(
+    ctx: click.Context,
+    stock_code: str,
+    source: str,
+    year: str,
+    report: str,
+    include_xbrl: bool,
+    statement_type: str | None,
+    json_output: bool,
+) -> None:
+    """Fetch domain-oriented financial statement data."""
+    use_json = json_output or bool(ctx.obj and ctx.obj.get("json"))
+    params = {
+        "stock_code": stock_code,
+        "source": source,
+        "year": year,
+        "report": report,
+        "include_xbrl": include_xbrl,
+        "statement_type": statement_type,
+    }
+    try:
+        snapshots = StatementsService().fetch(**params)
+    except Exception as exc:
+        if use_json:
+            write_json(error_envelope(command="statements", error_type=type(exc).__name__, message=str(exc)))
+            raise click.exceptions.Exit(1) from exc
+        console.print(f"[red]Error fetching statements: {exc}[/red]")
+        logger.exception("Statements command failed")
+        raise click.exceptions.Exit(1) from exc
+
+    if use_json:
+        write_json(success_envelope(command="statements", source=source, params=params, data={"items": snapshots}))
+        return
+
+    table = Table(title=f"Statements {stock_code}")
+    table.add_column("Source")
+    table.add_column("Company")
+    table.add_column("Accounts", justify="right")
+    table.add_column("Metrics", justify="right")
+    for snapshot in snapshots:
+        table.add_row(
+            snapshot.source,
+            snapshot.company_name or "-",
+            str(len(snapshot.accounts)),
+            str(len(snapshot.metrics)),
+        )
+    console.print(table)

--- a/apps/cluefin-cli/src/cluefin_cli/commands/technical_analysis.py
+++ b/apps/cluefin-cli/src/cluefin_cli/commands/technical_analysis.py
@@ -45,7 +45,7 @@ def technical_analysis(
     shap_analysis: bool,
     regime_analysis: bool,
 ):
-    """Run technical analysis for a given stock code."""
+    """DEPRECATED: use `chart` and `trading-flow` domain commands instead."""
     console.print(f"[bold blue]Analyzing {stock_code}...[/bold blue]")
 
     try:

--- a/apps/cluefin-cli/src/cluefin_cli/commands/trading_flow.py
+++ b/apps/cluefin-cli/src/cluefin_cli/commands/trading_flow.py
@@ -1,0 +1,81 @@
+"""Domain command for investor trading flow data."""
+
+from __future__ import annotations
+
+import click
+from loguru import logger
+from rich.console import Console
+from rich.table import Table
+
+from cluefin_cli.domains.trading_flow import TradingFlowService
+from cluefin_cli.output import error_envelope, success_envelope, write_json
+
+console = Console()
+
+
+@click.command(name="trading-flow")
+@click.pass_context
+@click.argument("stock_code")
+@click.option("--source", type=click.Choice(["auto", "kiwoom", "kis", "all"]), default="auto", show_default=True)
+@click.option("--start-date")
+@click.option("--end-date")
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON output")
+def trading_flow_command(
+    ctx: click.Context,
+    stock_code: str,
+    source: str,
+    start_date: str | None,
+    end_date: str | None,
+    json_output: bool,
+) -> None:
+    """Fetch normalized investor trading flow data."""
+    use_json = json_output or bool(ctx.obj and ctx.obj.get("json"))
+    params = {
+        "stock_code": stock_code,
+        "source": source,
+        "start_date": start_date,
+        "end_date": end_date,
+    }
+    try:
+        snapshots = TradingFlowService().fetch(
+            stock_code=stock_code,
+            source=source,
+            start_date=start_date,
+            end_date=end_date,
+        )
+    except Exception as exc:
+        if use_json:
+            write_json(error_envelope(command="trading-flow", error_type=type(exc).__name__, message=str(exc)))
+            raise click.exceptions.Exit(1) from exc
+        console.print(f"[red]Error fetching trading flow: {exc}[/red]")
+        logger.exception("Trading flow command failed")
+        raise click.exceptions.Exit(1) from exc
+
+    if use_json:
+        write_json(success_envelope(command="trading-flow", source=source, params=params, data={"items": snapshots}))
+        return
+
+    table = Table(title=f"Trading Flow {stock_code}")
+    table.add_column("Source")
+    table.add_column("Rows", justify="right")
+    table.add_column("Foreign", justify="right")
+    table.add_column("Institution", justify="right")
+    table.add_column("Individual", justify="right")
+    for snapshot in snapshots:
+        table.add_row(
+            snapshot.source,
+            str(len(snapshot.rows)),
+            _fmt(snapshot.totals.get("foreign")),
+            _fmt(snapshot.totals.get("institution")),
+            _fmt(snapshot.totals.get("individual")),
+        )
+    console.print(table)
+
+
+def _fmt(value: object) -> str:
+    if value is None:
+        return "-"
+    try:
+        return f"{float(value):,.0f}"
+    except (TypeError, ValueError):
+        return str(value)

--- a/apps/cluefin-cli/src/cluefin_cli/commands/xbrl_analysis.py
+++ b/apps/cluefin-cli/src/cluefin_cli/commands/xbrl_analysis.py
@@ -46,7 +46,7 @@ STATEMENT_TYPE_LABELS: dict[str, str] = {
     help="Filter to a specific statement type. Show all if not set.",
 )
 def xbrl_analysis(stock_code: str, year: str, report: str, statement_type: str | None) -> None:
-    """Analyse XBRL financial statements for a given stock code."""
+    """DEPRECATED: use `statements --include-xbrl` instead."""
     reprt_code = REPORT_CODE_MAP[report.lower()]
 
     console.print(f"[bold blue]XBRL Analysis for {stock_code} ({year}, {report})[/bold blue]")

--- a/apps/cluefin-cli/src/cluefin_cli/domains/__init__.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/__init__.py
@@ -1,0 +1,1 @@
+"""Domain-oriented services and adapters for cluefin-cli."""

--- a/apps/cluefin-cli/src/cluefin_cli/domains/chart.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/chart.py
@@ -1,0 +1,91 @@
+"""Domain service for normalized OHLCV chart data."""
+
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+import cluefin_ta
+import numpy as np
+
+from cluefin_cli.domains.models import IndicatorSnapshot, OhlcvSeries
+from cluefin_cli.domains.providers.kis import KisProvider
+from cluefin_cli.domains.providers.kiwoom import KiwoomProvider
+
+
+class ChartService:
+    def __init__(self, *, kiwoom_provider: KiwoomProvider | None = None, kis_provider: KisProvider | None = None):
+        self.kiwoom_provider = kiwoom_provider or KiwoomProvider()
+        self.kis_provider = kis_provider or KisProvider()
+
+    def fetch(
+        self,
+        *,
+        stock_code: str,
+        source: str = "auto",
+        interval: str = "daily",
+        days: int = 300,
+        indicators: bool = False,
+    ) -> OhlcvSeries:
+        if source == "kiwoom":
+            series = self.kiwoom_provider.fetch_ohlcv(stock_code=stock_code, interval=interval, days=days)
+        elif source == "kis":
+            series = self.kis_provider.fetch_ohlcv(stock_code=stock_code, interval=interval, days=days)
+        else:
+            series = self._fetch_auto(stock_code=stock_code, interval=interval, days=days)
+
+        if indicators:
+            series.indicators = calculate_indicators(series)
+        return series
+
+    def _fetch_auto(self, *, stock_code: str, interval: str, days: int) -> OhlcvSeries:
+        try:
+            return self.kiwoom_provider.fetch_ohlcv(stock_code=stock_code, interval=interval, days=days)
+        except Exception:
+            return self.kis_provider.fetch_ohlcv(stock_code=stock_code, interval=interval, days=days)
+
+
+def calculate_indicators(series: OhlcvSeries) -> list[IndicatorSnapshot]:
+    close = np.array([point.close if point.close is not None else np.nan for point in series.points], dtype=np.float64)
+    if close.size == 0:
+        return []
+
+    macd, macd_signal, macd_histogram = cluefin_ta.MACD(close)
+    indicators = [
+        IndicatorSnapshot(
+            name="sma_20", values=_json_values(cluefin_ta.SMA(close, timeperiod=20)), params={"period": 20}
+        ),
+        IndicatorSnapshot(
+            name="sma_50", values=_json_values(cluefin_ta.SMA(close, timeperiod=50)), params={"period": 50}
+        ),
+        IndicatorSnapshot(
+            name="rsi_14", values=_json_values(cluefin_ta.RSI(close, timeperiod=14)), params={"period": 14}
+        ),
+        IndicatorSnapshot(name="macd", values=_json_values(macd), params={"fast": 12, "slow": 26, "signal": 9}),
+        IndicatorSnapshot(
+            name="macd_signal", values=_json_values(macd_signal), params={"fast": 12, "slow": 26, "signal": 9}
+        ),
+        IndicatorSnapshot(
+            name="macd_histogram",
+            values=_json_values(macd_histogram),
+            params={"fast": 12, "slow": 26, "signal": 9},
+        ),
+    ]
+    for item in indicators:
+        item.latest = _latest(item.values)
+    return indicators
+
+
+def _json_values(values: Sequence[float]) -> list[float | None]:
+    result: list[float | None] = []
+    for value in values:
+        parsed = float(value)
+        result.append(None if math.isnan(parsed) or math.isinf(parsed) else parsed)
+    return result
+
+
+def _latest(values: Sequence[float | None]) -> float | None:
+    for value in reversed(values):
+        if value is not None:
+            return value
+    return None

--- a/apps/cluefin-cli/src/cluefin_cli/domains/market.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/market.py
@@ -1,0 +1,53 @@
+"""Domain service for market scanner data."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from cluefin_cli.domains.models import MarketRankItem
+from cluefin_cli.domains.providers.kis import KisProvider
+from cluefin_cli.domains.providers.kiwoom import KiwoomProvider
+
+MarketCategory = Literal["volume", "ranking", "theme", "sector"]
+
+
+class MarketService:
+    def __init__(self, *, kiwoom_provider: KiwoomProvider | None = None, kis_provider: KisProvider | None = None):
+        self.kiwoom_provider = kiwoom_provider or KiwoomProvider()
+        self.kis_provider = kis_provider or KisProvider()
+
+    def fetch(self, *, category: MarketCategory, source: str = "auto", limit: int = 20) -> list[MarketRankItem]:
+        if source == "auto":
+            return self._fetch_default(category=category, limit=limit)
+        if source == "all":
+            return self._fetch_all(category=category, limit=limit)
+        return self._fetch_provider(provider=source, category=category, limit=limit)
+
+    def _fetch_default(self, *, category: MarketCategory, limit: int) -> list[MarketRankItem]:
+        if category == "theme":
+            return self.kiwoom_provider.fetch_market_theme(limit=limit)
+        if category == "sector":
+            return self.kis_provider.fetch_market_sector(limit=limit)
+        if category == "ranking":
+            return self.kis_provider.fetch_market_ranking(limit=limit)
+        return self.kis_provider.fetch_market_volume(limit=limit)
+
+    def _fetch_all(self, *, category: MarketCategory, limit: int) -> list[MarketRankItem]:
+        if category == "theme":
+            return self.kiwoom_provider.fetch_market_theme(limit=limit)
+
+        items: list[MarketRankItem] = []
+        for provider in ["kis", "kiwoom"]:
+            try:
+                items.extend(self._fetch_provider(provider=provider, category=category, limit=limit))
+            except NotImplementedError:
+                continue
+        return items
+
+    def _fetch_provider(self, *, provider: str, category: MarketCategory, limit: int) -> list[MarketRankItem]:
+        adapter = self.kiwoom_provider if provider == "kiwoom" else self.kis_provider
+        method_name = f"fetch_market_{category}"
+        method = getattr(adapter, method_name, None)
+        if method is None:
+            raise NotImplementedError(f"{provider} does not support market {category}")
+        return method(limit=limit)

--- a/apps/cluefin-cli/src/cluefin_cli/domains/market.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/market.py
@@ -45,9 +45,22 @@ class MarketService:
         return items
 
     def _fetch_provider(self, *, provider: str, category: MarketCategory, limit: int) -> list[MarketRankItem]:
-        adapter = self.kiwoom_provider if provider == "kiwoom" else self.kis_provider
-        method_name = f"fetch_market_{category}"
-        method = getattr(adapter, method_name, None)
-        if method is None:
-            raise NotImplementedError(f"{provider} does not support market {category}")
-        return method(limit=limit)
+        if provider == "kis":
+            if category == "volume":
+                return self.kis_provider.fetch_market_volume(limit=limit)
+            if category == "ranking":
+                return self.kis_provider.fetch_market_ranking(limit=limit)
+            if category == "sector":
+                return self.kis_provider.fetch_market_sector(limit=limit)
+
+        if provider == "kiwoom":
+            if category == "volume":
+                return self.kiwoom_provider.fetch_market_volume(limit=limit)
+            if category == "ranking":
+                return self.kiwoom_provider.fetch_market_ranking(limit=limit)
+            if category == "theme":
+                return self.kiwoom_provider.fetch_market_theme(limit=limit)
+            if category == "sector":
+                return self.kiwoom_provider.fetch_market_sector(limit=limit)
+
+        raise NotImplementedError(f"{provider} does not support market {category}")

--- a/apps/cluefin-cli/src/cluefin_cli/domains/models.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/models.py
@@ -1,0 +1,122 @@
+"""Domain DTOs used by cluefin-cli services."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(slots=True)
+class FinancialMetric:
+    name: str
+    label: str | None = None
+    value: str | int | float | None = None
+    unit: str | None = None
+    period: str | None = None
+    source: str | None = None
+
+
+@dataclass(slots=True)
+class DividendSnapshot:
+    category: str
+    current: str | None = None
+    previous: str | None = None
+    two_years_ago: str | None = None
+    stock_kind: str | None = None
+    source: str | None = None
+
+
+@dataclass(slots=True)
+class ShareholderSnapshot:
+    name: str
+    relation: str | None = None
+    shares_current: str | None = None
+    holding_ratio_current: str | None = None
+    shares_previous: str | None = None
+    holding_ratio_previous: str | None = None
+    source: str | None = None
+
+
+@dataclass(slots=True)
+class StatementSnapshot:
+    stock_code: str
+    source: str
+    corp_code: str | None = None
+    company_name: str | None = None
+    business_year: str | None = None
+    report_code: str | None = None
+    accounts: list[FinancialMetric] = field(default_factory=list)
+    metrics: list[FinancialMetric] = field(default_factory=list)
+    dividends: list[DividendSnapshot] = field(default_factory=list)
+    shareholders: list[ShareholderSnapshot] = field(default_factory=list)
+    xbrl_statements: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class OhlcvPoint:
+    timestamp: str
+    open: float | None = None
+    high: float | None = None
+    low: float | None = None
+    close: float | None = None
+    volume: float | None = None
+
+
+@dataclass(slots=True)
+class IndicatorSnapshot:
+    name: str
+    values: list[float | None] = field(default_factory=list)
+    latest: float | None = None
+    params: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class OhlcvSeries:
+    stock_code: str
+    source: str
+    interval: str
+    points: list[OhlcvPoint] = field(default_factory=list)
+    indicators: list[IndicatorSnapshot] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class NewsHeadline:
+    source: str
+    title: str
+    published_at: str | None = None
+    stock_codes: list[str] = field(default_factory=list)
+    provider: str | None = None
+    raw_id: str | None = None
+
+
+@dataclass(slots=True)
+class DisclosureHeadline:
+    source: str
+    report_name: str
+    rcept_no: str | None = None
+    rcept_date: str | None = None
+    corp_code: str | None = None
+    corp_name: str | None = None
+    stock_code: str | None = None
+
+
+@dataclass(slots=True)
+class TradingFlowSnapshot:
+    stock_code: str
+    source: str
+    start_date: str
+    end_date: str
+    rows: list[dict[str, Any]] = field(default_factory=list)
+    totals: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class MarketRankItem:
+    source: str
+    category: str
+    rank: int | None = None
+    stock_code: str | None = None
+    stock_name: str | None = None
+    value: str | int | float | None = None
+    change_rate: str | int | float | None = None
+    raw: dict[str, Any] = field(default_factory=dict)

--- a/apps/cluefin-cli/src/cluefin_cli/domains/news.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/news.py
@@ -1,0 +1,29 @@
+"""News domain service."""
+
+from __future__ import annotations
+
+from cluefin_cli.domains.models import DisclosureHeadline, NewsHeadline
+from cluefin_cli.domains.providers import DartProvider, KisProvider
+
+
+class NewsService:
+    def __init__(self, dart_provider: DartProvider | None = None, kis_provider: KisProvider | None = None) -> None:
+        self.dart_provider = dart_provider or DartProvider()
+        self.kis_provider = kis_provider or KisProvider()
+
+    def fetch(
+        self,
+        *,
+        stock_code: str | None = None,
+        source: str = "auto",
+        days: int = 7,
+        query: str | None = None,
+    ) -> dict[str, list[NewsHeadline] | list[DisclosureHeadline]]:
+        include_kis = source in {"auto", "kis", "all"}
+        include_dart = source in {"dart", "all"}
+        return {
+            "news": self.kis_provider.fetch_news(stock_code=stock_code, days=days, query=query) if include_kis else [],
+            "disclosures": self.dart_provider.fetch_disclosures(stock_code=stock_code, days=days, query=query)
+            if include_dart
+            else [],
+        }

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/__init__.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/__init__.py
@@ -1,0 +1,7 @@
+"""Broker provider adapters for cluefin-cli domains."""
+
+from cluefin_cli.domains.providers.dart import DartProvider
+from cluefin_cli.domains.providers.kis import KisProvider
+from cluefin_cli.domains.providers.kiwoom import KiwoomProvider
+
+__all__ = ["DartProvider", "KisProvider", "KiwoomProvider"]

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/base.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/base.py
@@ -1,0 +1,25 @@
+"""Common provider adapter helpers."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from cluefin_openapi import BrokerClientFactory
+
+BrokerName = Literal["dart", "kis", "kiwoom"]
+
+
+class BrokerProvider:
+    """Lazy broker client holder backed by BrokerClientFactory."""
+
+    broker: BrokerName
+
+    def __init__(self, client_factory: BrokerClientFactory | None = None) -> None:
+        self._client_factory = client_factory or BrokerClientFactory()
+        self._client: Any | None = None
+
+    @property
+    def client(self) -> Any:
+        if self._client is None:
+            self._client = self._client_factory.create(self.broker)
+        return self._client

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/dart.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/dart.py
@@ -2,8 +2,205 @@
 
 from __future__ import annotations
 
+import tempfile
+from datetime import date, timedelta
+from pathlib import Path
+from typing import Any
+
+from cluefin_openapi.dart._periodic_report_financial_statement import PeriodicReportFinancialStatement
+from cluefin_xbrl import extract_financial_statements, parse_xbrl_directory
+
+from cluefin_cli.domains.models import (
+    DisclosureHeadline,
+    DividendSnapshot,
+    FinancialMetric,
+    ShareholderSnapshot,
+    StatementSnapshot,
+)
 from cluefin_cli.domains.providers.base import BrokerProvider
 
 
 class DartProvider(BrokerProvider):
     broker = "dart"
+
+    def resolve_corp_code(self, stock_code: str) -> str:
+        response = self.client.public_disclosure.corp_code()
+        items = getattr(response, "list", None) or getattr(getattr(response, "result", None), "list", None) or []
+        normalized = stock_code.zfill(6)
+        for item in items:
+            if getattr(item, "stock_code", None) == normalized:
+                return item.corp_code
+        raise ValueError(f"No DART corp code found for stock code {normalized}.")
+
+    def fetch_statement_snapshot(
+        self,
+        *,
+        stock_code: str,
+        business_year: str,
+        report_code: str,
+        include_xbrl: bool = False,
+        statement_type: str | None = None,
+    ) -> StatementSnapshot:
+        corp_code = self.resolve_corp_code(stock_code)
+        overview = self.client.public_disclosure.company_overview(corp_code)
+        financial_statement = PeriodicReportFinancialStatement(self.client)
+        key_information = self.client.periodic_report_key_information
+
+        accounts_response = financial_statement.get_single_company_major_accounts(corp_code, business_year, report_code)
+        indicators_response = financial_statement.get_single_company_major_indicators(
+            corp_code=corp_code,
+            bsns_year=business_year,
+            reprt_code=report_code,
+            idx_cl_code="M210000",
+        )
+        dividends_response = key_information.get_dividend_information(corp_code, business_year, report_code)
+        shareholders_response = key_information.get_major_shareholder_status(corp_code, business_year, report_code)
+
+        xbrl_statements: dict[str, Any] = {}
+        if include_xbrl:
+            xbrl_statements = self.fetch_xbrl_statements(
+                corp_code=corp_code,
+                business_year=business_year,
+                report_code=report_code,
+                statement_type=statement_type,
+            )
+
+        return StatementSnapshot(
+            stock_code=stock_code.zfill(6),
+            source="dart",
+            corp_code=corp_code,
+            company_name=getattr(overview, "corp_name", None),
+            business_year=business_year,
+            report_code=report_code,
+            accounts=[
+                FinancialMetric(
+                    name=getattr(item, "account_nm", ""),
+                    label=getattr(item, "account_nm", None),
+                    value=getattr(item, "thstrm_amount", None),
+                    unit=getattr(item, "currency", None),
+                    period=getattr(item, "thstrm_nm", None),
+                    source="dart",
+                )
+                for item in self._response_items(accounts_response)
+            ],
+            metrics=[
+                FinancialMetric(
+                    name=getattr(item, "idx_nm", ""),
+                    value=getattr(item, "idx_val", None),
+                    source="dart",
+                )
+                for item in self._response_items(indicators_response)
+            ],
+            dividends=[
+                DividendSnapshot(
+                    category=getattr(item, "se", ""),
+                    current=getattr(item, "thstrm", None),
+                    previous=getattr(item, "frmtrm", None),
+                    two_years_ago=getattr(item, "lwfr", None),
+                    stock_kind=getattr(item, "stock_knd", None),
+                    source="dart",
+                )
+                for item in self._response_items(dividends_response)
+            ],
+            shareholders=[
+                ShareholderSnapshot(
+                    name=getattr(item, "nm", ""),
+                    relation=getattr(item, "relate", None),
+                    shares_current=getattr(item, "trmend_posesn_stock_co", None),
+                    holding_ratio_current=getattr(item, "trmend_posesn_stock_qota_rt", None),
+                    shares_previous=getattr(item, "bsis_posesn_stock_co", None),
+                    holding_ratio_previous=getattr(item, "bsis_posesn_stock_qota_rt", None),
+                    source="dart",
+                )
+                for item in self._response_items(shareholders_response)
+            ],
+            xbrl_statements=xbrl_statements,
+        )
+
+    def fetch_disclosures(
+        self,
+        *,
+        stock_code: str | None = None,
+        days: int = 7,
+        query: str | None = None,
+    ) -> list[DisclosureHeadline]:
+        end = date.today()
+        begin = end - timedelta(days=days)
+        corp_code = self.resolve_corp_code(stock_code) if stock_code else None
+        response = self.client.public_disclosure.public_disclosure_search(
+            corp_code=corp_code,
+            bgn_de=begin.strftime("%Y%m%d"),
+            end_de=end.strftime("%Y%m%d"),
+            last_reprt_at="N",
+        )
+
+        items = self._response_items(response)
+        if query:
+            items = [item for item in items if query in getattr(item, "report_nm", "")]
+
+        return [
+            DisclosureHeadline(
+                source="dart",
+                report_name=getattr(item, "report_nm", ""),
+                rcept_no=getattr(item, "rcept_no", None),
+                rcept_date=getattr(item, "rcept_dt", None),
+                corp_code=getattr(item, "corp_code", None),
+                corp_name=getattr(item, "corp_name", None),
+                stock_code=getattr(item, "stock_code", None),
+            )
+            for item in items
+        ]
+
+    def fetch_xbrl_statements(
+        self,
+        *,
+        corp_code: str,
+        business_year: str,
+        report_code: str,
+        statement_type: str | None = None,
+    ) -> dict[str, Any]:
+        rcept_no = self.find_report_rcept_no(corp_code, business_year, report_code)
+        if rcept_no is None:
+            return {}
+
+        dest = Path(tempfile.mkdtemp(prefix="cluefin_xbrl_"))
+        xbrl_dir = PeriodicReportFinancialStatement(self.client).download_financial_statement_xbrl(
+            rcept_no=rcept_no,
+            reprt_code=report_code,
+            destination=dest,
+            overwrite=True,
+        )
+        parsed = extract_financial_statements(parse_xbrl_directory(xbrl_dir, include_taxonomy=True))
+        statements = parsed.statements
+        if statement_type:
+            statements = {key: value for key, value in statements.items() if key == statement_type.upper()}
+        return {key: value.model_dump() if hasattr(value, "model_dump") else value for key, value in statements.items()}
+
+    def find_report_rcept_no(self, corp_code: str, business_year: str, report_code: str) -> str | None:
+        markers = {
+            "11011": ("사업보고서", ".12)"),
+            "11012": ("반기보고서", ".06)"),
+            "11013": ("분기보고서", ".03)"),
+            "11014": ("분기보고서", ".09)"),
+        }
+        rule = markers.get(report_code)
+        if rule is None:
+            return None
+        keyword, period_marker = rule
+        response = self.client.public_disclosure.public_disclosure_search(
+            corp_code=corp_code,
+            bgn_de=f"{business_year}0101",
+            end_de=f"{int(business_year) + 1}1231",
+            pblntf_ty="A",
+            last_reprt_at="Y",
+        )
+        year_period = f"({business_year}{period_marker}"
+        for item in self._response_items(response):
+            if keyword in getattr(item, "report_nm", "") and year_period in getattr(item, "report_nm", ""):
+                return getattr(item, "rcept_no", None)
+        return None
+
+    @staticmethod
+    def _response_items(response: Any) -> list[Any]:
+        result = getattr(response, "result", response)
+        return list(getattr(result, "list", None) or getattr(response, "list", None) or [])

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/dart.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/dart.py
@@ -1,0 +1,9 @@
+"""DART provider adapter."""
+
+from __future__ import annotations
+
+from cluefin_cli.domains.providers.base import BrokerProvider
+
+
+class DartProvider(BrokerProvider):
+    broker = "dart"

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/kis.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/kis.py
@@ -1,0 +1,9 @@
+"""KIS provider adapter."""
+
+from __future__ import annotations
+
+from cluefin_cli.domains.providers.base import BrokerProvider
+
+
+class KisProvider(BrokerProvider):
+    broker = "kis"

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/kis.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/kis.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from cluefin_cli.domains.models import (
     FinancialMetric,
+    MarketRankItem,
     NewsHeadline,
     OhlcvPoint,
     OhlcvSeries,
@@ -125,6 +126,63 @@ class KisProvider(BrokerProvider):
             totals=self._totals(rows),
         )
 
+    def fetch_market_volume(self, *, limit: int = 20) -> list[MarketRankItem]:
+        response = self.client.domestic_ranking_analysis.get_trading_volume_rank(
+            "J",
+            "20171",
+            "0000",
+            "0",
+            "0",
+            "111111111",
+            "0000000000",
+            "",
+            "",
+            "",
+            "",
+        )
+        return [
+            self._market_item(item, source="kis", category="volume", value_field="acml_vol")
+            for item in getattr(response.body, "output", [])[:limit]
+        ]
+
+    def fetch_market_ranking(self, *, limit: int = 20) -> list[MarketRankItem]:
+        response = self.client.domestic_ranking_analysis.get_stock_fluctuation_rank(
+            "",
+            "J",
+            "20170",
+            "0000",
+            "0",
+            "0",
+            "0",
+            "",
+            "",
+            "",
+            "0",
+            "0",
+            "0",
+            "",
+        )
+        return [
+            self._market_item(item, source="kis", category="ranking", value_field="stck_prpr")
+            for item in getattr(response.body, "output", [])[:limit]
+        ]
+
+    def fetch_market_sector(self, *, limit: int = 20) -> list[MarketRankItem]:
+        response = self.client.domestic_issue_other.get_sector_all_quote_by_category("U", "0001", "20214", "K", "0")
+        return [
+            MarketRankItem(
+                source="kis",
+                category="sector",
+                rank=index + 1,
+                stock_code=getattr(item, "bstp_cls_code", None),
+                stock_name=getattr(item, "hts_kor_isnm", None),
+                value=getattr(item, "bstp_nmix_prpr", None),
+                change_rate=getattr(item, "bstp_nmix_prdy_ctrt", None),
+                raw=self._raw_dict(item),
+            )
+            for index, item in enumerate(getattr(response.body, "output2", [])[:limit])
+        ]
+
     @staticmethod
     def _extract_output(response: Any) -> list[Any]:
         output = getattr(getattr(response, "body", response), "output", [])
@@ -193,3 +251,31 @@ class KisProvider(BrokerProvider):
                     continue
                 totals[key] = totals.get(key, 0.0) + float(value)
         return totals
+
+    @classmethod
+    def _market_item(cls, item: Any, *, source: str, category: str, value_field: str) -> MarketRankItem:
+        return MarketRankItem(
+            source=source,
+            category=category,
+            rank=cls._to_int(getattr(item, "data_rank", None)),
+            stock_code=getattr(item, "mksc_shrn_iscd", None) or getattr(item, "stck_shrn_iscd", None),
+            stock_name=getattr(item, "hts_kor_isnm", None),
+            value=getattr(item, value_field, None),
+            change_rate=getattr(item, "prdy_ctrt", None),
+            raw=cls._raw_dict(item),
+        )
+
+    @staticmethod
+    def _to_int(value: Any) -> int | None:
+        if value in {None, ""}:
+            return None
+        try:
+            return int(str(value).replace(",", "").strip())
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _raw_dict(item: Any) -> dict[str, Any]:
+        if hasattr(item, "model_dump"):
+            return item.model_dump()
+        return dict(getattr(item, "__dict__", {}))

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/kis.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/kis.py
@@ -2,8 +2,89 @@
 
 from __future__ import annotations
 
+from datetime import date, timedelta
+from typing import Any
+
+from cluefin_cli.domains.models import FinancialMetric, NewsHeadline, StatementSnapshot
 from cluefin_cli.domains.providers.base import BrokerProvider
 
 
 class KisProvider(BrokerProvider):
     broker = "kis"
+
+    def fetch_statement_snapshot(self, *, stock_code: str, div_cls_code: str = "0") -> StatementSnapshot:
+        stock_info = self.client.domestic_stock_info
+        metrics: list[FinancialMetric] = []
+        for label, response in [
+            ("balance_sheet", stock_info.get_balance_sheet(div_cls_code, "J", stock_code)),
+            ("income_statement", stock_info.get_income_statement(div_cls_code, "J", stock_code)),
+            ("financial_ratio", stock_info.get_financial_ratio(div_cls_code, "J", stock_code)),
+        ]:
+            metrics.extend(self._metrics_from_output(label, self._extract_output(response)))
+
+        return StatementSnapshot(stock_code=stock_code.zfill(6), source="kis", metrics=metrics)
+
+    def fetch_news(
+        self, *, stock_code: str | None = None, days: int = 7, query: str | None = None
+    ) -> list[NewsHeadline]:
+        start = (date.today() - timedelta(days=days)).strftime("00%Y%m%d")
+        response = self.client.domestic_issue_other.get_market_announcement_schedule(
+            "",
+            "",
+            stock_code or "",
+            query or "",
+            start,
+            "",
+            "",
+            "",
+        )
+        items = self._extract_output(response)
+        return [
+            NewsHeadline(
+                source="kis",
+                title=getattr(item, "hts_pbnt_titl_cntt", ""),
+                published_at=self._published_at(item),
+                stock_codes=[
+                    code
+                    for code in [
+                        getattr(item, "iscd1", ""),
+                        getattr(item, "iscd2", ""),
+                        getattr(item, "iscd3", ""),
+                        getattr(item, "iscd4", ""),
+                        getattr(item, "iscd5", ""),
+                    ]
+                    if code
+                ],
+                provider=getattr(item, "dorg", None),
+                raw_id=getattr(item, "cntt_usiq_srno", None),
+            )
+            for item in items
+        ]
+
+    @staticmethod
+    def _extract_output(response: Any) -> list[Any]:
+        output = getattr(getattr(response, "body", response), "output", [])
+        if output is None:
+            return []
+        if isinstance(output, (list, tuple)):
+            return list(output)
+        return [output]
+
+    @staticmethod
+    def _metrics_from_output(section: str, items: list[Any]) -> list[FinancialMetric]:
+        metrics: list[FinancialMetric] = []
+        for item in items:
+            data = item.model_dump() if hasattr(item, "model_dump") else getattr(item, "__dict__", {})
+            for key, value in data.items():
+                if value in {None, ""}:
+                    continue
+                metrics.append(FinancialMetric(name=f"{section}.{key}", value=value, source="kis"))
+        return metrics
+
+    @staticmethod
+    def _published_at(item: Any) -> str | None:
+        data_dt = getattr(item, "data_dt", None)
+        data_tm = getattr(item, "data_tm", None)
+        if data_dt and data_tm:
+            return f"{data_dt}{data_tm}"
+        return data_dt

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/kis.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/kis.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 from datetime import date, timedelta
 from typing import Any
 
-from cluefin_cli.domains.models import FinancialMetric, NewsHeadline, StatementSnapshot
+from cluefin_cli.domains.models import (
+    FinancialMetric,
+    NewsHeadline,
+    OhlcvPoint,
+    OhlcvSeries,
+    StatementSnapshot,
+    TradingFlowSnapshot,
+)
 from cluefin_cli.domains.providers.base import BrokerProvider
 
 
@@ -61,6 +68,63 @@ class KisProvider(BrokerProvider):
             for item in items
         ]
 
+    def fetch_ohlcv(self, *, stock_code: str, interval: str = "daily", days: int = 300) -> OhlcvSeries:
+        quote = self.client.domestic_basic_quote
+        if interval == "minute":
+            response = quote.get_stock_today_minute_chart("J", stock_code, "153000", "Y", "")
+            items = getattr(response.body, "output2", [])
+            points = [self._ohlcv_from_minute(item) for item in items]
+        else:
+            end_date = date.today()
+            start_date = end_date - timedelta(days=days * 2)
+            response = quote.get_stock_period_quote(
+                "J",
+                stock_code,
+                start_date.strftime("%Y%m%d"),
+                end_date.strftime("%Y%m%d"),
+                "D",
+                "0",
+            )
+            items = getattr(response.body, "output2", [])
+            points = [self._ohlcv_from_daily(item) for item in items]
+
+        points = sorted(points, key=lambda item: item.timestamp)[-days:]
+        return OhlcvSeries(stock_code=stock_code.zfill(6), source="kis", interval=interval, points=points)
+
+    def fetch_trading_flow(self, *, stock_code: str, start_date: str, end_date: str) -> TradingFlowSnapshot:
+        response = self.client.domestic_market_analysis.get_investor_trading_trend_by_stock_daily(
+            "J", stock_code, end_date
+        )
+        rows: list[dict[str, Any]] = []
+        for item in getattr(response.body, "output2", []):
+            row_date = getattr(item, "stck_bsop_date", "")
+            if row_date and row_date < start_date:
+                continue
+            rows.append(
+                {
+                    "date": row_date,
+                    "individual": self._to_float(getattr(item, "prsn_ntby_qty", None)),
+                    "foreign": self._to_float(getattr(item, "frgn_ntby_qty", None)),
+                    "institution": self._to_float(getattr(item, "orgn_ntby_qty", None)),
+                    "securities": self._to_float(getattr(item, "scrt_ntby_qty", None)),
+                    "investment_trust": self._to_float(getattr(item, "ivtr_ntby_qty", None)),
+                    "private_fund": self._to_float(getattr(item, "pe_fund_ntby_vol", None)),
+                    "bank": self._to_float(getattr(item, "bank_ntby_qty", None)),
+                    "insurance": self._to_float(getattr(item, "insu_ntby_qty", None)),
+                    "fund": self._to_float(getattr(item, "fund_ntby_qty", None)),
+                    "other": self._to_float(getattr(item, "etc_ntby_qty", None)),
+                }
+            )
+        rows = sorted(rows, key=lambda item: item["date"])
+        return TradingFlowSnapshot(
+            stock_code=stock_code.zfill(6),
+            source="kis",
+            start_date=start_date,
+            end_date=end_date,
+            rows=rows,
+            totals=self._totals(rows),
+        )
+
     @staticmethod
     def _extract_output(response: Any) -> list[Any]:
         output = getattr(getattr(response, "body", response), "output", [])
@@ -88,3 +152,44 @@ class KisProvider(BrokerProvider):
         if data_dt and data_tm:
             return f"{data_dt}{data_tm}"
         return data_dt
+
+    @classmethod
+    def _ohlcv_from_daily(cls, item: Any) -> OhlcvPoint:
+        return OhlcvPoint(
+            timestamp=getattr(item, "stck_bsop_date", ""),
+            open=cls._to_float(getattr(item, "stck_oprc", None)),
+            high=cls._to_float(getattr(item, "stck_hgpr", None)),
+            low=cls._to_float(getattr(item, "stck_lwpr", None)),
+            close=cls._to_float(getattr(item, "stck_clpr", None)),
+            volume=cls._to_float(getattr(item, "acml_vol", None)),
+        )
+
+    @classmethod
+    def _ohlcv_from_minute(cls, item: Any) -> OhlcvPoint:
+        return OhlcvPoint(
+            timestamp=f"{getattr(item, 'stck_bsop_date', '')}{getattr(item, 'stck_cntg_hour', '')}",
+            open=cls._to_float(getattr(item, "stck_oprc", None)),
+            high=cls._to_float(getattr(item, "stck_hgpr", None)),
+            low=cls._to_float(getattr(item, "stck_lwpr", None)),
+            close=cls._to_float(getattr(item, "stck_prpr", None)),
+            volume=cls._to_float(getattr(item, "cntg_vol", None)),
+        )
+
+    @staticmethod
+    def _to_float(value: Any) -> float | None:
+        if value in {None, ""}:
+            return None
+        try:
+            return float(str(value).replace(",", "").strip())
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _totals(rows: list[dict[str, Any]]) -> dict[str, float]:
+        totals: dict[str, float] = {}
+        for row in rows:
+            for key, value in row.items():
+                if key == "date" or value is None:
+                    continue
+                totals[key] = totals.get(key, 0.0) + float(value)
+        return totals

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/kiwoom.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/kiwoom.py
@@ -2,8 +2,109 @@
 
 from __future__ import annotations
 
+from datetime import date
+from typing import Any
+
+from cluefin_cli.domains.models import OhlcvPoint, OhlcvSeries, TradingFlowSnapshot
 from cluefin_cli.domains.providers.base import BrokerProvider
 
 
 class KiwoomProvider(BrokerProvider):
     broker = "kiwoom"
+
+    def fetch_ohlcv(self, *, stock_code: str, interval: str = "daily", days: int = 300) -> OhlcvSeries:
+        chart = self.client.chart
+        if interval == "minute":
+            response = chart.get_stock_minute(stk_cd=stock_code, tic_scope="1", upd_stkpc_tp="1")
+            items = getattr(response.body, "stk_min_pole_chart_qry", [])
+            points = [self._ohlcv_from_minute(item) for item in items]
+        else:
+            response = chart.get_stock_daily(
+                stk_cd=stock_code,
+                base_dt=date.today().strftime("%Y%m%d"),
+                upd_stkpc_tp="1",
+            )
+            items = getattr(response.body, "stk_dt_pole_chart_qry", [])
+            points = [self._ohlcv_from_daily(item) for item in items]
+
+        points = sorted(points, key=lambda item: item.timestamp)[-days:]
+        return OhlcvSeries(stock_code=stock_code.zfill(6), source="kiwoom", interval=interval, points=points)
+
+    def fetch_trading_flow(self, *, stock_code: str, start_date: str, end_date: str) -> TradingFlowSnapshot:
+        response = self.client.chart.get_individual_stock_institutional_chart(
+            dt=end_date,
+            stk_cd=stock_code,
+            amt_qty_tp="2",
+            trde_tp="0",
+            unit_tp="1",
+        )
+        rows: list[dict[str, Any]] = []
+        for item in getattr(response.body, "stk_invsr_orgn_chart", []):
+            row_date = getattr(item, "dt", "")
+            if row_date and row_date < start_date:
+                continue
+            rows.append(
+                {
+                    "date": row_date,
+                    "individual": self._to_float(getattr(item, "ind_invsr", None)),
+                    "foreign": self._to_float(getattr(item, "frgnr_invsr", None)),
+                    "institution": self._to_float(getattr(item, "orgn", None)),
+                    "financial_investment": self._to_float(getattr(item, "fnnc_invt", None)),
+                    "insurance": self._to_float(getattr(item, "insrnc", None)),
+                    "investment_trust": self._to_float(getattr(item, "invtrt", None)),
+                    "bank": self._to_float(getattr(item, "bank", None)),
+                    "pension_fund": self._to_float(getattr(item, "penfnd_etc", None)),
+                    "other_corporation": self._to_float(getattr(item, "etc_corp", None)),
+                }
+            )
+        rows = sorted(rows, key=lambda item: item["date"])
+        return TradingFlowSnapshot(
+            stock_code=stock_code.zfill(6),
+            source="kiwoom",
+            start_date=start_date,
+            end_date=end_date,
+            rows=rows,
+            totals=self._totals(rows),
+        )
+
+    @classmethod
+    def _ohlcv_from_daily(cls, item: Any) -> OhlcvPoint:
+        return OhlcvPoint(
+            timestamp=getattr(item, "dt", ""),
+            open=cls._to_float(getattr(item, "open_pric", None), absolute=True),
+            high=cls._to_float(getattr(item, "high_pric", None), absolute=True),
+            low=cls._to_float(getattr(item, "low_pric", None), absolute=True),
+            close=cls._to_float(getattr(item, "cur_prc", None), absolute=True),
+            volume=cls._to_float(getattr(item, "trde_qty", None)),
+        )
+
+    @classmethod
+    def _ohlcv_from_minute(cls, item: Any) -> OhlcvPoint:
+        return OhlcvPoint(
+            timestamp=getattr(item, "cntr_tm", ""),
+            open=cls._to_float(getattr(item, "open_pric", None), absolute=True),
+            high=cls._to_float(getattr(item, "high_pric", None), absolute=True),
+            low=cls._to_float(getattr(item, "low_pric", None), absolute=True),
+            close=cls._to_float(getattr(item, "cur_prc", None), absolute=True),
+            volume=cls._to_float(getattr(item, "trde_qty", None)),
+        )
+
+    @staticmethod
+    def _to_float(value: Any, *, absolute: bool = False) -> float | None:
+        if value in {None, ""}:
+            return None
+        try:
+            parsed = float(str(value).replace(",", "").strip())
+        except (TypeError, ValueError):
+            return None
+        return abs(parsed) if absolute else parsed
+
+    @staticmethod
+    def _totals(rows: list[dict[str, Any]]) -> dict[str, float]:
+        totals: dict[str, float] = {}
+        for row in rows:
+            for key, value in row.items():
+                if key == "date" or value is None:
+                    continue
+                totals[key] = totals.get(key, 0.0) + float(value)
+        return totals

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/kiwoom.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/kiwoom.py
@@ -1,0 +1,9 @@
+"""Kiwoom provider adapter."""
+
+from __future__ import annotations
+
+from cluefin_cli.domains.providers.base import BrokerProvider
+
+
+class KiwoomProvider(BrokerProvider):
+    broker = "kiwoom"

--- a/apps/cluefin-cli/src/cluefin_cli/domains/providers/kiwoom.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/providers/kiwoom.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Any
 
-from cluefin_cli.domains.models import OhlcvPoint, OhlcvSeries, TradingFlowSnapshot
+from cluefin_cli.domains.models import MarketRankItem, OhlcvPoint, OhlcvSeries, TradingFlowSnapshot
 from cluefin_cli.domains.providers.base import BrokerProvider
 
 
@@ -67,6 +67,47 @@ class KiwoomProvider(BrokerProvider):
             totals=self._totals(rows),
         )
 
+    def fetch_market_volume(self, *, limit: int = 20) -> list[MarketRankItem]:
+        response = self.client.rank_info.get_top_current_day_trading_volume(
+            "000", "1", "4", "0", "0", "0", "0", "0", "1"
+        )
+        return [
+            self._market_item(item, source="kiwoom", category="volume", rank=index + 1, value_field="trde_qty")
+            for index, item in enumerate(getattr(response.body, "tdy_trde_qty_upper", [])[:limit])
+        ]
+
+    def fetch_market_ranking(self, *, limit: int = 20) -> list[MarketRankItem]:
+        response = self.client.rank_info.get_top_percentage_change_from_previous_day(
+            "000", "1", "0000", "4", "0", "1", "0", "0", "1"
+        )
+        return [
+            self._market_item(item, source="kiwoom", category="ranking", rank=index + 1, value_field="cur_prc")
+            for index, item in enumerate(getattr(response.body, "pred_pre_flu_rt_upper", [])[:limit])
+        ]
+
+    def fetch_market_theme(self, *, limit: int = 20) -> list[MarketRankItem]:
+        response = self.client.theme.get_theme_group("0", "1", "", "1", "3")
+        return [
+            MarketRankItem(
+                source="kiwoom",
+                category="theme",
+                rank=index + 1,
+                stock_code=getattr(item, "thema_grp_cd", None),
+                stock_name=getattr(item, "thema_nm", None),
+                value=getattr(item, "dt_prft_rt", None) or getattr(item, "flu_rt", None),
+                change_rate=getattr(item, "flu_rt", None),
+                raw=self._raw_dict(item),
+            )
+            for index, item in enumerate(getattr(response.body, "thema_grp", [])[:limit])
+        ]
+
+    def fetch_market_sector(self, *, limit: int = 20) -> list[MarketRankItem]:
+        response = self.client.sector.get_all_industry_index("001")
+        return [
+            self._market_item(item, source="kiwoom", category="sector", rank=index + 1, value_field="cur_prc")
+            for index, item in enumerate(getattr(response.body, "all_inds_idex", [])[:limit])
+        ]
+
     @classmethod
     def _ohlcv_from_daily(cls, item: Any) -> OhlcvPoint:
         return OhlcvPoint(
@@ -108,3 +149,39 @@ class KiwoomProvider(BrokerProvider):
                     continue
                 totals[key] = totals.get(key, 0.0) + float(value)
         return totals
+
+    @classmethod
+    def _market_item(
+        cls,
+        item: Any,
+        *,
+        source: str,
+        category: str,
+        rank: int,
+        value_field: str,
+    ) -> MarketRankItem:
+        return MarketRankItem(
+            source=source,
+            category=category,
+            rank=cls._to_int(getattr(item, "now_rank", None)) or rank,
+            stock_code=getattr(item, "stk_cd", None),
+            stock_name=getattr(item, "stk_nm", None),
+            value=getattr(item, value_field, None),
+            change_rate=getattr(item, "flu_rt", None),
+            raw=cls._raw_dict(item),
+        )
+
+    @staticmethod
+    def _to_int(value: Any) -> int | None:
+        if value in {None, ""}:
+            return None
+        try:
+            return int(str(value).replace(",", "").strip())
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _raw_dict(item: Any) -> dict[str, Any]:
+        if hasattr(item, "model_dump"):
+            return item.model_dump()
+        return dict(getattr(item, "__dict__", {}))

--- a/apps/cluefin-cli/src/cluefin_cli/domains/statements.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/statements.py
@@ -1,0 +1,58 @@
+"""Statements domain service."""
+
+from __future__ import annotations
+
+from datetime import date
+
+from cluefin_cli.domains.models import StatementSnapshot
+from cluefin_cli.domains.providers import DartProvider, KisProvider
+
+REPORT_CODE_MAP = {
+    "annual": "11011",
+    "half": "11012",
+    "q1": "11013",
+    "q3": "11014",
+}
+
+
+def default_business_year() -> str:
+    return str(date.today().year - 1)
+
+
+class StatementsService:
+    def __init__(self, dart_provider: DartProvider | None = None, kis_provider: KisProvider | None = None) -> None:
+        self.dart_provider = dart_provider or DartProvider()
+        self.kis_provider = kis_provider or KisProvider()
+
+    def fetch(
+        self,
+        *,
+        stock_code: str,
+        source: str = "auto",
+        year: str | None = None,
+        report: str = "annual",
+        include_xbrl: bool = False,
+        statement_type: str | None = None,
+    ) -> list[StatementSnapshot]:
+        report_code = REPORT_CODE_MAP[report]
+        business_year = year or default_business_year()
+        snapshots: list[StatementSnapshot] = []
+
+        if source in {"auto", "dart", "all"}:
+            snapshots.append(
+                self.dart_provider.fetch_statement_snapshot(
+                    stock_code=stock_code,
+                    business_year=business_year,
+                    report_code=report_code,
+                    include_xbrl=include_xbrl,
+                    statement_type=statement_type,
+                )
+            )
+
+        if source in {"kis", "all"}:
+            div_cls_code = "0" if report == "annual" else "1"
+            snapshots.append(
+                self.kis_provider.fetch_statement_snapshot(stock_code=stock_code, div_cls_code=div_cls_code)
+            )
+
+        return snapshots

--- a/apps/cluefin-cli/src/cluefin_cli/domains/trading_flow.py
+++ b/apps/cluefin-cli/src/cluefin_cli/domains/trading_flow.py
@@ -1,0 +1,68 @@
+"""Domain service for normalized investor trading flow data."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+
+from cluefin_cli.domains.models import TradingFlowSnapshot
+from cluefin_cli.domains.providers.kis import KisProvider
+from cluefin_cli.domains.providers.kiwoom import KiwoomProvider
+
+
+class TradingFlowService:
+    def __init__(self, *, kiwoom_provider: KiwoomProvider | None = None, kis_provider: KisProvider | None = None):
+        self.kiwoom_provider = kiwoom_provider or KiwoomProvider()
+        self.kis_provider = kis_provider or KisProvider()
+
+    def fetch(
+        self,
+        *,
+        stock_code: str,
+        source: str = "auto",
+        start_date: str | None = None,
+        end_date: str | None = None,
+    ) -> list[TradingFlowSnapshot]:
+        resolved_start, resolved_end = resolve_dates(start_date=start_date, end_date=end_date)
+        if source == "kiwoom":
+            return [
+                self.kiwoom_provider.fetch_trading_flow(
+                    stock_code=stock_code, start_date=resolved_start, end_date=resolved_end
+                )
+            ]
+        if source == "kis":
+            return [
+                self.kis_provider.fetch_trading_flow(
+                    stock_code=stock_code, start_date=resolved_start, end_date=resolved_end
+                )
+            ]
+        if source == "all":
+            snapshots: list[TradingFlowSnapshot] = []
+            for provider in [self.kiwoom_provider, self.kis_provider]:
+                snapshots.append(
+                    provider.fetch_trading_flow(stock_code=stock_code, start_date=resolved_start, end_date=resolved_end)
+                )
+            return snapshots
+        try:
+            return [
+                self.kiwoom_provider.fetch_trading_flow(
+                    stock_code=stock_code, start_date=resolved_start, end_date=resolved_end
+                )
+            ]
+        except Exception:
+            return [
+                self.kis_provider.fetch_trading_flow(
+                    stock_code=stock_code, start_date=resolved_start, end_date=resolved_end
+                )
+            ]
+
+
+def resolve_dates(*, start_date: str | None, end_date: str | None) -> tuple[str, str]:
+    end = _parse_date(end_date) if end_date else date.today()
+    start = _parse_date(start_date) if start_date else end - timedelta(days=365)
+    return start.strftime("%Y%m%d"), end.strftime("%Y%m%d")
+
+
+def _parse_date(value: str) -> date:
+    if len(value) != 8 or not value.isdigit():
+        raise ValueError("dates must use YYYYMMDD format")
+    return date(int(value[:4]), int(value[4:6]), int(value[6:]))

--- a/apps/cluefin-cli/src/cluefin_cli/main.py
+++ b/apps/cluefin-cli/src/cluefin_cli/main.py
@@ -5,16 +5,40 @@ from cluefin_cli.commands.fundamental_analysis import fundamental_analysis
 from cluefin_cli.commands.technical_analysis import technical_analysis
 from cluefin_cli.commands.xbrl_analysis import xbrl_analysis
 from cluefin_cli.config.logging import setup_logging
+from cluefin_cli.output import success_envelope, write_json
 
 console = Console()
 
 
-@click.group()
+@click.group(invoke_without_command=True)
+@click.pass_context
 @click.option("--debug", is_flag=True, help="Enable debug logging")
+@click.option("--json", "json_output", is_flag=True, help="Emit JSON output where supported")
 @click.version_option(version="0.1.0", prog_name="cluefin-cli")
-def cli(debug: bool):
+def cli(ctx: click.Context, debug: bool, json_output: bool):
     """Korean financial investment CLI toolkit with technical analysis and AI insights."""
     setup_logging(debug=debug)
+    ctx.ensure_object(dict)
+    ctx.obj["json"] = json_output
+    if ctx.invoked_subcommand is not None:
+        return
+
+    if json_output:
+        write_json(
+            success_envelope(
+                command="root",
+                source=None,
+                params={"debug": debug},
+                data={
+                    "app": "cluefin-cli",
+                    "commands": ["statements", "chart", "news", "trading-flow", "market"],
+                    "deprecated_commands": ["ta", "fa", "xbrl"],
+                },
+                meta={"version": "0.1.0"},
+            )
+        )
+        return
+
     console.print("[bold blue]Cluefin CLI - Stock Analysis Tool[/bold blue]")
     console.print("Use --help to see available commands")
 

--- a/apps/cluefin-cli/src/cluefin_cli/main.py
+++ b/apps/cluefin-cli/src/cluefin_cli/main.py
@@ -2,6 +2,7 @@ import click
 from rich.console import Console
 
 from cluefin_cli.commands.chart import chart_command
+from cluefin_cli.commands.describe import describe_command
 from cluefin_cli.commands.fundamental_analysis import fundamental_analysis
 from cluefin_cli.commands.market import market_command
 from cluefin_cli.commands.news import news_command
@@ -37,6 +38,7 @@ def cli(ctx: click.Context, debug: bool, json_output: bool):
                 data={
                     "app": "cluefin-cli",
                     "commands": ["statements", "chart", "news", "trading-flow", "market"],
+                    "discovery_commands": ["describe"],
                     "deprecated_commands": ["ta", "fa", "xbrl"],
                 },
                 meta={"version": "0.1.0"},
@@ -56,6 +58,7 @@ cli.add_command(news_command)
 cli.add_command(chart_command)
 cli.add_command(trading_flow_command)
 cli.add_command(market_command)
+cli.add_command(describe_command)
 
 
 if __name__ == "__main__":

--- a/apps/cluefin-cli/src/cluefin_cli/main.py
+++ b/apps/cluefin-cli/src/cluefin_cli/main.py
@@ -2,6 +2,8 @@ import click
 from rich.console import Console
 
 from cluefin_cli.commands.fundamental_analysis import fundamental_analysis
+from cluefin_cli.commands.news import news_command
+from cluefin_cli.commands.statements import statements_command
 from cluefin_cli.commands.technical_analysis import technical_analysis
 from cluefin_cli.commands.xbrl_analysis import xbrl_analysis
 from cluefin_cli.config.logging import setup_logging
@@ -46,6 +48,8 @@ def cli(ctx: click.Context, debug: bool, json_output: bool):
 cli.add_command(technical_analysis)
 cli.add_command(fundamental_analysis)
 cli.add_command(xbrl_analysis)
+cli.add_command(statements_command)
+cli.add_command(news_command)
 
 
 if __name__ == "__main__":

--- a/apps/cluefin-cli/src/cluefin_cli/main.py
+++ b/apps/cluefin-cli/src/cluefin_cli/main.py
@@ -3,6 +3,7 @@ from rich.console import Console
 
 from cluefin_cli.commands.chart import chart_command
 from cluefin_cli.commands.fundamental_analysis import fundamental_analysis
+from cluefin_cli.commands.market import market_command
 from cluefin_cli.commands.news import news_command
 from cluefin_cli.commands.statements import statements_command
 from cluefin_cli.commands.technical_analysis import technical_analysis
@@ -54,6 +55,7 @@ cli.add_command(statements_command)
 cli.add_command(news_command)
 cli.add_command(chart_command)
 cli.add_command(trading_flow_command)
+cli.add_command(market_command)
 
 
 if __name__ == "__main__":

--- a/apps/cluefin-cli/src/cluefin_cli/main.py
+++ b/apps/cluefin-cli/src/cluefin_cli/main.py
@@ -1,10 +1,12 @@
 import click
 from rich.console import Console
 
+from cluefin_cli.commands.chart import chart_command
 from cluefin_cli.commands.fundamental_analysis import fundamental_analysis
 from cluefin_cli.commands.news import news_command
 from cluefin_cli.commands.statements import statements_command
 from cluefin_cli.commands.technical_analysis import technical_analysis
+from cluefin_cli.commands.trading_flow import trading_flow_command
 from cluefin_cli.commands.xbrl_analysis import xbrl_analysis
 from cluefin_cli.config.logging import setup_logging
 from cluefin_cli.output import success_envelope, write_json
@@ -50,6 +52,8 @@ cli.add_command(fundamental_analysis)
 cli.add_command(xbrl_analysis)
 cli.add_command(statements_command)
 cli.add_command(news_command)
+cli.add_command(chart_command)
+cli.add_command(trading_flow_command)
 
 
 if __name__ == "__main__":

--- a/apps/cluefin-cli/src/cluefin_cli/output.py
+++ b/apps/cluefin-cli/src/cluefin_cli/output.py
@@ -1,0 +1,82 @@
+"""Structured output helpers for cluefin-cli."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict, is_dataclass
+from datetime import date, datetime
+from decimal import Decimal
+from typing import Any
+
+
+def to_jsonable(value: Any) -> Any:
+    """Convert common project objects into JSON-safe structures."""
+    if is_dataclass(value):
+        return {key: to_jsonable(item) for key, item in asdict(value).items()}
+    if hasattr(value, "model_dump"):
+        return to_jsonable(value.model_dump())
+    if isinstance(value, dict):
+        return {str(key): to_jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [to_jsonable(item) for item in value]
+    if isinstance(value, set):
+        return [to_jsonable(item) for item in sorted(value, key=str)]
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (date, datetime)):
+        return value.isoformat()
+    return value
+
+
+def success_envelope(
+    *,
+    command: str,
+    data: Any,
+    source: str | None = None,
+    params: dict[str, Any] | None = None,
+    warnings: list[str] | None = None,
+    meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a stable success envelope for agent-facing JSON output."""
+    return {
+        "ok": True,
+        "command": command,
+        "source": source,
+        "params": params or {},
+        "data": data,
+        "warnings": warnings or [],
+        "meta": meta or {},
+    }
+
+
+def error_envelope(
+    *,
+    command: str,
+    error_type: str,
+    message: str,
+    warnings: list[str] | None = None,
+    meta: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a stable error envelope for agent-facing JSON output."""
+    return {
+        "ok": False,
+        "command": command,
+        "error": {
+            "type": error_type,
+            "message": message,
+        },
+        "warnings": warnings or [],
+        "meta": meta or {},
+    }
+
+
+def dump_json(payload: Any) -> str:
+    """Serialize payload with stable formatting."""
+    return json.dumps(to_jsonable(payload), ensure_ascii=False, indent=2, default=str)
+
+
+def write_json(payload: Any) -> None:
+    """Write JSON payload to stdout."""
+    sys.stdout.write(dump_json(payload))
+    sys.stdout.write("\n")

--- a/apps/cluefin-cli/tests/unit/commands/test_describe.py
+++ b/apps/cluefin-cli/tests/unit/commands/test_describe.py
@@ -1,0 +1,51 @@
+import json
+
+from click.testing import CliRunner
+
+from cluefin_cli.main import cli
+
+
+def test_describe_json_lists_domain_commands_without_banner() -> None:
+    result = CliRunner().invoke(cli, ["describe", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["command"] == "describe"
+    assert "Cluefin CLI - Stock Analysis Tool" not in result.output
+    assert {item["name"] for item in payload["data"]["commands"]} == {
+        "statements",
+        "chart",
+        "news",
+        "trading-flow",
+        "market",
+    }
+
+
+def test_describe_json_can_select_one_command() -> None:
+    result = CliRunner().invoke(cli, ["describe", "chart", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    commands = payload["data"]["commands"]
+    assert len(commands) == 1
+    assert commands[0]["name"] == "chart"
+    assert commands[0]["usage"] == "cluefin-cli chart STOCK_CODE [OPTIONS]"
+    assert any(option["name"] == "--indicators" for option in commands[0]["options"])
+
+
+def test_describe_market_json_includes_subcommands() -> None:
+    result = CliRunner().invoke(cli, ["describe", "market", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    market = payload["data"]["commands"][0]
+    assert [item["name"] for item in market["subcommands"]] == ["volume", "ranking", "theme", "sector"]
+
+
+def test_root_json_mentions_describe_discovery_command() -> None:
+    result = CliRunner().invoke(cli, ["--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert "describe" in payload["data"]["discovery_commands"]

--- a/apps/cluefin-cli/tests/unit/commands/test_domain_chart_trading_flow.py
+++ b/apps/cluefin-cli/tests/unit/commands/test_domain_chart_trading_flow.py
@@ -1,0 +1,81 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from cluefin_cli.domains.models import IndicatorSnapshot, OhlcvPoint, OhlcvSeries, TradingFlowSnapshot
+from cluefin_cli.main import cli
+
+
+@patch("cluefin_cli.commands.chart.ChartService")
+def test_chart_command_json_uses_service(mock_service_cls: MagicMock) -> None:
+    service = MagicMock()
+    service.fetch.return_value = OhlcvSeries(
+        stock_code="005930",
+        source="kiwoom",
+        interval="daily",
+        points=[OhlcvPoint(timestamp="20250102", open=1, high=2, low=1, close=2, volume=100)],
+        indicators=[IndicatorSnapshot(name="sma_20", values=[None], latest=None)],
+    )
+    mock_service_cls.return_value = service
+
+    result = CliRunner().invoke(cli, ["chart", "005930", "--indicators", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["command"] == "chart"
+    assert payload["source"] == "kiwoom"
+    assert payload["data"]["points"][0]["timestamp"] == "20250102"
+    assert payload["data"]["indicators"][0]["name"] == "sma_20"
+    service.fetch.assert_called_once_with(
+        stock_code="005930", source="auto", interval="daily", days=300, indicators=True
+    )
+
+
+@patch("cluefin_cli.commands.trading_flow.TradingFlowService")
+def test_trading_flow_command_json_uses_service(mock_service_cls: MagicMock) -> None:
+    service = MagicMock()
+    service.fetch.return_value = [
+        TradingFlowSnapshot(
+            stock_code="005930",
+            source="kis",
+            start_date="20240101",
+            end_date="20241231",
+            rows=[{"date": "20241231", "foreign": 10.0}],
+            totals={"foreign": 10.0},
+        )
+    ]
+    mock_service_cls.return_value = service
+
+    result = CliRunner().invoke(
+        cli,
+        ["trading-flow", "005930", "--source", "kis", "--start-date", "20240101", "--end-date", "20241231", "--json"],
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["command"] == "trading-flow"
+    assert payload["data"]["items"][0]["rows"][0]["foreign"] == 10.0
+    service.fetch.assert_called_once_with(
+        stock_code="005930",
+        source="kis",
+        start_date="20240101",
+        end_date="20241231",
+    )
+
+
+@patch("cluefin_cli.commands.trading_flow.TradingFlowService")
+def test_trading_flow_command_json_error_envelope(mock_service_cls: MagicMock) -> None:
+    service = MagicMock()
+    service.fetch.side_effect = RuntimeError("provider failed")
+    mock_service_cls.return_value = service
+
+    result = CliRunner().invoke(cli, ["trading-flow", "005930", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    assert payload["error"]["type"] == "RuntimeError"
+    assert payload["error"]["message"] == "provider failed"

--- a/apps/cluefin-cli/tests/unit/commands/test_domain_market.py
+++ b/apps/cluefin-cli/tests/unit/commands/test_domain_market.py
@@ -1,0 +1,58 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from cluefin_cli.domains.models import MarketRankItem
+from cluefin_cli.main import cli
+
+
+def test_market_subcommands_are_registered() -> None:
+    result = CliRunner().invoke(cli, ["market", "--help"])
+
+    assert result.exit_code == 0
+    for subcommand in ["volume", "ranking", "theme", "sector"]:
+        assert subcommand in result.output
+
+
+@patch("cluefin_cli.commands.market.MarketService")
+def test_market_subcommands_emit_json(mock_service_cls: MagicMock) -> None:
+    service = MagicMock()
+    service.fetch.return_value = [
+        MarketRankItem(
+            source="kis", category="volume", rank=1, stock_code="005930", stock_name="삼성전자", value="1000"
+        )
+    ]
+    mock_service_cls.return_value = service
+
+    for subcommand in ["volume", "ranking", "theme", "sector"]:
+        result = CliRunner().invoke(cli, ["market", subcommand, "--limit", "1", "--json"])
+
+        assert result.exit_code == 0
+        payload = json.loads(result.output)
+        assert payload["ok"] is True
+        assert payload["command"] == f"market {subcommand}"
+        assert payload["data"]["items"][0]["stock_code"] == "005930"
+
+    assert service.fetch.call_count == 4
+
+
+def test_readme_domain_examples_match_registered_commands() -> None:
+    readme = Path("apps/cluefin-cli/README.md").read_text()
+    expected_examples = [
+        "cluefin-cli statements 005930 --json",
+        "cluefin-cli chart 005930 --indicators --json",
+        "cluefin-cli news 005930 --source all --json",
+        "cluefin-cli trading-flow 005930 --json",
+        "cluefin-cli market volume --json",
+        "cluefin-cli market ranking --json",
+        "cluefin-cli market theme --json",
+        "cluefin-cli market sector --json",
+    ]
+    for example in expected_examples:
+        assert example in readme
+
+    runner = CliRunner()
+    for command in ["statements", "chart", "news", "trading-flow", "market"]:
+        assert runner.invoke(cli, [command, "--help"]).exit_code == 0

--- a/apps/cluefin-cli/tests/unit/commands/test_domain_statements_news.py
+++ b/apps/cluefin-cli/tests/unit/commands/test_domain_statements_news.py
@@ -1,0 +1,65 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from cluefin_cli.domains.models import DisclosureHeadline, FinancialMetric, NewsHeadline, StatementSnapshot
+from cluefin_cli.main import cli
+
+
+@patch("cluefin_cli.commands.statements.StatementsService")
+def test_statements_command_json_uses_service(mock_service_cls: MagicMock) -> None:
+    service = MagicMock()
+    service.fetch.return_value = [
+        StatementSnapshot(
+            stock_code="005930",
+            source="dart",
+            company_name="Samsung Electronics",
+            accounts=[FinancialMetric(name="Revenue", value="1000")],
+        )
+    ]
+    mock_service_cls.return_value = service
+
+    result = CliRunner().invoke(cli, ["statements", "005930", "--year", "2024", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["command"] == "statements"
+    assert payload["data"]["items"][0]["accounts"][0]["name"] == "Revenue"
+    service.fetch.assert_called_once()
+
+
+@patch("cluefin_cli.commands.statements.StatementsService")
+def test_statements_command_json_error_envelope(mock_service_cls: MagicMock) -> None:
+    service = MagicMock()
+    service.fetch.side_effect = ValueError("missing credentials")
+    mock_service_cls.return_value = service
+
+    result = CliRunner().invoke(cli, ["statements", "005930", "--json"])
+
+    assert result.exit_code == 1
+    payload = json.loads(result.output)
+    assert payload["ok"] is False
+    assert payload["error"]["type"] == "ValueError"
+    assert payload["error"]["message"] == "missing credentials"
+
+
+@patch("cluefin_cli.commands.news.NewsService")
+def test_news_command_json_uses_service(mock_service_cls: MagicMock) -> None:
+    service = MagicMock()
+    service.fetch.return_value = {
+        "news": [NewsHeadline(source="kis", title="실적 발표", published_at="20260519090000")],
+        "disclosures": [DisclosureHeadline(source="dart", report_name="사업보고서", rcept_no="20260519000123")],
+    }
+    mock_service_cls.return_value = service
+
+    result = CliRunner().invoke(cli, ["news", "005930", "--source", "all", "--query", "실적", "--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["command"] == "news"
+    assert payload["data"]["news"][0]["title"] == "실적 발표"
+    assert payload["data"]["disclosures"][0]["report_name"] == "사업보고서"
+    service.fetch.assert_called_once()

--- a/apps/cluefin-cli/tests/unit/domains/test_chart_trading_flow_providers.py
+++ b/apps/cluefin-cli/tests/unit/domains/test_chart_trading_flow_providers.py
@@ -1,0 +1,114 @@
+from types import SimpleNamespace
+
+from cluefin_cli.domains.providers.kis import KisProvider
+from cluefin_cli.domains.providers.kiwoom import KiwoomProvider
+
+
+class Response:
+    def __init__(self, body: object):
+        self.body = body
+
+
+def test_kiwoom_provider_normalizes_daily_ohlcv() -> None:
+    provider = KiwoomProvider(client_factory=lambda broker: object())
+    provider._client = SimpleNamespace(
+        chart=SimpleNamespace(
+            get_stock_daily=lambda **_: Response(
+                SimpleNamespace(
+                    stk_dt_pole_chart_qry=[
+                        SimpleNamespace(
+                            dt="20250102",
+                            open_pric="-70000",
+                            high_pric="71000",
+                            low_pric="69000",
+                            cur_prc="-70500",
+                            trde_qty="1,000",
+                        )
+                    ]
+                )
+            )
+        )
+    )
+
+    series = provider.fetch_ohlcv(stock_code="005930", interval="daily", days=10)
+
+    assert series.source == "kiwoom"
+    assert series.points[0].timestamp == "20250102"
+    assert series.points[0].open == 70000
+    assert series.points[0].close == 70500
+    assert series.points[0].volume == 1000
+
+
+def test_kis_provider_normalizes_daily_ohlcv() -> None:
+    provider = KisProvider(client_factory=lambda broker: object())
+    provider._client = SimpleNamespace(
+        domestic_basic_quote=SimpleNamespace(
+            get_stock_period_quote=lambda *_: Response(
+                SimpleNamespace(
+                    output2=[
+                        SimpleNamespace(
+                            stck_bsop_date="20250102",
+                            stck_oprc="70000",
+                            stck_hgpr="71000",
+                            stck_lwpr="69000",
+                            stck_clpr="70500",
+                            acml_vol="1000",
+                        )
+                    ]
+                )
+            )
+        )
+    )
+
+    series = provider.fetch_ohlcv(stock_code="005930", interval="daily", days=10)
+
+    assert series.source == "kis"
+    assert series.points[0].timestamp == "20250102"
+    assert series.points[0].close == 70500
+
+
+def test_kiwoom_provider_normalizes_trading_flow_empty_case() -> None:
+    provider = KiwoomProvider(client_factory=lambda broker: object())
+    provider._client = SimpleNamespace(
+        chart=SimpleNamespace(
+            get_individual_stock_institutional_chart=lambda **_: Response(SimpleNamespace(stk_invsr_orgn_chart=[]))
+        )
+    )
+
+    snapshot = provider.fetch_trading_flow(stock_code="005930", start_date="20240101", end_date="20241231")
+
+    assert snapshot.rows == []
+    assert snapshot.totals == {}
+
+
+def test_kis_provider_normalizes_trading_flow() -> None:
+    provider = KisProvider(client_factory=lambda broker: object())
+    provider._client = SimpleNamespace(
+        domestic_market_analysis=SimpleNamespace(
+            get_investor_trading_trend_by_stock_daily=lambda *_: Response(
+                SimpleNamespace(
+                    output2=[
+                        SimpleNamespace(
+                            stck_bsop_date="20241231",
+                            prsn_ntby_qty="10",
+                            frgn_ntby_qty="-3",
+                            orgn_ntby_qty="2",
+                            scrt_ntby_qty="",
+                            ivtr_ntby_qty="",
+                            pe_fund_ntby_vol="",
+                            bank_ntby_qty="",
+                            insu_ntby_qty="",
+                            fund_ntby_qty="",
+                            etc_ntby_qty="",
+                        )
+                    ]
+                )
+            )
+        )
+    )
+
+    snapshot = provider.fetch_trading_flow(stock_code="005930", start_date="20240101", end_date="20241231")
+
+    assert snapshot.rows[0]["foreign"] == -3
+    assert snapshot.totals["individual"] == 10
+    assert snapshot.totals["institution"] == 2

--- a/apps/cluefin-cli/tests/unit/domains/test_chart_trading_flow_services.py
+++ b/apps/cluefin-cli/tests/unit/domains/test_chart_trading_flow_services.py
@@ -1,0 +1,89 @@
+from datetime import date, timedelta
+
+import pytest
+
+from cluefin_cli.domains.chart import ChartService, calculate_indicators
+from cluefin_cli.domains.models import OhlcvPoint, OhlcvSeries, TradingFlowSnapshot
+from cluefin_cli.domains.trading_flow import TradingFlowService, resolve_dates
+
+
+class FailingChartProvider:
+    def fetch_ohlcv(self, **_: object) -> OhlcvSeries:
+        raise ValueError("missing credentials")
+
+
+class FakeChartProvider:
+    def __init__(self, source: str):
+        self.source = source
+
+    def fetch_ohlcv(self, *, stock_code: str, interval: str, days: int) -> OhlcvSeries:
+        return OhlcvSeries(
+            stock_code=stock_code,
+            source=self.source,
+            interval=interval,
+            points=[
+                OhlcvPoint(timestamp=f"202501{i:02d}", open=float(i), high=float(i), low=float(i), close=float(i))
+                for i in range(1, min(days, 60) + 1)
+            ],
+        )
+
+
+class FakeFlowProvider:
+    def __init__(self, source: str):
+        self.source = source
+
+    def fetch_trading_flow(self, *, stock_code: str, start_date: str, end_date: str) -> TradingFlowSnapshot:
+        return TradingFlowSnapshot(
+            stock_code=stock_code,
+            source=self.source,
+            start_date=start_date,
+            end_date=end_date,
+            rows=[{"date": end_date, "foreign": 1.0}],
+            totals={"foreign": 1.0},
+        )
+
+
+def test_chart_service_falls_back_to_kis_and_adds_indicators() -> None:
+    service = ChartService(kiwoom_provider=FailingChartProvider(), kis_provider=FakeChartProvider("kis"))
+
+    series = service.fetch(stock_code="005930", source="auto", indicators=True)
+
+    assert series.source == "kis"
+    assert {item.name for item in series.indicators} >= {"sma_20", "rsi_14", "macd"}
+
+
+def test_calculate_indicators_returns_json_safe_none_for_nan() -> None:
+    series = OhlcvSeries(
+        stock_code="005930",
+        source="kiwoom",
+        interval="daily",
+        points=[OhlcvPoint(timestamp=f"202501{i:02d}", close=float(i)) for i in range(1, 31)],
+    )
+
+    indicators = calculate_indicators(series)
+
+    sma_20 = next(item for item in indicators if item.name == "sma_20")
+    assert sma_20.values[0] is None
+    assert sma_20.latest is not None
+
+
+def test_resolve_dates_defaults_to_recent_year() -> None:
+    start, end = resolve_dates(start_date=None, end_date=None)
+
+    expected_end = date.today()
+    expected_start = expected_end - timedelta(days=365)
+    assert end == expected_end.strftime("%Y%m%d")
+    assert start == expected_start.strftime("%Y%m%d")
+
+
+def test_resolve_dates_rejects_invalid_format() -> None:
+    with pytest.raises(ValueError, match="YYYYMMDD"):
+        resolve_dates(start_date="2025-01-01", end_date=None)
+
+
+def test_trading_flow_service_all_sources() -> None:
+    service = TradingFlowService(kiwoom_provider=FakeFlowProvider("kiwoom"), kis_provider=FakeFlowProvider("kis"))
+
+    snapshots = service.fetch(stock_code="005930", source="all", start_date="20240101", end_date="20241231")
+
+    assert [item.source for item in snapshots] == ["kiwoom", "kis"]

--- a/apps/cluefin-cli/tests/unit/domains/test_market_service_providers.py
+++ b/apps/cluefin-cli/tests/unit/domains/test_market_service_providers.py
@@ -1,0 +1,100 @@
+from types import SimpleNamespace
+
+from cluefin_cli.domains.market import MarketService
+from cluefin_cli.domains.models import MarketRankItem
+from cluefin_cli.domains.providers.kis import KisProvider
+from cluefin_cli.domains.providers.kiwoom import KiwoomProvider
+
+
+class Response:
+    def __init__(self, body: object):
+        self.body = body
+
+
+class FakeMarketProvider:
+    def __init__(self, source: str):
+        self.source = source
+
+    def fetch_market_volume(self, *, limit: int) -> list[MarketRankItem]:
+        return [MarketRankItem(source=self.source, category="volume", rank=1, stock_code="005930", value=limit)]
+
+    def fetch_market_ranking(self, *, limit: int) -> list[MarketRankItem]:
+        return [MarketRankItem(source=self.source, category="ranking", rank=1, stock_code="005930", value=limit)]
+
+    def fetch_market_theme(self, *, limit: int) -> list[MarketRankItem]:
+        return [MarketRankItem(source=self.source, category="theme", rank=1, stock_name="반도체", value=limit)]
+
+    def fetch_market_sector(self, *, limit: int) -> list[MarketRankItem]:
+        return [MarketRankItem(source=self.source, category="sector", rank=1, stock_name="전기전자", value=limit)]
+
+
+def test_market_service_uses_default_sources() -> None:
+    service = MarketService(kiwoom_provider=FakeMarketProvider("kiwoom"), kis_provider=FakeMarketProvider("kis"))
+
+    assert service.fetch(category="volume")[0].source == "kis"
+    assert service.fetch(category="ranking")[0].source == "kis"
+    assert service.fetch(category="sector")[0].source == "kis"
+    assert service.fetch(category="theme")[0].source == "kiwoom"
+
+
+def test_market_service_all_combines_available_providers() -> None:
+    service = MarketService(kiwoom_provider=FakeMarketProvider("kiwoom"), kis_provider=FakeMarketProvider("kis"))
+
+    items = service.fetch(category="volume", source="all", limit=3)
+
+    assert [item.source for item in items] == ["kis", "kiwoom"]
+
+
+def test_kis_provider_normalizes_market_volume() -> None:
+    provider = KisProvider(client_factory=lambda broker: object())
+    provider._client = SimpleNamespace(
+        domestic_ranking_analysis=SimpleNamespace(
+            get_trading_volume_rank=lambda *_: Response(
+                SimpleNamespace(
+                    output=[
+                        SimpleNamespace(
+                            data_rank="1",
+                            mksc_shrn_iscd="005930",
+                            hts_kor_isnm="삼성전자",
+                            acml_vol="1000",
+                            prdy_ctrt="1.2",
+                        )
+                    ]
+                )
+            )
+        )
+    )
+
+    items = provider.fetch_market_volume(limit=1)
+
+    assert items[0].source == "kis"
+    assert items[0].rank == 1
+    assert items[0].stock_code == "005930"
+    assert items[0].value == "1000"
+
+
+def test_kiwoom_provider_normalizes_market_theme() -> None:
+    provider = KiwoomProvider(client_factory=lambda broker: object())
+    provider._client = SimpleNamespace(
+        theme=SimpleNamespace(
+            get_theme_group=lambda *_: Response(
+                SimpleNamespace(
+                    thema_grp=[
+                        SimpleNamespace(
+                            thema_grp_cd="100",
+                            thema_nm="반도체",
+                            dt_prft_rt="3.1",
+                            flu_rt="1.5",
+                        )
+                    ]
+                )
+            )
+        )
+    )
+
+    items = provider.fetch_market_theme(limit=1)
+
+    assert items[0].source == "kiwoom"
+    assert items[0].stock_code == "100"
+    assert items[0].stock_name == "반도체"
+    assert items[0].change_rate == "1.5"

--- a/apps/cluefin-cli/tests/unit/domains/test_models.py
+++ b/apps/cluefin-cli/tests/unit/domains/test_models.py
@@ -1,0 +1,29 @@
+import json
+
+from cluefin_cli.domains.models import (
+    FinancialMetric,
+    OhlcvPoint,
+    OhlcvSeries,
+    StatementSnapshot,
+)
+from cluefin_cli.output import dump_json
+
+
+def test_domain_dtos_are_json_serializable() -> None:
+    snapshot = StatementSnapshot(
+        stock_code="005930",
+        source="dart",
+        corp_code="00126380",
+        accounts=[FinancialMetric(name="Revenue", label="매출액", value="1000", unit="KRW")],
+    )
+    series = OhlcvSeries(
+        stock_code="005930",
+        source="kiwoom",
+        interval="daily",
+        points=[OhlcvPoint(timestamp="20260519", open=70000, high=71000, low=69000, close=70500, volume=12345)],
+    )
+
+    payload = json.loads(dump_json({"statement": snapshot, "series": series}))
+
+    assert payload["statement"]["accounts"][0]["name"] == "Revenue"
+    assert payload["series"]["points"][0]["close"] == 70500

--- a/apps/cluefin-cli/tests/unit/domains/test_providers.py
+++ b/apps/cluefin-cli/tests/unit/domains/test_providers.py
@@ -1,0 +1,27 @@
+from cluefin_cli.domains.providers import DartProvider, KisProvider, KiwoomProvider
+
+
+class FakeFactory:
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    def create(self, broker: str):
+        self.calls.append(broker)
+        return {"broker": broker}
+
+
+def test_providers_create_clients_through_injected_factory() -> None:
+    factory = FakeFactory()
+
+    assert DartProvider(factory).client == {"broker": "dart"}
+    assert KisProvider(factory).client == {"broker": "kis"}
+    assert KiwoomProvider(factory).client == {"broker": "kiwoom"}
+    assert factory.calls == ["dart", "kis", "kiwoom"]
+
+
+def test_provider_client_is_cached() -> None:
+    factory = FakeFactory()
+    provider = KisProvider(factory)
+
+    assert provider.client is provider.client
+    assert factory.calls == ["kis"]

--- a/apps/cluefin-cli/tests/unit/domains/test_statement_news_providers.py
+++ b/apps/cluefin-cli/tests/unit/domains/test_statement_news_providers.py
@@ -1,0 +1,62 @@
+from types import SimpleNamespace
+
+from cluefin_cli.domains.providers.dart import DartProvider
+from cluefin_cli.domains.providers.kis import KisProvider
+
+
+class FakeFactory:
+    def __init__(self, client) -> None:
+        self.client = client
+
+    def create(self, broker: str):
+        return self.client
+
+
+def test_kis_provider_normalizes_news_headlines() -> None:
+    item = SimpleNamespace(
+        hts_pbnt_titl_cntt="시장 뉴스",
+        data_dt="20260519",
+        data_tm="090000",
+        iscd1="005930",
+        iscd2="",
+        iscd3="",
+        iscd4="",
+        iscd5="",
+        dorg="KIS",
+        cntt_usiq_srno="1",
+    )
+    client = SimpleNamespace(
+        domestic_issue_other=SimpleNamespace(
+            get_market_announcement_schedule=lambda *args: SimpleNamespace(body=SimpleNamespace(output=[item]))
+        )
+    )
+
+    headlines = KisProvider(FakeFactory(client)).fetch_news(stock_code="005930", days=7, query="시장")
+
+    assert headlines[0].source == "kis"
+    assert headlines[0].title == "시장 뉴스"
+    assert headlines[0].published_at == "20260519090000"
+    assert headlines[0].stock_codes == ["005930"]
+
+
+def test_dart_provider_normalizes_disclosure_headlines() -> None:
+    corp_item = SimpleNamespace(stock_code="005930", corp_code="00126380")
+    disclosure_item = SimpleNamespace(
+        report_nm="사업보고서",
+        rcept_no="20260519000123",
+        rcept_dt="20260519",
+        corp_code="00126380",
+        corp_name="삼성전자",
+        stock_code="005930",
+    )
+    public_disclosure = SimpleNamespace(
+        corp_code=lambda: SimpleNamespace(list=[corp_item]),
+        public_disclosure_search=lambda **kwargs: SimpleNamespace(result=SimpleNamespace(list=[disclosure_item])),
+    )
+    client = SimpleNamespace(public_disclosure=public_disclosure)
+
+    disclosures = DartProvider(FakeFactory(client)).fetch_disclosures(stock_code="005930", days=7, query="사업")
+
+    assert disclosures[0].source == "dart"
+    assert disclosures[0].report_name == "사업보고서"
+    assert disclosures[0].rcept_no == "20260519000123"

--- a/apps/cluefin-cli/tests/unit/domains/test_statement_news_services.py
+++ b/apps/cluefin-cli/tests/unit/domains/test_statement_news_services.py
@@ -1,0 +1,49 @@
+from cluefin_cli.domains.models import DisclosureHeadline, NewsHeadline, StatementSnapshot
+from cluefin_cli.domains.news import NewsService
+from cluefin_cli.domains.statements import StatementsService
+
+
+class FakeDartProvider:
+    def __init__(self) -> None:
+        self.statement_calls = []
+
+    def fetch_statement_snapshot(self, **kwargs):
+        self.statement_calls.append(kwargs)
+        return StatementSnapshot(stock_code=kwargs["stock_code"], source="dart")
+
+    def fetch_disclosures(self, **kwargs):
+        return [DisclosureHeadline(source="dart", report_name=kwargs["query"] or "공시")]
+
+
+class FakeKisProvider:
+    def __init__(self) -> None:
+        self.statement_calls = []
+
+    def fetch_statement_snapshot(self, **kwargs):
+        self.statement_calls.append(kwargs)
+        return StatementSnapshot(stock_code=kwargs["stock_code"], source="kis")
+
+    def fetch_news(self, **kwargs):
+        return [NewsHeadline(source="kis", title=kwargs["query"] or "뉴스")]
+
+
+def test_statements_service_fetches_dart_and_kis_for_all_source() -> None:
+    dart = FakeDartProvider()
+    kis = FakeKisProvider()
+    service = StatementsService(dart_provider=dart, kis_provider=kis)
+
+    snapshots = service.fetch(stock_code="005930", source="all", year="2024", report="q1", include_xbrl=True)
+
+    assert [snapshot.source for snapshot in snapshots] == ["dart", "kis"]
+    assert dart.statement_calls[0]["report_code"] == "11013"
+    assert dart.statement_calls[0]["include_xbrl"] is True
+    assert kis.statement_calls[0]["div_cls_code"] == "1"
+
+
+def test_news_service_combines_sources_for_all_source() -> None:
+    service = NewsService(dart_provider=FakeDartProvider(), kis_provider=FakeKisProvider())
+
+    data = service.fetch(stock_code="005930", source="all", days=3, query="배당")
+
+    assert data["news"][0].title == "배당"
+    assert data["disclosures"][0].report_name == "배당"

--- a/apps/cluefin-cli/tests/unit/test_deleted_cli_imports.py
+++ b/apps/cluefin-cli/tests/unit/test_deleted_cli_imports.py
@@ -1,0 +1,11 @@
+from pathlib import Path
+
+
+def test_cluefin_cli_does_not_import_deleted_cli_packages() -> None:
+    source_root = Path("apps/cluefin-cli/src/cluefin_cli")
+    forbidden = ("cluefin_openapi_cli", "cluefin_ta_cli")
+
+    for path in source_root.rglob("*.py"):
+        text = path.read_text(encoding="utf-8")
+        for name in forbidden:
+            assert name not in text, f"{path} must not import or reference {name}"

--- a/apps/cluefin-cli/tests/unit/test_main.py
+++ b/apps/cluefin-cli/tests/unit/test_main.py
@@ -1,0 +1,26 @@
+import json
+
+from click.testing import CliRunner
+
+from cluefin_cli.main import cli
+
+
+def test_root_json_emits_parseable_envelope_without_banner() -> None:
+    result = CliRunner().invoke(cli, ["--json"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["ok"] is True
+    assert payload["command"] == "root"
+    assert payload["data"]["app"] == "cluefin-cli"
+    assert "Cluefin CLI - Stock Analysis Tool" not in result.output
+
+
+def test_legacy_commands_are_marked_deprecated_in_help() -> None:
+    runner = CliRunner()
+
+    for command in ["ta", "fa", "xbrl"]:
+        result = runner.invoke(cli, [command, "--help"])
+
+        assert result.exit_code == 0
+        assert "DEPRECATED" in result.output

--- a/apps/cluefin-cli/tests/unit/test_output.py
+++ b/apps/cluefin-cli/tests/unit/test_output.py
@@ -1,0 +1,39 @@
+from dataclasses import dataclass
+from datetime import date, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+from cluefin_cli.output import dump_json, error_envelope, success_envelope, to_jsonable
+
+
+@dataclass(slots=True)
+class ExampleData:
+    amount: Decimal
+    as_of: date
+
+
+class ExampleModel(BaseModel):
+    created_at: datetime
+
+
+def test_to_jsonable_handles_project_value_types() -> None:
+    payload = {
+        "data": ExampleData(amount=Decimal("123.45"), as_of=date(2026, 5, 19)),
+        "model": ExampleModel(created_at=datetime(2026, 5, 19, 12, 30)),
+        "items": {3, 1, 2},
+    }
+
+    assert to_jsonable(payload) == {
+        "data": {"amount": "123.45", "as_of": "2026-05-19"},
+        "model": {"created_at": "2026-05-19T12:30:00"},
+        "items": [1, 2, 3],
+    }
+
+
+def test_envelopes_are_json_serializable() -> None:
+    success = success_envelope(command="chart", source="kiwoom", params={"stock_code": "005930"}, data={})
+    failure = error_envelope(command="chart", error_type="ValidationError", message="invalid stock code")
+
+    assert '"ok": true' in dump_json(success)
+    assert '"ok": false' in dump_json(failure)


### PR DESCRIPTION
## Summary
- cluefin-cli에서 statements, chart, news, trading-flow, market 도메인 명령을 JSON 중심으로 조회할 수 있게 추가했습니다.
- AI Agent가 CLI 사용법을 파악할 수 있도록 describe --json discovery 명령을 추가했습니다.
- 기존 ta/fa/xbrl 명령은 유지하되 deprecated help 문구로 분리했습니다.

## Related Issue / Context
- N/A

## What Changed
- 공통 JSON envelope와 dataclass/Pydantic/날짜/Decimal 직렬화 지원을 추가했습니다.
- Kiwoom/KIS/DART provider adapter와 도메인 DTO, 서비스 계층을 추가했습니다.
- statements/news/chart/trading-flow/market 명령과 Rich/JSON 출력을 구현했습니다.
- cluefin-openapi-cli, cluefin-ta-cli import 금지 테스트와 provider/service/command 단위 테스트를 추가했습니다.
- README를 신규 도메인 CLI와 --json 예시 중심으로 정리했습니다.

## Verification
- `uv run pytest apps/cluefin-cli/tests -v`
- Result: pass, 55 passed
- `uv run ruff check apps/cluefin-cli`
- Result: pass
- `uv run ruff format apps/cluefin-cli --check`
- Result: pass, 59 files already formatted

## Breaking Changes / Migration Notes
- None
- 기존 ta/fa/xbrl 명령은 제거하지 않고 deprecated help 문구만 추가했습니다.