### PR TITLE
feat: Agent CLI discovery 강화

### DIFF
--- a/apps/cluefin-openapi-cli/README.md
+++ b/apps/cluefin-openapi-cli/README.md
@@ -29,30 +29,51 @@ CLI는 현재 작업 디렉터리의 `.env`를 자동으로 읽습니다. 같은
 
 ### 1. Discovery
 
-전체 command 또는 broker/category별 command를 탐색합니다.
+전체 command, broker/category, domain/tag별 command를 탐색합니다.
 
 ```bash
 uv run cluefin-openapi-cli list --json
 uv run cluefin-openapi-cli list --broker kis --category stock --json
+uv run cluefin-openapi-cli list --domain chart --json
+uv run cluefin-openapi-cli list --tag ohlcv --json
+uv run cluefin-openapi-cli domains --json
+uv run cluefin-openapi-cli tags --json
 ```
+
+`category`는 provider SDK 구조이고, `domain`은 Agent 업무 의도입니다. 예를 들어 `kis chart period`는 category가 `chart`이고 domain도 `chart`지만, 투자자 수급성 API는 provider별 category가 달라도 `trading-flow` domain으로 함께 찾을 수 있습니다.
 
 ### 2. Describe
 
-단일 command의 설명, 입력 schema, required 필드, help payload를 확인합니다.
+단일 command의 설명, 입력 schema, required 필드, domain/tag, examples, agent_notes, help payload를 확인합니다.
 
 ```bash
 uv run cluefin-openapi-cli describe kis stock current-price --json
 uv run cluefin-openapi-cli kis stock current-price --help --json
 ```
 
-### 3. Command Path
+Agent는 `describe --json`의 `examples[0].command`를 실행 skeleton으로 사용하고, `agent_notes`를 provider별 주의사항으로 참고할 수 있습니다.
+
+### 3. Workflow Recipes
+
+대표 업무 흐름은 recipe metadata로 탐색합니다. Recipe는 실행기가 아니라 여러 command를 조합하기 위한 JSON guide입니다.
+
+```bash
+uv run cluefin-openapi-cli recipes --json
+uv run cluefin-openapi-cli recipe stock-research --json
+uv run cluefin-openapi-cli recipe technical-analysis --json
+uv run cluefin-openapi-cli recipe market-scan --json
+uv run cluefin-openapi-cli recipe corporate-actions --json
+uv run cluefin-openapi-cli recipe disclosure-monitoring --json
+```
+
+### 4. Command Path
 
 broker-first path 규칙은 아래와 같습니다.
 
 - `kis <category> <name>`
 - `kiwoom <category> <name>`
 - `dart <name>`
-- `list`, `describe`는 meta command
+- `list`, `describe`, `domains`, `tags`, `recipes`, `recipe`는 meta command
 
 예시:
 
@@ -101,6 +122,16 @@ uv run cluefin-openapi-cli kis stock current-price --help --json
 
 ## 예시
 
+Agent discovery:
+
+```bash
+uv run cluefin-openapi-cli domains --json
+uv run cluefin-openapi-cli tags --json
+uv run cluefin-openapi-cli list --domain trading-flow --json
+uv run cluefin-openapi-cli list --tag dividend --json
+uv run cluefin-openapi-cli recipe stock-research --json
+```
+
 KIS:
 
 ```bash
@@ -126,6 +157,8 @@ uv run cluefin-openapi-cli dart company-overview --corp-code 00126380 --json
 - CLI 내부 registry가 command metadata와 executor set을 직접 관리
 - 실제 broker client 생성은 `cluefin_openapi.client_factory`를 사용
 - KIS, Kiwoom은 토큰 캐시를 사용하고, DART는 stateless client로 동작
+- Agent integration은 이 CLI의 JSON discovery를 직접 사용합니다
+- `cluefin-cli` 삭제 또는 정리는 별도 후속 작업이며, 이 CLI는 wrapper 없이 독립적으로 사용됩니다
 
 ## 주의사항
 

--- a/apps/cluefin-openapi-cli/README.md
+++ b/apps/cluefin-openapi-cli/README.md
@@ -42,6 +42,28 @@ uv run cluefin-openapi-cli tags --json
 
 `category`는 provider SDK 구조이고, `domain`은 Agent 업무 의도입니다. 예를 들어 `kis chart period`는 category가 `chart`이고 domain도 `chart`지만, 투자자 수급성 API는 provider별 category가 달라도 `trading-flow` domain으로 함께 찾을 수 있습니다.
 
+Agent용 분류 기준:
+
+- `domains`: 업무 영역입니다. 예: `chart`, `statements`, `trading-flow`.
+- `tags`: 세부 기능 또는 데이터 특성입니다. 예: `ohlcv`, `dividend`, `program-trading`.
+- `recipes`: 여러 command를 조합하는 workflow guide입니다. Recipe는 command 실행기가 아니라 탐색 순서와 조합 의도를 설명합니다.
+
+`domains --json`, `tags --json`는 `name`, `command_count`뿐 아니라 `description`, `when_to_use`, `avoid_when`, `related_domains`, `related_tags`, `example_filter`를 포함합니다. Agent는 `example_filter`를 그대로 다음 탐색 명령으로 사용할 수 있습니다.
+
+예시 taxonomy 응답:
+
+```json
+{
+  "name": "chart",
+  "description": "Price, volume, and OHLCV time-series lookup commands.",
+  "when_to_use": "Use before technical analysis, price trend review, or volume analysis.",
+  "avoid_when": "Use cluefin-ta-cli technical-indicator commands when OHLCV arrays are already available.",
+  "related_tags": ["ohlcv", "daily", "minute", "tick"],
+  "example_filter": "uv run cluefin-openapi-cli list --domain chart --json",
+  "command_count": 8
+}
+```
+
 ### 2. Describe
 
 단일 command의 설명, 입력 schema, required 필드, domain/tag, examples, agent_notes, help payload를 확인합니다.

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/main.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/main.py
@@ -73,14 +73,34 @@ def _emit_error(exc: CliError, *, force_json: bool) -> None:
     _write_stderr(exc.message)
 
 
-def _list_payload(broker: str | None = None, category: str | None = None) -> dict[str, Any]:
+def _list_payload(
+    broker: str | None = None,
+    category: str | None = None,
+    domain: str | None = None,
+    tag: str | None = None,
+) -> dict[str, Any]:
     registry = get_registry()
-    commands = registry.list_commands(broker=broker, category=category)
+    commands = registry.list_commands(broker=broker, category=category, domain=domain, tag=tag)
     return {
         "broker": broker,
         "category": category,
+        "domain": domain,
+        "tag": tag,
         "count": len(commands),
         "commands": [to_jsonable(_command_summary(command)) for command in commands],
+    }
+
+
+def _discovery_payload(kind: str) -> dict[str, Any]:
+    registry = get_registry()
+    commands = registry.list_commands()
+    values = sorted({value for command in commands for value in getattr(command, kind)})
+    return {
+        kind: [
+            {"name": value, "command_count": sum(value in getattr(command, kind) for command in commands)}
+            for value in values
+        ],
+        "count": len(values),
     }
 
 
@@ -211,13 +231,16 @@ def _run_root(argv: list[str]) -> None:
         "app": "cluefin-openapi-cli",
         "interactive": stdout_is_tty(),
         "brokers": list(registry.iter_brokers()),
-        "commands": ["list", "describe"],
+        "commands": ["list", "describe", "domains", "tags"],
     }
     if bool(options.get("help", False)):
         payload["usage"] = [
             "cluefin-openapi-cli list [--broker BROKER] [--category CATEGORY] [--json]",
+            "cluefin-openapi-cli list [--domain DOMAIN] [--tag TAG] [--json]",
             "cluefin-openapi-cli describe <broker> <category> <name> [--json]",
             "cluefin-openapi-cli describe dart <name> [--json]",
+            "cluefin-openapi-cli domains [--json]",
+            "cluefin-openapi-cli tags [--json]",
             "cluefin-openapi-cli <broker> <category> <name> [--params-json JSON] [schema options] [--json]",
             "cluefin-openapi-cli dart <name> [--params-json JSON] [schema options] [--json]",
         ]
@@ -231,14 +254,32 @@ def _run_list(argv: list[str]) -> None:
 
     broker = options.get("broker")
     category = options.get("category")
+    domain = options.get("domain")
+    tag = options.get("tag")
     force_json = bool(options.get("json", False))
     render_output(
         _list_payload(
             broker=broker if isinstance(broker, str) else None,
             category=category if isinstance(category, str) else None,
+            domain=domain if isinstance(domain, str) else None,
+            tag=tag if isinstance(tag, str) else None,
         ),
         force_json=force_json,
     )
+
+
+def _run_domains(argv: list[str]) -> None:
+    positional, options = _parse_named_options(argv)
+    if positional:
+        raise CliError("`domains` does not accept positional arguments.", exit_code=2)
+    render_output(_discovery_payload("domains"), force_json=bool(options.get("json", False)))
+
+
+def _run_tags(argv: list[str]) -> None:
+    positional, options = _parse_named_options(argv)
+    if positional:
+        raise CliError("`tags` does not accept positional arguments.", exit_code=2)
+    render_output(_discovery_payload("tags"), force_json=bool(options.get("json", False)))
 
 
 def _run_describe(argv: list[str]) -> None:
@@ -348,6 +389,12 @@ def dispatch(argv: list[str] | None = None) -> None:
         return
     if command == "describe":
         _run_describe(args[1:])
+        return
+    if command == "domains":
+        _run_domains(args[1:])
+        return
+    if command == "tags":
+        _run_tags(args[1:])
         return
 
     _run_dynamic(args)

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/main.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/main.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from cluefin_openapi_cli.output import render_output, stdout_is_tty, to_jsonable
+from cluefin_openapi_cli.recipes import get_recipe, recipe_summaries
 from cluefin_openapi_cli.registry import CommandSpec, get_registry
 
 
@@ -231,7 +232,7 @@ def _run_root(argv: list[str]) -> None:
         "app": "cluefin-openapi-cli",
         "interactive": stdout_is_tty(),
         "brokers": list(registry.iter_brokers()),
-        "commands": ["list", "describe", "domains", "tags"],
+        "commands": ["list", "describe", "domains", "tags", "recipes", "recipe"],
     }
     if bool(options.get("help", False)):
         payload["usage"] = [
@@ -241,6 +242,8 @@ def _run_root(argv: list[str]) -> None:
             "cluefin-openapi-cli describe dart <name> [--json]",
             "cluefin-openapi-cli domains [--json]",
             "cluefin-openapi-cli tags [--json]",
+            "cluefin-openapi-cli recipes [--json]",
+            "cluefin-openapi-cli recipe <name> [--json]",
             "cluefin-openapi-cli <broker> <category> <name> [--params-json JSON] [schema options] [--json]",
             "cluefin-openapi-cli dart <name> [--params-json JSON] [schema options] [--json]",
         ]
@@ -280,6 +283,26 @@ def _run_tags(argv: list[str]) -> None:
     if positional:
         raise CliError("`tags` does not accept positional arguments.", exit_code=2)
     render_output(_discovery_payload("tags"), force_json=bool(options.get("json", False)))
+
+
+def _run_recipes(argv: list[str]) -> None:
+    positional, options = _parse_named_options(argv)
+    if positional:
+        raise CliError("`recipes` does not accept positional arguments.", exit_code=2)
+    summaries = recipe_summaries()
+    render_output({"recipes": summaries, "count": len(summaries)}, force_json=bool(options.get("json", False)))
+
+
+def _run_recipe(argv: list[str]) -> None:
+    positional, options = _parse_named_options(argv)
+    if len(positional) != 1:
+        raise CliError("Usage: recipe <name>.", exit_code=2)
+
+    recipe = get_recipe(positional[0])
+    if recipe is None:
+        raise CliError(f"Unknown recipe `{positional[0]}`.", exit_code=2)
+
+    render_output({"recipe": to_jsonable(recipe)}, force_json=bool(options.get("json", False)))
 
 
 def _run_describe(argv: list[str]) -> None:
@@ -395,6 +418,12 @@ def dispatch(argv: list[str] | None = None) -> None:
         return
     if command == "tags":
         _run_tags(args[1:])
+        return
+    if command == "recipes":
+        _run_recipes(args[1:])
+        return
+    if command == "recipe":
+        _run_recipe(args[1:])
         return
 
     _run_dynamic(args)

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/main.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/main.py
@@ -7,6 +7,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from typing import Any
 
+from cluefin_openapi_cli.metadata import build_taxonomy_entry
 from cluefin_openapi_cli.output import render_output, stdout_is_tty, to_jsonable
 from cluefin_openapi_cli.recipes import get_recipe, recipe_summaries
 from cluefin_openapi_cli.registry import CommandSpec, get_registry
@@ -98,7 +99,12 @@ def _discovery_payload(kind: str) -> dict[str, Any]:
     values = sorted({value for command in commands for value in getattr(command, kind)})
     return {
         kind: [
-            {"name": value, "command_count": sum(value in getattr(command, kind) for command in commands)}
+            build_taxonomy_entry(
+                kind=kind,
+                name=value,
+                command_count=sum(value in getattr(command, kind) for command in commands),
+                app_name="cluefin-openapi-cli",
+            )
             for value in values
         ],
         "count": len(values),

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/main.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/main.py
@@ -36,6 +36,13 @@ def _command_summary(command: CommandSpec) -> dict[str, Any]:
         "description": command.description,
         "parameters": command.parameters,
         "returns": command.returns,
+        "domains": list(command.domains),
+        "tags": list(command.tags),
+        "use_cases": list(command.use_cases),
+        "examples": list(command.examples),
+        "agent_notes": command.agent_notes,
+        "required_credentials": list(command.required_credentials),
+        "side_effect": command.side_effect,
         "has_executor": command.executor is not None,
     }
 

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class CommandMetadata:
+    """Agent discovery metadata for one broker command."""
+
+    domains: tuple[str, ...]
+    tags: tuple[str, ...]
+    use_cases: tuple[str, ...] = ()
+    examples: tuple[dict[str, Any], ...] = ()
+    agent_notes: str | None = None
+    required_credentials: tuple[str, ...] = ()
+    side_effect: str = "read"
+
+
+_BROKER_CREDENTIALS: dict[str, tuple[str, ...]] = {
+    "dart": ("DART_AUTH_KEY",),
+    "kis": ("KIS_APP_KEY", "KIS_SECRET_KEY"),
+    "kiwoom": ("KIWOOM_APP_KEY", "KIWOOM_SECRET_KEY"),
+}
+
+_CATEGORY_DEFAULTS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
+    "analysis": (("trading-flow", "market"), ("foreign", "institution")),
+    "chart": (("chart",), ("ohlcv",)),
+    "dart": (("news", "statements"), ("disclosure",)),
+    "etf": (("etf", "market"), ("current-price",)),
+    "financial": (("statements",), ("financial-statement", "financial-ratio")),
+    "market": (("market",), ("market-calendar",)),
+    "program": (("trading-flow", "market"), ("program-trading",)),
+    "ranking": (("market",), ("ranking",)),
+    "schedule": (("corporate-actions", "market-calendar"), ("announcement",)),
+    "sector": (("sector", "market"), ("sector-index",)),
+    "stock": (("quote", "market"), ("current-price",)),
+    "theme": (("theme", "market"), ("theme-group",)),
+}
+
+_COMMAND_OVERRIDES: dict[tuple[str, str, str], tuple[tuple[str, ...], tuple[str, ...]]] = {
+    ("dart", "dart", "disclosure-search"): (("news", "statements"), ("disclosure",)),
+    ("dart", "dart", "company-overview"): (("statements",), ("disclosure", "shareholder")),
+    ("dart", "dart", "corp-code-lookup"): (("market",), ("disclosure",)),
+    ("dart", "dart", "major-shareholder"): (("statements",), ("shareholder", "disclosure")),
+    ("kis", "market", "announcement"): (("news", "market"), ("announcement", "disclosure")),
+    ("kis", "market", "holiday"): (("market-calendar", "market"), ("market-calendar",)),
+    ("kis", "market", "futures-business-day"): (("market-calendar", "market"), ("market-calendar",)),
+    ("kis", "schedule", "dividend"): (("corporate-actions",), ("dividend", "announcement")),
+    ("kiwoom", "theme", "group"): (("theme", "market"), ("theme-group",)),
+}
+
+_TAG_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("daily", ("daily",)),
+    ("minute", ("minute",)),
+    ("tick", ("tick",)),
+    ("current-price", ("current-price",)),
+    ("order-book", ("order-book",)),
+    ("conclusion", ("conclusion",)),
+    ("overtime", ("overtime",)),
+    ("balance-sheet", ("financial-statement",)),
+    ("income-statement", ("financial-statement",)),
+    ("ratio", ("financial-ratio",)),
+    ("profitability", ("financial-ratio",)),
+    ("stability", ("financial-ratio",)),
+    ("growth", ("financial-ratio",)),
+    ("dividend", ("dividend",)),
+    ("shareholder", ("shareholder",)),
+    ("foreign", ("foreign",)),
+    ("foreigner", ("foreign",)),
+    ("institution", ("institution",)),
+    ("investor", ("foreign", "institution")),
+    ("program", ("program-trading",)),
+    ("volume", ("volume-rank",)),
+    ("market-cap", ("market-cap",)),
+    ("market-value", ("market-cap",)),
+    ("short-selling", ("short-selling",)),
+    ("loan", ("short-selling",)),
+    ("credit", ("credit",)),
+    ("sector", ("sector-index",)),
+    ("industry", ("sector-index",)),
+    ("theme", ("theme-group",)),
+    ("ipo", ("ipo",)),
+    ("capital-increase", ("capital-increase",)),
+    ("capital-reduction", ("capital-reduction",)),
+    ("merger-split", ("merger-split",)),
+    ("shareholder-meeting", ("shareholder-meeting",)),
+)
+
+_DOMAIN_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("announcement", ("news",)),
+    ("disclosure", ("news",)),
+    ("financial", ("statements",)),
+    ("balance-sheet", ("statements",)),
+    ("income-statement", ("statements",)),
+    ("ratio", ("statements",)),
+    ("dividend", ("corporate-actions",)),
+    ("shareholder", ("statements",)),
+    ("foreign", ("trading-flow",)),
+    ("foreigner", ("trading-flow",)),
+    ("institution", ("trading-flow",)),
+    ("investor", ("trading-flow",)),
+    ("program", ("trading-flow",)),
+    ("sector", ("sector",)),
+    ("industry", ("sector",)),
+    ("theme", ("theme",)),
+    ("ipo", ("corporate-actions",)),
+    ("capital", ("corporate-actions",)),
+    ("merger", ("corporate-actions",)),
+    ("split", ("corporate-actions",)),
+    ("meeting", ("corporate-actions",)),
+)
+
+
+def _append_unique(values: list[str], new_values: tuple[str, ...]) -> None:
+    for value in new_values:
+        if value not in values:
+            values.append(value)
+
+
+def get_command_metadata(*, broker: str, category: str, name: str) -> CommandMetadata:
+    """Return domain/tag metadata for a generated CLI command."""
+
+    domains: list[str] = []
+    tags: list[str] = []
+
+    default_domains, default_tags = _CATEGORY_DEFAULTS.get(category, (("market",), ("ranking",)))
+    _append_unique(domains, default_domains)
+    _append_unique(tags, default_tags)
+
+    override = _COMMAND_OVERRIDES.get((broker, category, name))
+    if override is not None:
+        override_domains, override_tags = override
+        domains = []
+        tags = []
+        _append_unique(domains, override_domains)
+        _append_unique(tags, override_tags)
+
+    haystack = f"{broker}.{category}.{name}"
+    for keyword, keyword_domains in _DOMAIN_KEYWORDS:
+        if keyword in haystack:
+            _append_unique(domains, keyword_domains)
+    for keyword, keyword_tags in _TAG_KEYWORDS:
+        if keyword in haystack:
+            _append_unique(tags, keyword_tags)
+
+    return CommandMetadata(
+        domains=tuple(domains),
+        tags=tuple(tags),
+        required_credentials=_BROKER_CREDENTIALS.get(broker, ()),
+    )

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
@@ -18,11 +18,26 @@ class CommandMetadata:
     side_effect: str = "read"
 
 
+@dataclass(frozen=True, slots=True)
+class TaxonomyMetadata:
+    """Agent-facing explanation for one domain or tag."""
+
+    name: str
+    description: str
+    when_to_use: str
+    avoid_when: str | None = None
+    related_domains: tuple[str, ...] = ()
+    related_tags: tuple[str, ...] = ()
+
+
 _BROKER_CREDENTIALS: dict[str, tuple[str, ...]] = {
     "dart": ("DART_AUTH_KEY",),
     "kis": ("KIS_APP_KEY", "KIS_SECRET_KEY"),
     "kiwoom": ("KIWOOM_APP_KEY", "KIWOOM_SECRET_KEY"),
 }
+
+_DOMAIN_TAXONOMY: dict[str, TaxonomyMetadata] = {}
+_TAG_TAXONOMY: dict[str, TaxonomyMetadata] = {}
 
 _CATEGORY_DEFAULTS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     "analysis": (("trading-flow", "market"), ("foreign", "institution")),
@@ -117,6 +132,33 @@ def _append_unique(values: list[str], new_values: tuple[str, ...]) -> None:
     for value in new_values:
         if value not in values:
             values.append(value)
+
+
+def _generic_taxonomy(kind: str, name: str) -> TaxonomyMetadata:
+    label = "domain" if kind == "domains" else "tag"
+    return TaxonomyMetadata(
+        name=name,
+        description=f"Agent discovery {label} for `{name}` commands.",
+        when_to_use=f"Use when a task needs commands classified by `{name}`.",
+    )
+
+
+def build_taxonomy_entry(*, kind: str, name: str, command_count: int, app_name: str) -> dict[str, Any]:
+    """Build a JSON-safe taxonomy discovery entry."""
+
+    catalog = _DOMAIN_TAXONOMY if kind == "domains" else _TAG_TAXONOMY
+    item = catalog.get(name, _generic_taxonomy(kind, name))
+    filter_name = "domain" if kind == "domains" else "tag"
+    return {
+        "name": item.name,
+        "description": item.description,
+        "when_to_use": item.when_to_use,
+        "avoid_when": item.avoid_when,
+        "related_domains": list(item.related_domains),
+        "related_tags": list(item.related_tags),
+        "example_filter": f"uv run {app_name} list --{filter_name} {name} --json",
+        "command_count": command_count,
+    }
 
 
 def get_command_metadata(*, broker: str, category: str, name: str) -> CommandMetadata:

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
@@ -36,8 +36,276 @@ _BROKER_CREDENTIALS: dict[str, tuple[str, ...]] = {
     "kiwoom": ("KIWOOM_APP_KEY", "KIWOOM_SECRET_KEY"),
 }
 
-_DOMAIN_TAXONOMY: dict[str, TaxonomyMetadata] = {}
-_TAG_TAXONOMY: dict[str, TaxonomyMetadata] = {}
+_DOMAIN_TAXONOMY: dict[str, TaxonomyMetadata] = {
+    "chart": TaxonomyMetadata(
+        name="chart",
+        description="Price, volume, and OHLCV time-series lookup commands.",
+        when_to_use="Use before technical analysis, price trend review, or volume analysis.",
+        avoid_when="Use cluefin-ta-cli technical-indicator commands when OHLCV arrays are already available.",
+        related_tags=("ohlcv", "daily", "minute", "tick"),
+    ),
+    "corporate-actions": TaxonomyMetadata(
+        name="corporate-actions",
+        description="Dividend, capital change, merger, split, IPO, listing, and meeting event commands.",
+        when_to_use="Use when an agent needs issuer event schedules or corporate-action monitoring.",
+        avoid_when="Use news or statements domains when the task needs disclosure text or financial statement values.",
+        related_tags=(
+            "dividend",
+            "ipo",
+            "capital-increase",
+            "capital-reduction",
+            "merger-split",
+            "shareholder-meeting",
+        ),
+    ),
+    "etf": TaxonomyMetadata(
+        name="etf",
+        description="ETF quote, holdings, NAV, and execution data commands.",
+        when_to_use="Use for ETF research, ETF market scans, or component stock lookups.",
+        avoid_when="Use quote or chart domains for regular stock quote and OHLCV tasks.",
+        related_tags=("current-price", "daily"),
+    ),
+    "market": TaxonomyMetadata(
+        name="market",
+        description="Market-wide scan, ranking, schedule, and summary commands.",
+        when_to_use="Use when the task starts from a market universe rather than one known stock.",
+        avoid_when="Use quote or statements domains when the task is already focused on one issuer.",
+        related_tags=("ranking", "volume-rank", "market-cap", "market-calendar"),
+    ),
+    "market-calendar": TaxonomyMetadata(
+        name="market-calendar",
+        description="Trading calendar, business day, holiday, and dated market-event commands.",
+        when_to_use="Use to validate trading dates or discover dated market and issuer events.",
+        avoid_when="Use corporate-actions for issuer action details and market for broad scans.",
+        related_tags=("market-calendar", "announcement"),
+    ),
+    "news": TaxonomyMetadata(
+        name="news",
+        description="Market announcement and DART disclosure discovery commands.",
+        when_to_use="Use for title-level news, formal disclosures, and disclosure monitoring workflows.",
+        avoid_when="Use statements when the task needs normalized financial values rather than filing discovery.",
+        related_tags=("announcement", "disclosure"),
+    ),
+    "quote": TaxonomyMetadata(
+        name="quote",
+        description="Current price, order book, execution, and stock identity lookup commands.",
+        when_to_use="Use for latest stock state, quote snapshots, and immediate market microstructure context.",
+        avoid_when="Use chart when historical OHLCV series are required.",
+        related_tags=("current-price", "order-book", "conclusion", "overtime"),
+    ),
+    "sector": TaxonomyMetadata(
+        name="sector",
+        description="Sector and industry index commands.",
+        when_to_use="Use for sector context, sector trend checks, or market scan grouping.",
+        avoid_when="Use theme when the grouping is thematic rather than exchange sector based.",
+        related_tags=("sector-index", "daily", "minute"),
+    ),
+    "statements": TaxonomyMetadata(
+        name="statements",
+        description="Financial statement, financial ratio, company overview, and shareholder commands.",
+        when_to_use="Use for fundamental analysis, issuer financials, ratios, and ownership context.",
+        avoid_when="Use news for disclosure search or quote for current market pricing.",
+        related_tags=("financial-statement", "financial-ratio", "shareholder", "disclosure"),
+    ),
+    "theme": TaxonomyMetadata(
+        name="theme",
+        description="Theme group and theme constituent commands.",
+        when_to_use="Use for thematic market scans and group membership discovery.",
+        avoid_when="Use sector for exchange sector or industry index analysis.",
+        related_tags=("theme-group",),
+    ),
+    "trading-flow": TaxonomyMetadata(
+        name="trading-flow",
+        description="Investor, foreigner, institution, brokerage, short-selling, and program trading commands.",
+        when_to_use="Use when a task asks who is buying or selling, or needs supply/demand context.",
+        avoid_when="Use chart for price series or quote for current price snapshots.",
+        related_tags=("foreign", "institution", "program-trading", "short-selling", "credit"),
+    ),
+}
+
+_TAG_TAXONOMY: dict[str, TaxonomyMetadata] = {
+    "announcement": TaxonomyMetadata(
+        name="announcement",
+        description="Market announcement and event title data.",
+        when_to_use="Use to discover recent market notices or schedule announcements.",
+        related_domains=("news", "market-calendar", "corporate-actions"),
+    ),
+    "capital-increase": TaxonomyMetadata(
+        name="capital-increase",
+        description="Paid-in capital increase schedule or decision data.",
+        when_to_use="Use when tracking equity issuance or capital raise events.",
+        related_domains=("corporate-actions",),
+    ),
+    "capital-reduction": TaxonomyMetadata(
+        name="capital-reduction",
+        description="Capital reduction and reverse split schedule data.",
+        when_to_use="Use when tracking capital structure reductions or reverse split events.",
+        related_domains=("corporate-actions",),
+    ),
+    "conclusion": TaxonomyMetadata(
+        name="conclusion",
+        description="Execution or trade conclusion data.",
+        when_to_use="Use for recent executed trade details and microstructure checks.",
+        related_domains=("quote",),
+    ),
+    "credit": TaxonomyMetadata(
+        name="credit",
+        description="Margin, credit, or loan-related market data.",
+        when_to_use="Use when supply/demand analysis needs credit balance or margin-tradable context.",
+        related_domains=("trading-flow", "market"),
+    ),
+    "current-price": TaxonomyMetadata(
+        name="current-price",
+        description="Latest quote or current price snapshot.",
+        when_to_use="Use as the first lookup for current market state of a stock or ETF.",
+        related_domains=("quote", "etf"),
+    ),
+    "daily": TaxonomyMetadata(
+        name="daily",
+        description="Daily interval series or daily event data.",
+        when_to_use="Use for day-level chart, sector, ETF, and trading-flow analysis.",
+        related_domains=("chart", "sector", "etf"),
+    ),
+    "disclosure": TaxonomyMetadata(
+        name="disclosure",
+        description="Formal DART disclosure or disclosure-linked company data.",
+        when_to_use="Use to find filings, issuer details, and disclosure-backed records.",
+        related_domains=("news", "statements"),
+    ),
+    "dividend": TaxonomyMetadata(
+        name="dividend",
+        description="Cash dividend or stock dividend schedule and decision data.",
+        when_to_use="Use for income, payout, corporate-action, and event monitoring tasks.",
+        related_domains=("corporate-actions",),
+    ),
+    "financial-ratio": TaxonomyMetadata(
+        name="financial-ratio",
+        description="Profitability, stability, growth, valuation, and other financial ratios.",
+        when_to_use="Use after statement lookup when comparing issuer fundamentals.",
+        related_domains=("statements",),
+    ),
+    "financial-statement": TaxonomyMetadata(
+        name="financial-statement",
+        description="Balance sheet, income statement, and related financial statement data.",
+        when_to_use="Use for fundamental analysis and statement-driven research.",
+        related_domains=("statements",),
+    ),
+    "foreign": TaxonomyMetadata(
+        name="foreign",
+        description="Foreign investor or foreign brokerage trading data.",
+        when_to_use="Use when analyzing foreign buying, selling, ownership, or flow.",
+        related_domains=("trading-flow", "market"),
+    ),
+    "institution": TaxonomyMetadata(
+        name="institution",
+        description="Institutional investor trading data.",
+        when_to_use="Use when analyzing institution-driven supply and demand.",
+        related_domains=("trading-flow", "market"),
+    ),
+    "ipo": TaxonomyMetadata(
+        name="ipo",
+        description="IPO subscription and listing schedule data.",
+        when_to_use="Use for new listing and public offering event workflows.",
+        related_domains=("corporate-actions", "market-calendar"),
+    ),
+    "market-calendar": TaxonomyMetadata(
+        name="market-calendar",
+        description="Holiday, business day, and date-based market schedule data.",
+        when_to_use="Use to validate tradable dates or discover market calendar events.",
+        related_domains=("market-calendar", "market"),
+    ),
+    "market-cap": TaxonomyMetadata(
+        name="market-cap",
+        description="Market capitalization or market value ranking data.",
+        when_to_use="Use for size-based market screening and ranking tasks.",
+        related_domains=("market",),
+    ),
+    "merger-split": TaxonomyMetadata(
+        name="merger-split",
+        description="Merger, split, and par value change event data.",
+        when_to_use="Use for issuer restructuring and corporate-action monitoring.",
+        related_domains=("corporate-actions",),
+    ),
+    "minute": TaxonomyMetadata(
+        name="minute",
+        description="Minute interval price or index data.",
+        when_to_use="Use for intraday chart analysis and short-horizon market context.",
+        related_domains=("chart", "sector"),
+    ),
+    "ohlcv": TaxonomyMetadata(
+        name="ohlcv",
+        description="Open, high, low, close, and volume price series data.",
+        when_to_use="Use to collect source arrays for technical indicators and price/volume analysis.",
+        avoid_when="Use cluefin-ta-cli tags such as moving-average or momentum when OHLCV arrays are already available.",
+        related_domains=("chart",),
+    ),
+    "order-book": TaxonomyMetadata(
+        name="order-book",
+        description="Bid/ask order book and quote depth data.",
+        when_to_use="Use for current liquidity and market microstructure context.",
+        related_domains=("quote",),
+    ),
+    "overtime": TaxonomyMetadata(
+        name="overtime",
+        description="After-hours or overtime trading data.",
+        when_to_use="Use when the task specifically involves off-regular-session prices or execution.",
+        related_domains=("quote",),
+    ),
+    "program-trading": TaxonomyMetadata(
+        name="program-trading",
+        description="Program trading summary, cumulative, arbitrage, or by-stock flow data.",
+        when_to_use="Use when supply/demand analysis needs program trading context.",
+        related_domains=("trading-flow", "market"),
+    ),
+    "ranking": TaxonomyMetadata(
+        name="ranking",
+        description="Provider ranking outputs for market screening.",
+        when_to_use="Use to find candidate stocks by a provider-defined ranking criterion.",
+        related_domains=("market",),
+    ),
+    "sector-index": TaxonomyMetadata(
+        name="sector-index",
+        description="Sector or industry index price and time-series data.",
+        when_to_use="Use when comparing a stock against sector-level movement.",
+        related_domains=("sector", "market"),
+    ),
+    "shareholder": TaxonomyMetadata(
+        name="shareholder",
+        description="Major shareholder or ownership-related issuer data.",
+        when_to_use="Use for ownership, governance, and shareholder context.",
+        related_domains=("statements",),
+    ),
+    "shareholder-meeting": TaxonomyMetadata(
+        name="shareholder-meeting",
+        description="Shareholder meeting schedule data.",
+        when_to_use="Use for governance event monitoring and calendar workflows.",
+        related_domains=("corporate-actions", "market-calendar"),
+    ),
+    "short-selling": TaxonomyMetadata(
+        name="short-selling",
+        description="Short selling, stock loan, or loanable stock data.",
+        when_to_use="Use when bearish positioning or lending context is relevant.",
+        related_domains=("trading-flow", "market"),
+    ),
+    "theme-group": TaxonomyMetadata(
+        name="theme-group",
+        description="Theme group list or theme constituent data.",
+        when_to_use="Use for thematic screening and theme membership discovery.",
+        related_domains=("theme", "market"),
+    ),
+    "tick": TaxonomyMetadata(
+        name="tick",
+        description="Tick interval price or index data.",
+        when_to_use="Use for high-frequency or execution-level chart analysis.",
+        related_domains=("chart",),
+    ),
+    "volume-rank": TaxonomyMetadata(
+        name="volume-rank",
+        description="Trading volume ranking or volume renewal data.",
+        when_to_use="Use for liquidity, unusual volume, and market scan workflows.",
+        related_domains=("market",),
+    ),
+}
 
 _CATEGORY_DEFAULTS: dict[str, tuple[tuple[str, ...], tuple[str, ...]]] = {
     "analysis": (("trading-flow", "market"), ("foreign", "institution")),
@@ -159,6 +427,13 @@ def build_taxonomy_entry(*, kind: str, name: str, command_count: int, app_name: 
         "example_filter": f"uv run {app_name} list --{filter_name} {name} --json",
         "command_count": command_count,
     }
+
+
+def missing_taxonomy_names(*, kind: str, names: set[str]) -> set[str]:
+    """Return taxonomy names that do not have explicit metadata."""
+
+    catalog = _DOMAIN_TAXONOMY if kind == "domains" else _TAG_TAXONOMY
+    return names - set(catalog)
 
 
 def get_command_metadata(*, broker: str, category: str, name: str) -> CommandMetadata:

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from dataclasses import dataclass
 from typing import Any
 
@@ -149,3 +150,74 @@ def get_command_metadata(*, broker: str, category: str, name: str) -> CommandMet
         tags=tuple(tags),
         required_credentials=_BROKER_CREDENTIALS.get(broker, ()),
     )
+
+
+def _sample_value(field_name: str, schema: dict[str, Any]) -> Any:
+    if "default" in schema:
+        return schema["default"]
+    if "enum" in schema and schema["enum"]:
+        return schema["enum"][0]
+
+    schema_type = schema.get("type", "string")
+    if schema_type == "integer":
+        return 1
+    if schema_type == "number":
+        return 1.0
+    if schema_type == "boolean":
+        return False
+    if schema_type == "array":
+        return []
+
+    lowered = field_name.lower()
+    if "date" in lowered or lowered.endswith("_dt") or lowered.endswith("ymd"):
+        return "20250101"
+    if "corp_code" in lowered:
+        return "00126380"
+    if "stock_code" in lowered or "code" in lowered or "iscd" in lowered:
+        return "005930"
+    if "market" in lowered:
+        return "J"
+    return "value"
+
+
+def build_command_examples(path_segments: tuple[str, ...], parameters: dict[str, Any]) -> tuple[dict[str, Any], ...]:
+    """Build one JSON-first executable command skeleton from a command schema."""
+
+    command = " ".join(("uv run cluefin-openapi-cli", *path_segments))
+    properties = parameters.get("properties", {})
+    required = parameters.get("required", [])
+    sample_params = {field: _sample_value(field, properties.get(field, {})) for field in required}
+
+    if sample_params:
+        params_json = json.dumps(sample_params, ensure_ascii=False, separators=(",", ":"))
+        command = f"{command} --params-json '{params_json}' --json"
+    else:
+        command = f"{command} --json"
+
+    return (
+        {
+            "description": "Run this command with JSON output.",
+            "command": command,
+        },
+    )
+
+
+def build_agent_notes(*, broker: str, category: str, name: str, required_credentials: tuple[str, ...]) -> str:
+    """Build concise command-use guidance for agents."""
+
+    credential_note = ", ".join(required_credentials) if required_credentials else "configured broker credentials"
+    base = f"Read-only {broker.upper()} command. Use --json for machine-readable output. Requires {credential_note}."
+
+    if category == "chart":
+        return f"{base} Use chart output as provider-normalized market data before calculating technical indicators."
+    if category == "financial":
+        return f"{base} Use for statements and financial ratios; confirm fiscal period fields in the response."
+    if category == "schedule":
+        return f"{base} Use for corporate-action and market-calendar event discovery."
+    if category in {"analysis", "program"} or "investor" in name:
+        return f"{base} Use for trading-flow analysis; check date and market parameters before comparing providers."
+    if category == "ranking":
+        return f"{base} Use for market screening; ranking criteria are provider-specific."
+    if category == "market" and name == "announcement":
+        return f"{base} Use with DART disclosure search when a disclosure/news workflow needs cross-provider context."
+    return base

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/recipes.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/recipes.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+from cluefin_openapi_cli.registry import RegistryProtocol
+
+
+@dataclass(frozen=True, slots=True)
+class RecipeStep:
+    title: str
+    command: tuple[str, ...]
+    purpose: str
+    agent_notes: str
+
+
+@dataclass(frozen=True, slots=True)
+class WorkflowRecipe:
+    name: str
+    title: str
+    description: str
+    domains: tuple[str, ...]
+    tags: tuple[str, ...]
+    steps: tuple[RecipeStep, ...]
+    agent_notes: str
+
+
+_RECIPES: tuple[WorkflowRecipe, ...] = (
+    WorkflowRecipe(
+        name="stock-research",
+        title="Stock Research",
+        description="Collect quote, company, financial, disclosure, and flow context for one Korean stock.",
+        domains=("quote", "statements", "news", "trading-flow"),
+        tags=("current-price", "financial-statement", "disclosure", "foreign", "institution"),
+        steps=(
+            RecipeStep(
+                title="Get current quote",
+                command=("kis", "stock", "current-price"),
+                purpose="Start with the latest KIS current-price snapshot.",
+                agent_notes="Use the target stock code as a required parameter.",
+            ),
+            RecipeStep(
+                title="Get company basics",
+                command=("kis", "stock", "basic-info"),
+                purpose="Resolve basic stock identity and listing context.",
+                agent_notes="Compare with DART corp-code lookup when a DART workflow needs corp_code.",
+            ),
+            RecipeStep(
+                title="Get financial statement",
+                command=("kis", "financial", "balance-sheet"),
+                purpose="Fetch statement context before ratios or valuation notes.",
+                agent_notes="Follow with income-statement or ratio commands when deeper financial context is needed.",
+            ),
+            RecipeStep(
+                title="Search disclosures",
+                command=("dart", "disclosure-search"),
+                purpose="Find recent DART disclosures for the issuer.",
+                agent_notes="Use corp_code or date filters to reduce result size.",
+            ),
+            RecipeStep(
+                title="Check investor flow",
+                command=("kis", "analysis", "institutional-foreign"),
+                purpose="Add foreign and institutional trading-flow context.",
+                agent_notes="Check date fields before comparing with price movement.",
+            ),
+        ),
+        agent_notes="Use this recipe as a broad first pass, then narrow by domain/tag for detailed follow-up.",
+    ),
+    WorkflowRecipe(
+        name="technical-analysis",
+        title="Technical Analysis",
+        description="Collect chart data for downstream technical indicator calculation.",
+        domains=("chart", "technical-indicator"),
+        tags=("ohlcv", "daily", "minute"),
+        steps=(
+            RecipeStep(
+                title="Fetch daily OHLCV",
+                command=("kis", "chart", "period"),
+                purpose="Retrieve period chart data suitable for daily indicators.",
+                agent_notes="Feed close/high/low/volume arrays into cluefin-ta-cli commands such as sma, rsi, macd, or atr.",
+            ),
+            RecipeStep(
+                title="Fetch intraday OHLCV",
+                command=("kis", "chart", "minute"),
+                purpose="Retrieve minute chart data when intraday analysis is needed.",
+                agent_notes="Keep interval and date window consistent before comparing to daily signals.",
+            ),
+            RecipeStep(
+                title="Fallback chart source",
+                command=("kiwoom", "chart", "tick"),
+                purpose="Use Kiwoom chart data when KIS coverage or parameters are insufficient.",
+                agent_notes="Normalize provider response shape before TA calculation.",
+            ),
+        ),
+        agent_notes="Recipes do not run TA indicators directly; use cluefin-ta-cli after collecting OHLCV arrays.",
+    ),
+    WorkflowRecipe(
+        name="market-scan",
+        title="Market Scan",
+        description="Screen ranking, sector, theme, and volume signals for market-wide ideas.",
+        domains=("market", "sector", "theme"),
+        tags=("ranking", "volume-rank", "sector-index", "theme-group"),
+        steps=(
+            RecipeStep(
+                title="Volume ranking",
+                command=("kis", "ranking", "volume"),
+                purpose="Find high-volume stocks from KIS ranking data.",
+                agent_notes="Use market and ranking parameters to keep scans comparable.",
+            ),
+            RecipeStep(
+                title="Sector index",
+                command=("kis", "sector", "current-index"),
+                purpose="Add sector-level market context.",
+                agent_notes="Combine with sector daily or period commands for trend context.",
+            ),
+            RecipeStep(
+                title="Theme groups",
+                command=("kiwoom", "theme", "group"),
+                purpose="Discover Kiwoom theme groups for thematic scans.",
+                agent_notes="Follow with theme group-stocks for constituents.",
+            ),
+        ),
+        agent_notes="Use ranking outputs as candidates; verify with quote/chart commands before drawing conclusions.",
+    ),
+    WorkflowRecipe(
+        name="corporate-actions",
+        title="Corporate Actions",
+        description="Discover dividend, issuance, split, merger, listing, and meeting events.",
+        domains=("corporate-actions", "market-calendar"),
+        tags=("dividend", "capital-increase", "capital-reduction", "merger-split", "shareholder-meeting"),
+        steps=(
+            RecipeStep(
+                title="Dividend decisions",
+                command=("kis", "schedule", "dividend"),
+                purpose="Find cash dividend decision events.",
+                agent_notes="Use date ranges to scope event searches.",
+            ),
+            RecipeStep(
+                title="Capital increase",
+                command=("kis", "schedule", "capital-increase"),
+                purpose="Find paid-in capital increase schedules.",
+                agent_notes="Cross-check with disclosure search for issuer filings.",
+            ),
+            RecipeStep(
+                title="Merger or split",
+                command=("kis", "schedule", "merger-split"),
+                purpose="Find merger and split decision schedules.",
+                agent_notes="Use DART disclosures for original filings when material.",
+            ),
+            RecipeStep(
+                title="Shareholder meeting",
+                command=("kis", "schedule", "shareholder-meeting"),
+                purpose="Find shareholder meeting schedules.",
+                agent_notes="Useful for governance and event monitoring workflows.",
+            ),
+        ),
+        agent_notes="Corporate-action APIs are event oriented; always include date windows where the schema supports them.",
+    ),
+    WorkflowRecipe(
+        name="disclosure-monitoring",
+        title="Disclosure Monitoring",
+        description="Monitor market announcements and DART disclosures.",
+        domains=("news", "market"),
+        tags=("announcement", "disclosure"),
+        steps=(
+            RecipeStep(
+                title="Market announcements",
+                command=("kis", "market", "announcement"),
+                purpose="Fetch KIS market news and announcement titles.",
+                agent_notes="Use as a quick title-level monitor.",
+            ),
+            RecipeStep(
+                title="DART disclosure search",
+                command=("dart", "disclosure-search"),
+                purpose="Search formal DART disclosures.",
+                agent_notes="Use corp_code and date filters when monitoring a specific issuer.",
+            ),
+            RecipeStep(
+                title="DART company overview",
+                command=("dart", "company-overview"),
+                purpose="Resolve issuer context for DART results.",
+                agent_notes="Requires corp_code from lookup or known issuer mapping.",
+            ),
+        ),
+        agent_notes="Use KIS for title-level discovery and DART for formal disclosure records.",
+    ),
+)
+
+
+def list_recipes() -> list[WorkflowRecipe]:
+    return sorted(_RECIPES, key=lambda recipe: recipe.name)
+
+
+def get_recipe(name: str) -> WorkflowRecipe | None:
+    for recipe in _RECIPES:
+        if recipe.name == name:
+            return recipe
+    return None
+
+
+def recipe_summaries() -> list[dict[str, object]]:
+    return [
+        {
+            "name": recipe.name,
+            "title": recipe.title,
+            "description": recipe.description,
+            "domains": list(recipe.domains),
+            "tags": list(recipe.tags),
+            "step_count": len(recipe.steps),
+        }
+        for recipe in list_recipes()
+    ]
+
+
+def iter_recipe_command_paths() -> Iterable[tuple[str, ...]]:
+    for recipe in _RECIPES:
+        for step in recipe.steps:
+            yield step.command
+
+
+def validate_recipe_commands(registry: RegistryProtocol) -> list[tuple[str, ...]]:
+    return [path for path in iter_recipe_command_paths() if registry.resolve_command(path) is None]

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/registry.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/registry.py
@@ -46,8 +46,10 @@ class RegistryProtocol(Protocol):
         *,
         broker: str | None = None,
         category: str | None = None,
+        domain: str | None = None,
+        tag: str | None = None,
     ) -> list[CommandSpec]:
-        """Return commands filtered by broker and category."""
+        """Return commands filtered by broker, category, domain, and tag."""
 
     def get_command(self, broker: str, category: str, name: str) -> CommandSpec | None:
         """Return one command definition when available."""
@@ -70,6 +72,8 @@ class EmptyRegistry:
         *,
         broker: str | None = None,
         category: str | None = None,
+        domain: str | None = None,
+        tag: str | None = None,
     ) -> list[CommandSpec]:
         return []
 
@@ -173,12 +177,23 @@ class RpcRegistry:
         self._client_factory = client_factory or BrokerClientFactory()
         self._commands = build_cli_registry()
 
-    def list_commands(self, *, broker: str | None = None, category: str | None = None) -> list[CommandSpec]:
+    def list_commands(
+        self,
+        *,
+        broker: str | None = None,
+        category: str | None = None,
+        domain: str | None = None,
+        tag: str | None = None,
+    ) -> list[CommandSpec]:
         commands = list(self._commands.values())
         if broker is not None:
             commands = [command for command in commands if command.broker == broker]
         if category is not None:
             commands = [command for command in commands if command.category == category]
+        if domain is not None:
+            commands = [command for command in commands if domain in command.domains]
+        if tag is not None:
+            commands = [command for command in commands if tag in command.tags]
         return sorted(commands, key=lambda command: command.path_segments)
 
     def get_command(self, broker: str, category: str, name: str) -> CommandSpec | None:

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/registry.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/registry.py
@@ -8,6 +8,7 @@ from cluefin_openapi import BrokerClientFactory
 from cluefin_openapi_cli.handlers.dart import _ALL_HANDLERS as DART_HANDLERS
 from cluefin_openapi_cli.handlers.kis import get_kis_handlers
 from cluefin_openapi_cli.handlers.kiwoom import get_kiwoom_handlers
+from cluefin_openapi_cli.metadata import get_command_metadata
 
 
 @dataclass(frozen=True, slots=True)
@@ -142,6 +143,8 @@ def build_cli_registry() -> dict[tuple[str, ...], CommandSpec]:
         if path_segments in registry:
             raise ValueError(f"Duplicate CLI path detected: {' '.join(path_segments)}")
 
+        metadata = get_command_metadata(broker=schema.broker, category=category, name=command_name)
+
         registry[path_segments] = CommandSpec(
             broker=schema.broker,
             category=category,
@@ -150,6 +153,13 @@ def build_cli_registry() -> dict[tuple[str, ...], CommandSpec]:
             path_segments=path_segments,
             parameters=schema.parameters,
             returns=schema.returns,
+            domains=metadata.domains,
+            tags=metadata.tags,
+            use_cases=metadata.use_cases,
+            examples=metadata.examples,
+            agent_notes=metadata.agent_notes,
+            required_credentials=metadata.required_credentials,
+            side_effect=metadata.side_effect,
             executor=handler,
         )
 

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/registry.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/registry.py
@@ -21,6 +21,13 @@ class CommandSpec:
     path_segments: tuple[str, ...]
     parameters: dict[str, Any] = field(default_factory=dict)
     returns: dict[str, Any] = field(default_factory=dict)
+    domains: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    use_cases: tuple[str, ...] = ()
+    examples: tuple[dict[str, Any], ...] = ()
+    agent_notes: str | None = None
+    required_credentials: tuple[str, ...] = ()
+    side_effect: str = "read"
     executor: Callable[[dict[str, Any], Any], Any] | None = None
 
     @property

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/registry.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/registry.py
@@ -8,7 +8,7 @@ from cluefin_openapi import BrokerClientFactory
 from cluefin_openapi_cli.handlers.dart import _ALL_HANDLERS as DART_HANDLERS
 from cluefin_openapi_cli.handlers.kis import get_kis_handlers
 from cluefin_openapi_cli.handlers.kiwoom import get_kiwoom_handlers
-from cluefin_openapi_cli.metadata import get_command_metadata
+from cluefin_openapi_cli.metadata import build_agent_notes, build_command_examples, get_command_metadata
 
 
 @dataclass(frozen=True, slots=True)
@@ -148,6 +148,13 @@ def build_cli_registry() -> dict[tuple[str, ...], CommandSpec]:
             raise ValueError(f"Duplicate CLI path detected: {' '.join(path_segments)}")
 
         metadata = get_command_metadata(broker=schema.broker, category=category, name=command_name)
+        examples = metadata.examples or build_command_examples(path_segments, schema.parameters)
+        agent_notes = metadata.agent_notes or build_agent_notes(
+            broker=schema.broker,
+            category=category,
+            name=command_name,
+            required_credentials=metadata.required_credentials,
+        )
 
         registry[path_segments] = CommandSpec(
             broker=schema.broker,
@@ -160,8 +167,8 @@ def build_cli_registry() -> dict[tuple[str, ...], CommandSpec]:
             domains=metadata.domains,
             tags=metadata.tags,
             use_cases=metadata.use_cases,
-            examples=metadata.examples,
-            agent_notes=metadata.agent_notes,
+            examples=examples,
+            agent_notes=agent_notes,
             required_credentials=metadata.required_credentials,
             side_effect=metadata.side_effect,
             executor=handler,

--- a/apps/cluefin-openapi-cli/tests/test_main.py
+++ b/apps/cluefin-openapi-cli/tests/test_main.py
@@ -153,15 +153,16 @@ def test_domains_and_tags_return_discovery_catalogs() -> None:
     domains_payload = json.loads(domains.stdout)
     chart_domain = next(item for item in domains_payload["domains"] if item["name"] == "chart")
     assert chart_domain["command_count"] == 1
-    assert chart_domain["description"]
-    assert chart_domain["when_to_use"]
+    assert "OHLCV" in chart_domain["description"]
+    assert "technical analysis" in chart_domain["when_to_use"]
+    assert "ohlcv" in chart_domain["related_tags"]
     assert chart_domain["example_filter"] == "uv run cluefin-openapi-cli list --domain chart --json"
     assert tags.exit_code == 0
     tags_payload = json.loads(tags.stdout)
     ohlcv_tag = next(item for item in tags_payload["tags"] if item["name"] == "ohlcv")
-    assert ohlcv_tag["description"]
-    assert ohlcv_tag["when_to_use"]
-    assert "related_domains" in ohlcv_tag
+    assert "Open, high, low, close" in ohlcv_tag["description"]
+    assert "technical indicators" in ohlcv_tag["when_to_use"]
+    assert "chart" in ohlcv_tag["related_domains"]
     assert ohlcv_tag["example_filter"] == "uv run cluefin-openapi-cli list --tag ohlcv --json"
 
 

--- a/apps/cluefin-openapi-cli/tests/test_main.py
+++ b/apps/cluefin-openapi-cli/tests/test_main.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from cluefin_openapi_cli.main import run_cli
 from cluefin_openapi_cli.registry import CommandSpec, set_registry_provider
 
@@ -109,7 +111,17 @@ def test_describe_returns_command_metadata() -> None:
     result = run_cli(["describe", "kis", "stock", "current-price", "--json"])
 
     assert result.exit_code == 0
-    assert '"qualified_name": "kis.stock.current-price"' in result.stdout
+    payload = json.loads(result.stdout)
+    command = payload["command"]
+
+    assert command["qualified_name"] == "kis.stock.current-price"
+    assert command["domains"] == []
+    assert command["tags"] == []
+    assert command["use_cases"] == []
+    assert command["examples"] == []
+    assert command["agent_notes"] is None
+    assert command["required_credentials"] == []
+    assert command["side_effect"] == "read"
 
 
 def test_describe_missing_command_exits_2() -> None:

--- a/apps/cluefin-openapi-cli/tests/test_main.py
+++ b/apps/cluefin-openapi-cli/tests/test_main.py
@@ -156,6 +156,26 @@ def test_domains_and_tags_return_discovery_catalogs() -> None:
     assert '"name": "ohlcv"' in tags.stdout
 
 
+def test_recipes_and_recipe_return_workflow_metadata() -> None:
+    recipes = run_cli(["recipes", "--json"])
+    recipe = run_cli(["recipe", "stock-research", "--json"])
+
+    assert recipes.exit_code == 0
+    assert '"name": "stock-research"' in recipes.stdout
+    assert '"step_count"' in recipes.stdout
+    assert recipe.exit_code == 0
+    assert '"title": "Stock Research"' in recipe.stdout
+    assert '"command"' in recipe.stdout
+    assert '"kis"' in recipe.stdout
+
+
+def test_unknown_recipe_exits_2() -> None:
+    result = run_cli(["recipe", "missing", "--json"])
+
+    assert result.exit_code == 2
+    assert "Unknown recipe" in result.stdout
+
+
 def test_describe_returns_command_metadata() -> None:
     result = run_cli(["describe", "kis", "stock", "current-price", "--json"])
 
@@ -187,6 +207,8 @@ def test_root_help_returns_usage_payload() -> None:
     assert '"usage"' in result.stdout
     assert "domains [--json]" in result.stdout
     assert "list [--domain DOMAIN] [--tag TAG]" in result.stdout
+    assert "recipes [--json]" in result.stdout
+    assert "recipe <name> [--json]" in result.stdout
 
 
 def test_broker_help_lists_categories() -> None:

--- a/apps/cluefin-openapi-cli/tests/test_main.py
+++ b/apps/cluefin-openapi-cli/tests/test_main.py
@@ -17,6 +17,8 @@ class FakeRegistry:
                 path_segments=("kis", "stock", "current-price"),
                 parameters={"type": "object"},
                 returns={"type": "object"},
+                domains=("quote", "market"),
+                tags=("current-price",),
                 executor=lambda params: {"params": params, "source": "kis"},
             ),
             CommandSpec(
@@ -27,6 +29,8 @@ class FakeRegistry:
                 path_segments=("kiwoom", "chart", "tick"),
                 parameters={"type": "object"},
                 returns={"type": "object"},
+                domains=("chart",),
+                tags=("tick", "ohlcv"),
             ),
             CommandSpec(
                 broker="dart",
@@ -40,6 +44,8 @@ class FakeRegistry:
                     "required": ["corp_code"],
                 },
                 returns={"type": "object"},
+                domains=("statements",),
+                tags=("disclosure",),
                 executor=lambda params: {"corp_code": params["corp_code"]},
             ),
             CommandSpec(
@@ -50,16 +56,29 @@ class FakeRegistry:
                 path_segments=("dart", "failing-command"),
                 parameters={"type": "object"},
                 returns={"type": "object"},
+                domains=("news",),
+                tags=("disclosure",),
                 executor=lambda params: (_ for _ in ()).throw(RuntimeError("broker unavailable")),
             ),
         ]
 
-    def list_commands(self, *, broker: str | None = None, category: str | None = None):
+    def list_commands(
+        self,
+        *,
+        broker: str | None = None,
+        category: str | None = None,
+        domain: str | None = None,
+        tag: str | None = None,
+    ):
         commands = self._commands
         if broker is not None:
             commands = [command for command in commands if command.broker == broker]
         if category is not None:
             commands = [command for command in commands if command.category == category]
+        if domain is not None:
+            commands = [command for command in commands if domain in command.domains]
+        if tag is not None:
+            commands = [command for command in commands if tag in command.tags]
         return commands
 
     def get_command(self, broker: str, category: str, name: str):
@@ -107,6 +126,29 @@ def test_list_filters_registry_and_emits_json() -> None:
     assert '"count": 1' in result.stdout
 
 
+def test_list_filters_by_domain_and_tag() -> None:
+    domain_result = run_cli(["list", "--domain", "chart", "--json"])
+    tag_result = run_cli(["list", "--tag", "current-price", "--json"])
+
+    assert domain_result.exit_code == 0
+    assert '"domain": "chart"' in domain_result.stdout
+    assert '"qualified_name": "kiwoom.chart.tick"' in domain_result.stdout
+    assert tag_result.exit_code == 0
+    assert '"tag": "current-price"' in tag_result.stdout
+    assert '"qualified_name": "kis.stock.current-price"' in tag_result.stdout
+
+
+def test_domains_and_tags_return_discovery_catalogs() -> None:
+    domains = run_cli(["domains", "--json"])
+    tags = run_cli(["tags", "--json"])
+
+    assert domains.exit_code == 0
+    assert '"name": "chart"' in domains.stdout
+    assert '"command_count": 1' in domains.stdout
+    assert tags.exit_code == 0
+    assert '"name": "ohlcv"' in tags.stdout
+
+
 def test_describe_returns_command_metadata() -> None:
     result = run_cli(["describe", "kis", "stock", "current-price", "--json"])
 
@@ -115,8 +157,8 @@ def test_describe_returns_command_metadata() -> None:
     command = payload["command"]
 
     assert command["qualified_name"] == "kis.stock.current-price"
-    assert command["domains"] == []
-    assert command["tags"] == []
+    assert command["domains"] == ["quote", "market"]
+    assert command["tags"] == ["current-price"]
     assert command["use_cases"] == []
     assert command["examples"] == []
     assert command["agent_notes"] is None

--- a/apps/cluefin-openapi-cli/tests/test_main.py
+++ b/apps/cluefin-openapi-cli/tests/test_main.py
@@ -19,6 +19,13 @@ class FakeRegistry:
                 returns={"type": "object"},
                 domains=("quote", "market"),
                 tags=("current-price",),
+                examples=(
+                    {
+                        "description": "Run current price.",
+                        "command": 'uv run cluefin-openapi-cli kis stock current-price --params-json \'{"stock_code":"005930"}\' --json',
+                    },
+                ),
+                agent_notes="Use --json for machine-readable current-price output.",
                 executor=lambda params: {"params": params, "source": "kis"},
             ),
             CommandSpec(
@@ -160,8 +167,9 @@ def test_describe_returns_command_metadata() -> None:
     assert command["domains"] == ["quote", "market"]
     assert command["tags"] == ["current-price"]
     assert command["use_cases"] == []
-    assert command["examples"] == []
-    assert command["agent_notes"] is None
+    assert command["examples"]
+    assert "cluefin-openapi-cli kis stock current-price" in command["examples"][0]["command"]
+    assert command["agent_notes"] == "Use --json for machine-readable current-price output."
     assert command["required_credentials"] == []
     assert command["side_effect"] == "read"
 
@@ -177,6 +185,8 @@ def test_root_help_returns_usage_payload() -> None:
 
     assert result.exit_code == 0
     assert '"usage"' in result.stdout
+    assert "domains [--json]" in result.stdout
+    assert "list [--domain DOMAIN] [--tag TAG]" in result.stdout
 
 
 def test_broker_help_lists_categories() -> None:

--- a/apps/cluefin-openapi-cli/tests/test_main.py
+++ b/apps/cluefin-openapi-cli/tests/test_main.py
@@ -150,10 +150,19 @@ def test_domains_and_tags_return_discovery_catalogs() -> None:
     tags = run_cli(["tags", "--json"])
 
     assert domains.exit_code == 0
-    assert '"name": "chart"' in domains.stdout
-    assert '"command_count": 1' in domains.stdout
+    domains_payload = json.loads(domains.stdout)
+    chart_domain = next(item for item in domains_payload["domains"] if item["name"] == "chart")
+    assert chart_domain["command_count"] == 1
+    assert chart_domain["description"]
+    assert chart_domain["when_to_use"]
+    assert chart_domain["example_filter"] == "uv run cluefin-openapi-cli list --domain chart --json"
     assert tags.exit_code == 0
-    assert '"name": "ohlcv"' in tags.stdout
+    tags_payload = json.loads(tags.stdout)
+    ohlcv_tag = next(item for item in tags_payload["tags"] if item["name"] == "ohlcv")
+    assert ohlcv_tag["description"]
+    assert ohlcv_tag["when_to_use"]
+    assert "related_domains" in ohlcv_tag
+    assert ohlcv_tag["example_filter"] == "uv run cluefin-openapi-cli list --tag ohlcv --json"
 
 
 def test_recipes_and_recipe_return_workflow_metadata() -> None:

--- a/apps/cluefin-openapi-cli/tests/test_readme_smoke.py
+++ b/apps/cluefin-openapi-cli/tests/test_readme_smoke.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cluefin_openapi_cli.main import run_cli
+
+README = Path("apps/cluefin-openapi-cli/README.md")
+
+
+def test_readme_mentions_agent_discovery_commands() -> None:
+    content = README.read_text(encoding="utf-8")
+
+    assert "list --domain chart --json" in content
+    assert "list --tag ohlcv --json" in content
+    assert "domains --json" in content
+    assert "tags --json" in content
+    assert "recipes --json" in content
+    assert "recipe stock-research --json" in content
+    assert "agent_notes" in content
+    assert "cluefin-cli" in content
+
+
+def test_readme_discovery_examples_execute() -> None:
+    examples = [
+        ["list", "--domain", "chart", "--json"],
+        ["list", "--tag", "ohlcv", "--json"],
+        ["domains", "--json"],
+        ["tags", "--json"],
+        ["recipes", "--json"],
+        ["recipe", "stock-research", "--json"],
+    ]
+
+    for argv in examples:
+        result = run_cli(argv)
+        assert result.exit_code == 0, argv
+        assert result.stdout.strip().startswith("{"), argv

--- a/apps/cluefin-openapi-cli/tests/test_readme_smoke.py
+++ b/apps/cluefin-openapi-cli/tests/test_readme_smoke.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from cluefin_openapi_cli.main import run_cli
+from cluefin_openapi_cli.registry import RpcRegistry, set_registry_provider
 
 README = Path("apps/cluefin-openapi-cli/README.md")
 
@@ -18,9 +20,17 @@ def test_readme_mentions_agent_discovery_commands() -> None:
     assert "recipe stock-research --json" in content
     assert "agent_notes" in content
     assert "cluefin-cli" in content
+    assert "`domains`: 업무 영역" in content
+    assert "`tags`: 세부 기능" in content
+    assert "`recipes`: 여러 command를 조합하는 workflow guide" in content
+    assert "description" in content
+    assert "when_to_use" in content
+    assert "avoid_when" in content
+    assert "example_filter" in content
 
 
 def test_readme_discovery_examples_execute() -> None:
+    set_registry_provider(RpcRegistry)
     examples = [
         ["list", "--domain", "chart", "--json"],
         ["list", "--tag", "ohlcv", "--json"],
@@ -34,3 +44,20 @@ def test_readme_discovery_examples_execute() -> None:
         result = run_cli(argv)
         assert result.exit_code == 0, argv
         assert result.stdout.strip().startswith("{"), argv
+
+
+def test_readme_taxonomy_examples_match_json_shape() -> None:
+    set_registry_provider(RpcRegistry)
+    domains = json.loads(run_cli(["domains", "--json"]).stdout)
+    tags = json.loads(run_cli(["tags", "--json"]).stdout)
+
+    chart = next(item for item in domains["domains"] if item["name"] == "chart")
+    ohlcv = next(item for item in tags["tags"] if item["name"] == "ohlcv")
+
+    assert chart["description"]
+    assert chart["when_to_use"]
+    assert chart["avoid_when"]
+    assert "ohlcv" in chart["related_tags"]
+    assert chart["example_filter"] == "uv run cluefin-openapi-cli list --domain chart --json"
+    assert ohlcv["related_domains"] == ["chart"]
+    assert ohlcv["example_filter"] == "uv run cluefin-openapi-cli list --tag ohlcv --json"

--- a/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
+++ b/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from cluefin_openapi_cli.metadata import missing_taxonomy_names
 from cluefin_openapi_cli.recipes import list_recipes, validate_recipe_commands
 from cluefin_openapi_cli.registry import RpcRegistry, build_cli_registry
 
@@ -68,6 +69,15 @@ def test_cli_registry_all_commands_have_domain_tag_and_credentials() -> None:
     assert all(command.agent_notes for command in registry.values())
     assert all(command.required_credentials for command in registry.values())
     assert {command.side_effect for command in registry.values()} == {"read"}
+
+
+def test_openapi_taxonomy_catalog_covers_all_real_domains_and_tags() -> None:
+    registry = build_cli_registry()
+    domains = {domain for command in registry.values() for domain in command.domains}
+    tags = {tag for command in registry.values() for tag in command.tags}
+
+    assert missing_taxonomy_names(kind="domains", names=domains) == set()
+    assert missing_taxonomy_names(kind="tags", names=tags) == set()
 
 
 def test_cli_registry_examples_are_json_first_command_skeletons() -> None:

--- a/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
+++ b/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from cluefin_openapi_cli.recipes import list_recipes, validate_recipe_commands
 from cluefin_openapi_cli.registry import RpcRegistry, build_cli_registry
 
 
@@ -103,6 +104,15 @@ def test_cli_registry_maps_representative_domains_and_tags() -> None:
     assert "ohlcv" in registry[("kis", "chart", "period")].tags
     assert "announcement" in registry[("kis", "market", "announcement")].tags
     assert "theme-group" in registry[("kiwoom", "theme", "group")].tags
+
+
+def test_recipe_command_references_exist_in_registry() -> None:
+    registry = RpcRegistry(client_factory=_FakeFactory())
+
+    missing = validate_recipe_commands(registry)
+
+    assert list_recipes()
+    assert missing == []
 
 
 def test_rpc_registry_resolves_real_command_path() -> None:

--- a/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
+++ b/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
@@ -67,6 +67,18 @@ def test_cli_registry_all_commands_have_domain_tag_and_credentials() -> None:
     assert {command.side_effect for command in registry.values()} == {"read"}
 
 
+def test_rpc_registry_filters_by_domain_and_tag() -> None:
+    registry = RpcRegistry(client_factory=_FakeFactory())
+
+    chart_commands = registry.list_commands(domain="chart")
+    ohlcv_commands = registry.list_commands(tag="ohlcv")
+
+    assert chart_commands
+    assert all("chart" in command.domains for command in chart_commands)
+    assert ohlcv_commands
+    assert all("ohlcv" in command.tags for command in ohlcv_commands)
+
+
 def test_cli_registry_maps_representative_domains_and_tags() -> None:
     registry = build_cli_registry()
 

--- a/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
+++ b/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
@@ -45,17 +45,40 @@ def test_cli_registry_keeps_existing_command_surface() -> None:
     assert len(registry) == len(set(registry))
 
 
-def test_cli_registry_commands_expose_metadata_defaults() -> None:
+def test_cli_registry_commands_expose_agent_metadata() -> None:
     registry = build_cli_registry()
     command = registry[("kis", "stock", "current-price")]
 
-    assert command.domains == ()
-    assert command.tags == ()
+    assert command.domains
+    assert command.tags
     assert command.use_cases == ()
     assert command.examples == ()
     assert command.agent_notes is None
-    assert command.required_credentials == ()
+    assert command.required_credentials == ("KIS_APP_KEY", "KIS_SECRET_KEY")
     assert command.side_effect == "read"
+
+
+def test_cli_registry_all_commands_have_domain_tag_and_credentials() -> None:
+    registry = build_cli_registry()
+
+    assert all(command.domains for command in registry.values())
+    assert all(command.tags for command in registry.values())
+    assert all(command.required_credentials for command in registry.values())
+    assert {command.side_effect for command in registry.values()} == {"read"}
+
+
+def test_cli_registry_maps_representative_domains_and_tags() -> None:
+    registry = build_cli_registry()
+
+    assert "chart" in registry[("kis", "chart", "period")].domains
+    assert {"news", "market"}.issubset(registry[("kis", "market", "announcement")].domains)
+    assert "corporate-actions" in registry[("kis", "schedule", "dividend")].domains
+    assert {"theme", "market"}.issubset(registry[("kiwoom", "theme", "group")].domains)
+    assert {"news", "statements"}.issubset(registry[("dart", "disclosure-search")].domains)
+
+    assert "ohlcv" in registry[("kis", "chart", "period")].tags
+    assert "announcement" in registry[("kis", "market", "announcement")].tags
+    assert "theme-group" in registry[("kiwoom", "theme", "group")].tags
 
 
 def test_rpc_registry_resolves_real_command_path() -> None:

--- a/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
+++ b/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
@@ -45,6 +45,19 @@ def test_cli_registry_keeps_existing_command_surface() -> None:
     assert len(registry) == len(set(registry))
 
 
+def test_cli_registry_commands_expose_metadata_defaults() -> None:
+    registry = build_cli_registry()
+    command = registry[("kis", "stock", "current-price")]
+
+    assert command.domains == ()
+    assert command.tags == ()
+    assert command.use_cases == ()
+    assert command.examples == ()
+    assert command.agent_notes is None
+    assert command.required_credentials == ()
+    assert command.side_effect == "read"
+
+
 def test_rpc_registry_resolves_real_command_path() -> None:
     registry = RpcRegistry(client_factory=_FakeFactory())
     command = registry.resolve_command(("dart", "company-overview"))

--- a/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
+++ b/apps/cluefin-openapi-cli/tests/test_rpc_registry.py
@@ -52,8 +52,8 @@ def test_cli_registry_commands_expose_agent_metadata() -> None:
     assert command.domains
     assert command.tags
     assert command.use_cases == ()
-    assert command.examples == ()
-    assert command.agent_notes is None
+    assert command.examples
+    assert command.agent_notes
     assert command.required_credentials == ("KIS_APP_KEY", "KIS_SECRET_KEY")
     assert command.side_effect == "read"
 
@@ -63,8 +63,20 @@ def test_cli_registry_all_commands_have_domain_tag_and_credentials() -> None:
 
     assert all(command.domains for command in registry.values())
     assert all(command.tags for command in registry.values())
+    assert all(command.examples for command in registry.values())
+    assert all(command.agent_notes for command in registry.values())
     assert all(command.required_credentials for command in registry.values())
     assert {command.side_effect for command in registry.values()} == {"read"}
+
+
+def test_cli_registry_examples_are_json_first_command_skeletons() -> None:
+    registry = build_cli_registry()
+    command = registry[("kis", "stock", "current-price")]
+    example = command.examples[0]["command"]
+
+    assert example.startswith("uv run cluefin-openapi-cli kis stock current-price")
+    assert "--json" in example
+    assert "--params-json" in example
 
 
 def test_rpc_registry_filters_by_domain_and_tag() -> None:

--- a/apps/cluefin-ta-cli/README.md
+++ b/apps/cluefin-ta-cli/README.md
@@ -17,27 +17,33 @@ uv run cluefin-ta-cli --help --json
 
 ### 1. Discovery
 
-전체 command를 탐색합니다.
+전체 command 또는 domain/tag별 command를 탐색합니다.
 
 ```bash
 uv run cluefin-ta-cli list --json
+uv run cluefin-ta-cli list --domain technical-indicator --json
+uv run cluefin-ta-cli list --tag momentum --json
+uv run cluefin-ta-cli domains --json
+uv run cluefin-ta-cli tags --json
 ```
 
 ### 2. Describe
 
-단일 command의 설명, 입력 schema, required 필드, help payload를 확인합니다.
+단일 command의 설명, 입력 schema, required 필드, domain/tag, examples, agent_notes, help payload를 확인합니다.
 
 ```bash
 uv run cluefin-ta-cli describe ta sma --json
 uv run cluefin-ta-cli ta sma --help --json
 ```
 
+Agent는 `describe --json`의 `examples[0].command`를 실행 skeleton으로 사용하고, `agent_notes`에서 입력 배열 조건과 warm-up 구간의 `null` 반환 가능성을 확인할 수 있습니다.
+
 ### 3. Command Path
 
 TA command path 규칙은 아래와 같습니다.
 
 - `ta <name>`
-- `list`, `describe`는 meta command
+- `list`, `describe`, `domains`, `tags`는 meta command
 
 예시:
 
@@ -79,7 +85,22 @@ uv run cluefin-ta-cli ta sma --params-json '{"close":[100,101,102,103,104]}' --t
 uv run cluefin-ta-cli --help --json
 uv run cluefin-ta-cli ta --help --json
 uv run cluefin-ta-cli ta sma --help --json
+uv run cluefin-ta-cli domains --json
+uv run cluefin-ta-cli tags --json
 ```
+
+## Agent Workflow
+
+`cluefin-openapi-cli`에서 OHLCV 데이터를 조회한 뒤, 필요한 배열만 추출해 `cluefin-ta-cli`에 전달합니다.
+
+```bash
+uv run cluefin-openapi-cli list --domain chart --json
+uv run cluefin-ta-cli list --tag moving-average --json
+uv run cluefin-ta-cli describe ta rsi --json
+uv run cluefin-ta-cli ta rsi --params-json '{"close":[100,101,102,103,104]}' --json
+```
+
+`cluefin-cli` 삭제 또는 정리는 별도 후속 작업입니다. Agent integration은 이 CLI의 JSON discovery를 직접 사용할 수 있습니다.
 
 ## 지원 명령
 

--- a/apps/cluefin-ta-cli/README.md
+++ b/apps/cluefin-ta-cli/README.md
@@ -27,6 +27,28 @@ uv run cluefin-ta-cli domains --json
 uv run cluefin-ta-cli tags --json
 ```
 
+Agent용 분류 기준:
+
+- `domains`: 업무 영역입니다. 예: `technical-indicator`, `risk-metric`, `portfolio-metric`.
+- `tags`: 세부 기능 또는 계산 특성입니다. 예: `moving-average`, `momentum`, `volatility`.
+- `recipes`: 이 CLI에는 별도 recipe 명령이 없습니다. Workflow guide가 필요하면 `cluefin-openapi-cli recipes --json`로 원천 데이터 조회 흐름을 확인한 뒤, `cluefin-ta-cli describe ... --json`로 지표 입력을 맞춥니다.
+
+`domains --json`, `tags --json`는 `name`, `command_count`뿐 아니라 `description`, `when_to_use`, `avoid_when`, `related_domains`, `related_tags`, `example_filter`를 포함합니다. Agent는 `technical-indicator`가 OHLCV 배열 기반 지표이고, `portfolio-metric`과 `risk-metric`은 수익률 배열 기반 계산이라는 차이를 응답만으로 구분할 수 있습니다.
+
+예시 taxonomy 응답:
+
+```json
+{
+  "name": "technical-indicator",
+  "description": "Technical analysis indicators calculated from price, volume, or OHLCV arrays.",
+  "when_to_use": "Use after collecting chart data from cluefin-openapi-cli and extracting arrays for indicator calculation.",
+  "avoid_when": "Use portfolio-metric or risk-metric when the input is a return series rather than market price arrays.",
+  "related_tags": ["moving-average", "momentum", "trend", "volatility", "volume-indicator"],
+  "example_filter": "uv run cluefin-ta-cli list --domain technical-indicator --json",
+  "command_count": 9
+}
+```
+
 ### 2. Describe
 
 단일 command의 설명, 입력 schema, required 필드, domain/tag, examples, agent_notes, help payload를 확인합니다.

--- a/apps/cluefin-ta-cli/src/cluefin_ta_cli/main.py
+++ b/apps/cluefin-ta-cli/src/cluefin_ta_cli/main.py
@@ -7,6 +7,7 @@ from contextlib import redirect_stderr, redirect_stdout
 from dataclasses import dataclass
 from typing import Any
 
+from cluefin_ta_cli.metadata import build_taxonomy_entry
 from cluefin_ta_cli.output import render_output, stdout_is_tty, to_jsonable
 from cluefin_ta_cli.registry import CommandSpec, Registry
 
@@ -102,7 +103,12 @@ def _discovery_payload(kind: str) -> dict[str, Any]:
     values = sorted({value for command in commands for value in getattr(command, kind)})
     return {
         kind: [
-            {"name": value, "command_count": sum(value in getattr(command, kind) for command in commands)}
+            build_taxonomy_entry(
+                kind=kind,
+                name=value,
+                command_count=sum(value in getattr(command, kind) for command in commands),
+                app_name="cluefin-ta-cli",
+            )
             for value in values
         ],
         "count": len(values),

--- a/apps/cluefin-ta-cli/src/cluefin_ta_cli/main.py
+++ b/apps/cluefin-ta-cli/src/cluefin_ta_cli/main.py
@@ -96,6 +96,19 @@ def _parse_named_options(argv: list[str]) -> tuple[list[str], dict[str, str | bo
     return positional, options
 
 
+def _discovery_payload(kind: str) -> dict[str, Any]:
+    registry = Registry()
+    commands = registry.list_commands(category="ta")
+    values = sorted({value for command in commands for value in getattr(command, kind)})
+    return {
+        kind: [
+            {"name": value, "command_count": sum(value in getattr(command, kind) for command in commands)}
+            for value in values
+        ],
+        "count": len(values),
+    }
+
+
 def _load_params_json(raw: str | None) -> dict[str, Any]:
     if not raw:
         return {}
@@ -201,12 +214,15 @@ def _run_root(argv: list[str]) -> None:
         "app": "cluefin-ta-cli",
         "interactive": stdout_is_tty(),
         "categories": ["ta"],
-        "commands": ["list", "describe"],
+        "commands": ["list", "describe", "domains", "tags"],
     }
     if bool(options.get("help", False)):
         payload["usage"] = [
             "cluefin-ta-cli list [--json]",
+            "cluefin-ta-cli list [--domain DOMAIN] [--tag TAG] [--json]",
             "cluefin-ta-cli describe ta <name> [--json]",
+            "cluefin-ta-cli domains [--json]",
+            "cluefin-ta-cli tags [--json]",
             "cluefin-ta-cli ta [--help] [--json]",
             "cluefin-ta-cli ta <name> [--params-json JSON] [schema options] [--json]",
         ]
@@ -219,16 +235,38 @@ def _run_list(argv: list[str]) -> None:
         raise CliError("`list` does not accept positional arguments.", exit_code=2)
 
     force_json = bool(options.get("json", False))
+    domain = options.get("domain")
+    tag = options.get("tag")
     registry = Registry()
-    commands = registry.list_commands(category="ta")
+    commands = registry.list_commands(
+        category="ta",
+        domain=domain if isinstance(domain, str) else None,
+        tag=tag if isinstance(tag, str) else None,
+    )
     render_output(
         {
             "category": "ta",
+            "domain": domain if isinstance(domain, str) else None,
+            "tag": tag if isinstance(tag, str) else None,
             "count": len(commands),
             "commands": [to_jsonable(_command_summary(command)) for command in commands],
         },
         force_json=force_json,
     )
+
+
+def _run_domains(argv: list[str]) -> None:
+    positional, options = _parse_named_options(argv)
+    if positional:
+        raise CliError("`domains` does not accept positional arguments.", exit_code=2)
+    render_output(_discovery_payload("domains"), force_json=bool(options.get("json", False)))
+
+
+def _run_tags(argv: list[str]) -> None:
+    positional, options = _parse_named_options(argv)
+    if positional:
+        raise CliError("`tags` does not accept positional arguments.", exit_code=2)
+    render_output(_discovery_payload("tags"), force_json=bool(options.get("json", False)))
 
 
 def _run_describe(argv: list[str]) -> None:
@@ -304,6 +342,12 @@ def dispatch(argv: list[str] | None = None) -> None:
         return
     if command == "describe":
         _run_describe(args[1:])
+        return
+    if command == "domains":
+        _run_domains(args[1:])
+        return
+    if command == "tags":
+        _run_tags(args[1:])
         return
 
     _run_dynamic(args)

--- a/apps/cluefin-ta-cli/src/cluefin_ta_cli/main.py
+++ b/apps/cluefin-ta-cli/src/cluefin_ta_cli/main.py
@@ -35,6 +35,11 @@ def _command_summary(command: CommandSpec) -> dict[str, Any]:
         "description": command.description,
         "parameters": command.parameters,
         "returns": command.returns,
+        "domains": list(command.domains),
+        "tags": list(command.tags),
+        "use_cases": list(command.use_cases),
+        "examples": list(command.examples),
+        "agent_notes": command.agent_notes,
         "has_executor": command.executor is not None,
     }
 

--- a/apps/cluefin-ta-cli/src/cluefin_ta_cli/metadata.py
+++ b/apps/cluefin-ta-cli/src/cluefin_ta_cli/metadata.py
@@ -15,6 +15,18 @@ class CommandMetadata:
     agent_notes: str
 
 
+@dataclass(frozen=True, slots=True)
+class TaxonomyMetadata:
+    """Agent-facing explanation for one domain or tag."""
+
+    name: str
+    description: str
+    when_to_use: str
+    avoid_when: str | None = None
+    related_domains: tuple[str, ...] = ()
+    related_tags: tuple[str, ...] = ()
+
+
 def _example(name: str, params_json: str) -> tuple[dict[str, Any], ...]:
     return (
         {
@@ -27,6 +39,9 @@ def _example(name: str, params_json: str) -> tuple[dict[str, Any], ...]:
 _COMMON_PRICE_NOTE = (
     "Supply price arrays through --params-json. Indicator warm-up periods can return null values in JSON output."
 )
+
+_DOMAIN_TAXONOMY: dict[str, TaxonomyMetadata] = {}
+_TAG_TAXONOMY: dict[str, TaxonomyMetadata] = {}
 
 _METADATA: dict[str, CommandMetadata] = {
     "adx": CommandMetadata(
@@ -116,3 +131,30 @@ def get_command_metadata(name: str) -> CommandMetadata:
     """Return discovery metadata for a TA command name."""
 
     return _METADATA[name]
+
+
+def _generic_taxonomy(kind: str, name: str) -> TaxonomyMetadata:
+    label = "domain" if kind == "domains" else "tag"
+    return TaxonomyMetadata(
+        name=name,
+        description=f"Agent discovery {label} for `{name}` commands.",
+        when_to_use=f"Use when a task needs commands classified by `{name}`.",
+    )
+
+
+def build_taxonomy_entry(*, kind: str, name: str, command_count: int, app_name: str) -> dict[str, Any]:
+    """Build a JSON-safe taxonomy discovery entry."""
+
+    catalog = _DOMAIN_TAXONOMY if kind == "domains" else _TAG_TAXONOMY
+    item = catalog.get(name, _generic_taxonomy(kind, name))
+    filter_name = "domain" if kind == "domains" else "tag"
+    return {
+        "name": item.name,
+        "description": item.description,
+        "when_to_use": item.when_to_use,
+        "avoid_when": item.avoid_when,
+        "related_domains": list(item.related_domains),
+        "related_tags": list(item.related_tags),
+        "example_filter": f"uv run {app_name} list --{filter_name} {name} --json",
+        "command_count": command_count,
+    }

--- a/apps/cluefin-ta-cli/src/cluefin_ta_cli/metadata.py
+++ b/apps/cluefin-ta-cli/src/cluefin_ta_cli/metadata.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class CommandMetadata:
+    """Agent discovery metadata for one TA command."""
+
+    domains: tuple[str, ...]
+    tags: tuple[str, ...]
+    use_cases: tuple[str, ...]
+    examples: tuple[dict[str, Any], ...]
+    agent_notes: str
+
+
+def _example(name: str, params_json: str) -> tuple[dict[str, Any], ...]:
+    return (
+        {
+            "description": f"Run {name} with inline JSON input.",
+            "command": f"uv run cluefin-ta-cli ta {name} --params-json '{params_json}' --json",
+        },
+    )
+
+
+_COMMON_PRICE_NOTE = (
+    "Supply price arrays through --params-json. Indicator warm-up periods can return null values in JSON output."
+)
+
+_METADATA: dict[str, CommandMetadata] = {
+    "adx": CommandMetadata(
+        domains=("technical-indicator",),
+        tags=("momentum", "trend", "volatility"),
+        use_cases=("Measure trend strength from high/low/close OHLCV data.",),
+        examples=_example("adx", '{"high":[3,4,5],"low":[1,2,3],"close":[2,3,4],"timeperiod":14}'),
+        agent_notes=_COMMON_PRICE_NOTE + " Requires high, low, and close arrays of the same length.",
+    ),
+    "atr": CommandMetadata(
+        domains=("technical-indicator",),
+        tags=("volatility",),
+        use_cases=("Measure price range volatility from high/low/close OHLCV data.",),
+        examples=_example("atr", '{"high":[3,4,5],"low":[1,2,3],"close":[2,3,4],"timeperiod":14}'),
+        agent_notes=_COMMON_PRICE_NOTE + " Requires high, low, and close arrays of the same length.",
+    ),
+    "bbands": CommandMetadata(
+        domains=("technical-indicator",),
+        tags=("volatility", "moving-average"),
+        use_cases=("Calculate Bollinger Bands around a close-price series.",),
+        examples=_example("bbands", '{"close":[1,2,3,4,5],"timeperiod":20,"nbdevup":2,"nbdevdn":2}'),
+        agent_notes=_COMMON_PRICE_NOTE + " Use close prices ordered oldest to newest.",
+    ),
+    "ema": CommandMetadata(
+        domains=("technical-indicator",),
+        tags=("moving-average", "trend"),
+        use_cases=("Smooth close prices with an exponential moving average.",),
+        examples=_example("ema", '{"close":[1,2,3,4,5],"timeperiod":14}'),
+        agent_notes=_COMMON_PRICE_NOTE + " Use close prices ordered oldest to newest.",
+    ),
+    "macd": CommandMetadata(
+        domains=("technical-indicator",),
+        tags=("momentum", "trend", "moving-average"),
+        use_cases=("Calculate MACD, signal, and histogram values from close prices.",),
+        examples=_example("macd", '{"close":[1,2,3,4,5,6],"fastperiod":12,"slowperiod":26,"signalperiod":9}'),
+        agent_notes=_COMMON_PRICE_NOTE + " Use close prices ordered oldest to newest.",
+    ),
+    "mdd": CommandMetadata(
+        domains=("risk-metric",),
+        tags=("portfolio-risk",),
+        use_cases=("Calculate maximum drawdown from a return series.",),
+        examples=_example("mdd", '{"returns":[0.1,-0.2,0.05,-0.1]}'),
+        agent_notes="Supply periodic returns through --params-json, not prices. Returns a scalar value.",
+    ),
+    "obv": CommandMetadata(
+        domains=("technical-indicator",),
+        tags=("volume-indicator",),
+        use_cases=("Calculate On Balance Volume from close and volume series.",),
+        examples=_example("obv", '{"close":[1,2,1.5,3],"volume":[100,120,90,150]}'),
+        agent_notes=_COMMON_PRICE_NOTE + " Requires close and volume arrays of the same length.",
+    ),
+    "rsi": CommandMetadata(
+        domains=("technical-indicator",),
+        tags=("momentum",),
+        use_cases=("Measure overbought or oversold momentum from close prices.",),
+        examples=_example("rsi", '{"close":[1,2,3,2,4,5],"timeperiod":14}'),
+        agent_notes=_COMMON_PRICE_NOTE + " Use close prices ordered oldest to newest.",
+    ),
+    "sharpe": CommandMetadata(
+        domains=("portfolio-metric",),
+        tags=("portfolio-risk",),
+        use_cases=("Calculate annualized Sharpe ratio from periodic returns.",),
+        examples=_example("sharpe", '{"returns":[0.01,-0.02,0.015],"risk_free_rate":0,"periods_per_year":252}'),
+        agent_notes="Supply periodic returns through --params-json, not prices. Returns a scalar value.",
+    ),
+    "sma": CommandMetadata(
+        domains=("technical-indicator",),
+        tags=("moving-average", "trend"),
+        use_cases=("Smooth close prices with a simple moving average.",),
+        examples=_example("sma", '{"close":[1,2,3,4,5],"timeperiod":14}'),
+        agent_notes=_COMMON_PRICE_NOTE + " Use close prices ordered oldest to newest.",
+    ),
+    "stoch": CommandMetadata(
+        domains=("technical-indicator",),
+        tags=("momentum",),
+        use_cases=("Calculate stochastic oscillator values from high/low/close OHLCV data.",),
+        examples=_example(
+            "stoch",
+            '{"high":[3,4,5],"low":[1,2,3],"close":[2,3,4],"fastk_period":14,"slowk_period":3,"slowd_period":3}',
+        ),
+        agent_notes=_COMMON_PRICE_NOTE + " Requires high, low, and close arrays of the same length.",
+    ),
+}
+
+
+def get_command_metadata(name: str) -> CommandMetadata:
+    """Return discovery metadata for a TA command name."""
+
+    return _METADATA[name]

--- a/apps/cluefin-ta-cli/src/cluefin_ta_cli/metadata.py
+++ b/apps/cluefin-ta-cli/src/cluefin_ta_cli/metadata.py
@@ -40,8 +40,74 @@ _COMMON_PRICE_NOTE = (
     "Supply price arrays through --params-json. Indicator warm-up periods can return null values in JSON output."
 )
 
-_DOMAIN_TAXONOMY: dict[str, TaxonomyMetadata] = {}
-_TAG_TAXONOMY: dict[str, TaxonomyMetadata] = {}
+_DOMAIN_TAXONOMY: dict[str, TaxonomyMetadata] = {
+    "portfolio-metric": TaxonomyMetadata(
+        name="portfolio-metric",
+        description="Portfolio-level performance metrics calculated from periodic returns.",
+        when_to_use="Use when the input is a return series and the task needs performance-adjusted portfolio evaluation.",
+        avoid_when="Use technical-indicator when the input is OHLCV price data rather than periodic returns.",
+        related_tags=("portfolio-risk",),
+    ),
+    "risk-metric": TaxonomyMetadata(
+        name="risk-metric",
+        description="Risk metrics calculated from returns or drawdown series.",
+        when_to_use="Use when the task asks about downside risk, drawdown, or loss magnitude.",
+        avoid_when="Use volatility tag under technical-indicator when the task needs price-range volatility from OHLCV.",
+        related_tags=("portfolio-risk",),
+    ),
+    "technical-indicator": TaxonomyMetadata(
+        name="technical-indicator",
+        description="Technical analysis indicators calculated from price, volume, or OHLCV arrays.",
+        when_to_use="Use after collecting chart data from cluefin-openapi-cli and extracting arrays for indicator calculation.",
+        avoid_when="Use portfolio-metric or risk-metric when the input is a return series rather than market price arrays.",
+        related_tags=("moving-average", "momentum", "trend", "volatility", "volume-indicator"),
+    ),
+}
+
+_TAG_TAXONOMY: dict[str, TaxonomyMetadata] = {
+    "momentum": TaxonomyMetadata(
+        name="momentum",
+        description="Indicators that measure price momentum or overbought/oversold conditions.",
+        when_to_use="Use for RSI, MACD, STOCH, and ADX-style signal generation after OHLCV collection.",
+        avoid_when="Use moving-average for smoothing and trend-following averages.",
+        related_domains=("technical-indicator",),
+    ),
+    "moving-average": TaxonomyMetadata(
+        name="moving-average",
+        description="Indicators that smooth close prices or derive trend signals from averages.",
+        when_to_use="Use for SMA, EMA, Bollinger middle band, and MACD average components.",
+        avoid_when="Use momentum when the task asks for oscillator-style overbought or oversold signals.",
+        related_domains=("technical-indicator",),
+    ),
+    "portfolio-risk": TaxonomyMetadata(
+        name="portfolio-risk",
+        description="Portfolio risk or performance metrics calculated from periodic returns.",
+        when_to_use="Use for MDD and Sharpe ratio workflows where the input is returns, not prices.",
+        avoid_when="Use volatility when the input is OHLCV high/low/close arrays.",
+        related_domains=("risk-metric", "portfolio-metric"),
+    ),
+    "trend": TaxonomyMetadata(
+        name="trend",
+        description="Indicators that help identify trend direction or trend strength.",
+        when_to_use="Use for moving averages, MACD, and ADX-style trend analysis from price arrays.",
+        avoid_when="Use volume-indicator when the task is primarily about price-volume confirmation.",
+        related_domains=("technical-indicator",),
+    ),
+    "volatility": TaxonomyMetadata(
+        name="volatility",
+        description="Indicators that measure price range or band-based volatility from OHLCV data.",
+        when_to_use="Use for ATR, Bollinger Bands, or ADX contexts when high/low/close arrays are available.",
+        avoid_when="Use portfolio-risk when the task is about return-series drawdown or Sharpe ratio.",
+        related_domains=("technical-indicator",),
+    ),
+    "volume-indicator": TaxonomyMetadata(
+        name="volume-indicator",
+        description="Indicators that combine price movement and volume data.",
+        when_to_use="Use when the task asks whether volume confirms price movement, such as OBV analysis.",
+        avoid_when="Use momentum or moving-average when volume is not part of the input data.",
+        related_domains=("technical-indicator",),
+    ),
+}
 
 _METADATA: dict[str, CommandMetadata] = {
     "adx": CommandMetadata(
@@ -158,3 +224,10 @@ def build_taxonomy_entry(*, kind: str, name: str, command_count: int, app_name: 
         "example_filter": f"uv run {app_name} list --{filter_name} {name} --json",
         "command_count": command_count,
     }
+
+
+def missing_taxonomy_names(*, kind: str, names: set[str]) -> set[str]:
+    """Return taxonomy names that do not have explicit metadata."""
+
+    catalog = _DOMAIN_TAXONOMY if kind == "domains" else _TAG_TAXONOMY
+    return names - set(catalog)

--- a/apps/cluefin-ta-cli/src/cluefin_ta_cli/registry.py
+++ b/apps/cluefin-ta-cli/src/cluefin_ta_cli/registry.py
@@ -59,10 +59,20 @@ class Registry:
     def __init__(self) -> None:
         self._commands = build_registry()
 
-    def list_commands(self, *, category: str | None = None) -> list[CommandSpec]:
+    def list_commands(
+        self,
+        *,
+        category: str | None = None,
+        domain: str | None = None,
+        tag: str | None = None,
+    ) -> list[CommandSpec]:
         commands = list(self._commands.values())
         if category is not None:
             commands = [command for command in commands if command.category == category]
+        if domain is not None:
+            commands = [command for command in commands if domain in command.domains]
+        if tag is not None:
+            commands = [command for command in commands if tag in command.tags]
         return sorted(commands, key=lambda command: command.path_segments)
 
     def resolve_command(self, path_segments: tuple[str, ...]) -> CommandSpec | None:

--- a/apps/cluefin-ta-cli/src/cluefin_ta_cli/registry.py
+++ b/apps/cluefin-ta-cli/src/cluefin_ta_cli/registry.py
@@ -5,6 +5,8 @@ from typing import Any, Callable
 
 import numpy as np
 
+from cluefin_ta_cli.metadata import get_command_metadata
+
 
 def _to_array(data: list[float]) -> np.ndarray:
     """Convert a list of numbers to a numpy float64 array."""
@@ -405,6 +407,7 @@ def build_registry() -> dict[tuple[str, ...], CommandSpec]:
 
     registry: dict[tuple[str, ...], CommandSpec] = {}
     for definition, executor in command_definitions:
+        metadata = get_command_metadata(definition["name"])
         spec = CommandSpec(
             category=definition["category"],
             name=definition["name"],
@@ -412,6 +415,11 @@ def build_registry() -> dict[tuple[str, ...], CommandSpec]:
             path_segments=definition["path_segments"],
             parameters=definition["parameters"],
             returns=definition["returns"],
+            domains=metadata.domains,
+            tags=metadata.tags,
+            use_cases=metadata.use_cases,
+            examples=metadata.examples,
+            agent_notes=metadata.agent_notes,
             executor=executor,
         )
         if spec.path_segments in registry:

--- a/apps/cluefin-ta-cli/src/cluefin_ta_cli/registry.py
+++ b/apps/cluefin-ta-cli/src/cluefin_ta_cli/registry.py
@@ -35,6 +35,11 @@ class CommandSpec:
     path_segments: tuple[str, ...]
     parameters: dict[str, Any] = field(default_factory=dict)
     returns: dict[str, Any] = field(default_factory=dict)
+    domains: tuple[str, ...] = ()
+    tags: tuple[str, ...] = ()
+    use_cases: tuple[str, ...] = ()
+    examples: tuple[dict[str, Any], ...] = ()
+    agent_notes: str | None = None
     executor: Callable[[dict[str, Any]], Any] | None = None
 
     @property

--- a/apps/cluefin-ta-cli/tests/test_main.py
+++ b/apps/cluefin-ta-cli/tests/test_main.py
@@ -28,11 +28,12 @@ def test_describe_returns_command_metadata() -> None:
     command = payload["command"]
 
     assert command["qualified_name"] == "ta.sma"
-    assert command["domains"] == []
-    assert command["tags"] == []
-    assert command["use_cases"] == []
-    assert command["examples"] == []
-    assert command["agent_notes"] is None
+    assert command["domains"] == ["technical-indicator"]
+    assert command["tags"] == ["moving-average", "trend"]
+    assert command["use_cases"]
+    assert command["examples"]
+    assert "--params-json" in command["examples"][0]["command"]
+    assert command["agent_notes"]
 
 
 def test_ta_help_lists_commands() -> None:

--- a/apps/cluefin-ta-cli/tests/test_main.py
+++ b/apps/cluefin-ta-cli/tests/test_main.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+
 from cluefin_ta_cli.main import run_cli
 
 
@@ -22,7 +24,15 @@ def test_describe_returns_command_metadata() -> None:
     result = run_cli(["describe", "ta", "sma", "--json"])
 
     assert result.exit_code == 0
-    assert '"qualified_name": "ta.sma"' in result.stdout
+    payload = json.loads(result.stdout)
+    command = payload["command"]
+
+    assert command["qualified_name"] == "ta.sma"
+    assert command["domains"] == []
+    assert command["tags"] == []
+    assert command["use_cases"] == []
+    assert command["examples"] == []
+    assert command["agent_notes"] is None
 
 
 def test_ta_help_lists_commands() -> None:

--- a/apps/cluefin-ta-cli/tests/test_main.py
+++ b/apps/cluefin-ta-cli/tests/test_main.py
@@ -37,9 +37,18 @@ def test_domains_and_tags_return_discovery_catalogs() -> None:
     tags = run_cli(["tags", "--json"])
 
     assert domains.exit_code == 0
-    assert '"name": "technical-indicator"' in domains.stdout
+    domains_payload = json.loads(domains.stdout)
+    indicator_domain = next(item for item in domains_payload["domains"] if item["name"] == "technical-indicator")
+    assert indicator_domain["description"]
+    assert indicator_domain["when_to_use"]
+    assert indicator_domain["example_filter"] == "uv run cluefin-ta-cli list --domain technical-indicator --json"
     assert tags.exit_code == 0
-    assert '"name": "momentum"' in tags.stdout
+    tags_payload = json.loads(tags.stdout)
+    momentum_tag = next(item for item in tags_payload["tags"] if item["name"] == "momentum")
+    assert momentum_tag["description"]
+    assert momentum_tag["when_to_use"]
+    assert "related_domains" in momentum_tag
+    assert momentum_tag["example_filter"] == "uv run cluefin-ta-cli list --tag momentum --json"
 
 
 def test_describe_returns_command_metadata() -> None:

--- a/apps/cluefin-ta-cli/tests/test_main.py
+++ b/apps/cluefin-ta-cli/tests/test_main.py
@@ -39,16 +39,18 @@ def test_domains_and_tags_return_discovery_catalogs() -> None:
     assert domains.exit_code == 0
     domains_payload = json.loads(domains.stdout)
     indicator_domain = next(item for item in domains_payload["domains"] if item["name"] == "technical-indicator")
-    assert indicator_domain["description"]
-    assert indicator_domain["when_to_use"]
+    assert "OHLCV" in indicator_domain["description"]
+    assert "chart data" in indicator_domain["when_to_use"]
+    assert "portfolio-metric" in indicator_domain["avoid_when"]
+    assert "momentum" in indicator_domain["related_tags"]
     assert indicator_domain["example_filter"] == "uv run cluefin-ta-cli list --domain technical-indicator --json"
     assert tags.exit_code == 0
     tags_payload = json.loads(tags.stdout)
-    momentum_tag = next(item for item in tags_payload["tags"] if item["name"] == "momentum")
-    assert momentum_tag["description"]
-    assert momentum_tag["when_to_use"]
-    assert "related_domains" in momentum_tag
-    assert momentum_tag["example_filter"] == "uv run cluefin-ta-cli list --tag momentum --json"
+    moving_average_tag = next(item for item in tags_payload["tags"] if item["name"] == "moving-average")
+    assert "smooth close prices" in moving_average_tag["description"]
+    assert "SMA" in moving_average_tag["when_to_use"]
+    assert moving_average_tag["related_domains"] == ["technical-indicator"]
+    assert moving_average_tag["example_filter"] == "uv run cluefin-ta-cli list --tag moving-average --json"
 
 
 def test_describe_returns_command_metadata() -> None:

--- a/apps/cluefin-ta-cli/tests/test_main.py
+++ b/apps/cluefin-ta-cli/tests/test_main.py
@@ -20,6 +20,28 @@ def test_list_returns_all_commands() -> None:
     assert '"count": 11' in result.stdout
 
 
+def test_list_filters_by_domain_and_tag() -> None:
+    domain_result = run_cli(["list", "--domain", "risk-metric", "--json"])
+    tag_result = run_cli(["list", "--tag", "moving-average", "--json"])
+
+    assert domain_result.exit_code == 0
+    assert '"domain": "risk-metric"' in domain_result.stdout
+    assert '"qualified_name": "ta.mdd"' in domain_result.stdout
+    assert tag_result.exit_code == 0
+    assert '"tag": "moving-average"' in tag_result.stdout
+    assert '"qualified_name": "ta.sma"' in tag_result.stdout
+
+
+def test_domains_and_tags_return_discovery_catalogs() -> None:
+    domains = run_cli(["domains", "--json"])
+    tags = run_cli(["tags", "--json"])
+
+    assert domains.exit_code == 0
+    assert '"name": "technical-indicator"' in domains.stdout
+    assert tags.exit_code == 0
+    assert '"name": "momentum"' in tags.stdout
+
+
 def test_describe_returns_command_metadata() -> None:
     result = run_cli(["describe", "ta", "sma", "--json"])
 

--- a/apps/cluefin-ta-cli/tests/test_main.py
+++ b/apps/cluefin-ta-cli/tests/test_main.py
@@ -55,7 +55,7 @@ def test_describe_returns_command_metadata() -> None:
     assert command["use_cases"]
     assert command["examples"]
     assert "--params-json" in command["examples"][0]["command"]
-    assert command["agent_notes"]
+    assert "ordered oldest to newest" in command["agent_notes"]
 
 
 def test_ta_help_lists_commands() -> None:
@@ -64,6 +64,14 @@ def test_ta_help_lists_commands() -> None:
     assert result.exit_code == 0
     assert '"commands"' in result.stdout
     assert '"sma"' in result.stdout
+
+
+def test_root_help_mentions_discovery_commands() -> None:
+    result = run_cli(["--help", "--json"])
+
+    assert result.exit_code == 0
+    assert "domains [--json]" in result.stdout
+    assert "list [--domain DOMAIN] [--tag TAG]" in result.stdout
 
 
 def test_leaf_command_merges_flags_and_params_json() -> None:

--- a/apps/cluefin-ta-cli/tests/test_readme_smoke.py
+++ b/apps/cluefin-ta-cli/tests/test_readme_smoke.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from cluefin_ta_cli.main import run_cli
+
+README = Path("apps/cluefin-ta-cli/README.md")
+
+
+def test_readme_mentions_agent_discovery_commands() -> None:
+    content = README.read_text(encoding="utf-8")
+
+    assert "list --domain technical-indicator --json" in content
+    assert "list --tag momentum --json" in content
+    assert "domains --json" in content
+    assert "tags --json" in content
+    assert "agent_notes" in content
+    assert "cluefin-cli" in content
+
+
+def test_readme_discovery_examples_execute() -> None:
+    examples = [
+        ["list", "--domain", "technical-indicator", "--json"],
+        ["list", "--tag", "momentum", "--json"],
+        ["domains", "--json"],
+        ["tags", "--json"],
+        ["describe", "ta", "rsi", "--json"],
+    ]
+
+    for argv in examples:
+        result = run_cli(argv)
+        assert result.exit_code == 0, argv
+        assert result.stdout.strip().startswith("{"), argv

--- a/apps/cluefin-ta-cli/tests/test_readme_smoke.py
+++ b/apps/cluefin-ta-cli/tests/test_readme_smoke.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 from cluefin_ta_cli.main import run_cli
@@ -16,6 +17,13 @@ def test_readme_mentions_agent_discovery_commands() -> None:
     assert "tags --json" in content
     assert "agent_notes" in content
     assert "cluefin-cli" in content
+    assert "`domains`: 업무 영역" in content
+    assert "`tags`: 세부 기능" in content
+    assert "`recipes`: 이 CLI에는 별도 recipe 명령이 없습니다" in content
+    assert "description" in content
+    assert "when_to_use" in content
+    assert "avoid_when" in content
+    assert "example_filter" in content
 
 
 def test_readme_discovery_examples_execute() -> None:
@@ -31,3 +39,19 @@ def test_readme_discovery_examples_execute() -> None:
         result = run_cli(argv)
         assert result.exit_code == 0, argv
         assert result.stdout.strip().startswith("{"), argv
+
+
+def test_readme_taxonomy_examples_match_json_shape() -> None:
+    domains = json.loads(run_cli(["domains", "--json"]).stdout)
+    tags = json.loads(run_cli(["tags", "--json"]).stdout)
+
+    technical_indicator = next(item for item in domains["domains"] if item["name"] == "technical-indicator")
+    moving_average = next(item for item in tags["tags"] if item["name"] == "moving-average")
+
+    assert technical_indicator["description"]
+    assert technical_indicator["when_to_use"]
+    assert "portfolio-metric" in technical_indicator["avoid_when"]
+    assert "moving-average" in technical_indicator["related_tags"]
+    assert technical_indicator["example_filter"] == "uv run cluefin-ta-cli list --domain technical-indicator --json"
+    assert moving_average["related_domains"] == ["technical-indicator"]
+    assert moving_average["example_filter"] == "uv run cluefin-ta-cli list --tag moving-average --json"

--- a/apps/cluefin-ta-cli/tests/test_registry.py
+++ b/apps/cluefin-ta-cli/tests/test_registry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from cluefin_ta_cli.metadata import missing_taxonomy_names
 from cluefin_ta_cli.registry import Registry, build_registry
 
 
@@ -58,6 +59,17 @@ def test_all_commands_have_agent_metadata() -> None:
     assert all(command.use_cases for command in commands)
     assert all(command.examples for command in commands)
     assert all(command.agent_notes for command in commands)
+
+
+def test_ta_taxonomy_catalog_covers_all_real_domains_and_tags() -> None:
+    registry = Registry()
+
+    commands = registry.list_commands(category="ta")
+    domains = {domain for command in commands for domain in command.domains}
+    tags = {tag for command in commands for tag in command.tags}
+
+    assert missing_taxonomy_names(kind="domains", names=domains) == set()
+    assert missing_taxonomy_names(kind="tags", names=tags) == set()
 
 
 def test_registry_filters_by_domain_and_tag() -> None:

--- a/apps/cluefin-ta-cli/tests/test_registry.py
+++ b/apps/cluefin-ta-cli/tests/test_registry.py
@@ -35,17 +35,42 @@ def test_command_spec_qualified_name() -> None:
     assert spec.description == "Simple Moving Average."
 
 
-def test_command_spec_exposes_metadata_defaults() -> None:
+def test_command_spec_exposes_agent_metadata() -> None:
     registry = Registry()
 
     spec = registry.resolve_command(("ta", "sma"))
 
     assert spec is not None
-    assert spec.domains == ()
-    assert spec.tags == ()
-    assert spec.use_cases == ()
-    assert spec.examples == ()
-    assert spec.agent_notes is None
+    assert spec.domains == ("technical-indicator",)
+    assert spec.tags == ("moving-average", "trend")
+    assert spec.use_cases
+    assert spec.examples
+    assert spec.agent_notes
+
+
+def test_all_commands_have_agent_metadata() -> None:
+    registry = Registry()
+
+    commands = registry.list_commands(category="ta")
+
+    assert all(command.domains for command in commands)
+    assert all(command.tags for command in commands)
+    assert all(command.use_cases for command in commands)
+    assert all(command.examples for command in commands)
+    assert all(command.agent_notes for command in commands)
+
+
+def test_representative_ta_tags() -> None:
+    registry = Registry()
+
+    assert {"moving-average", "trend"}.issubset(registry.resolve_command(("ta", "sma")).tags)
+    assert {"moving-average", "trend"}.issubset(registry.resolve_command(("ta", "ema")).tags)
+    assert "momentum" in registry.resolve_command(("ta", "rsi")).tags
+    assert "momentum" in registry.resolve_command(("ta", "macd")).tags
+    assert "momentum" in registry.resolve_command(("ta", "stoch")).tags
+    assert "trend" in registry.resolve_command(("ta", "adx")).tags
+    assert "portfolio-risk" in registry.resolve_command(("ta", "mdd")).tags
+    assert "portfolio-risk" in registry.resolve_command(("ta", "sharpe")).tags
 
 
 def test_registry_paths_are_unique() -> None:

--- a/apps/cluefin-ta-cli/tests/test_registry.py
+++ b/apps/cluefin-ta-cli/tests/test_registry.py
@@ -35,6 +35,19 @@ def test_command_spec_qualified_name() -> None:
     assert spec.description == "Simple Moving Average."
 
 
+def test_command_spec_exposes_metadata_defaults() -> None:
+    registry = Registry()
+
+    spec = registry.resolve_command(("ta", "sma"))
+
+    assert spec is not None
+    assert spec.domains == ()
+    assert spec.tags == ()
+    assert spec.use_cases == ()
+    assert spec.examples == ()
+    assert spec.agent_notes is None
+
+
 def test_registry_paths_are_unique() -> None:
     registry = build_registry()
 

--- a/apps/cluefin-ta-cli/tests/test_registry.py
+++ b/apps/cluefin-ta-cli/tests/test_registry.py
@@ -60,6 +60,18 @@ def test_all_commands_have_agent_metadata() -> None:
     assert all(command.agent_notes for command in commands)
 
 
+def test_registry_filters_by_domain_and_tag() -> None:
+    registry = Registry()
+
+    assert [command.name for command in registry.list_commands(category="ta", domain="risk-metric")] == ["mdd"]
+    assert {command.name for command in registry.list_commands(category="ta", tag="moving-average")} == {
+        "bbands",
+        "ema",
+        "macd",
+        "sma",
+    }
+
+
 def test_representative_ta_tags() -> None:
     registry = Registry()
 

--- a/docs/plan/agent-cli-discovery-prd.md
+++ b/docs/plan/agent-cli-discovery-prd.md
@@ -245,7 +245,7 @@ Completion Rule:
 
 ### Phase 3: cluefin-ta-cli Domain/Tag Metadata
 
-Status: `pending`
+Status: `completed`
 
 Tasks:
 

--- a/docs/plan/agent-cli-discovery-prd.md
+++ b/docs/plan/agent-cli-discovery-prd.md
@@ -277,7 +277,7 @@ Completion Rule:
 
 ### Phase 4: Domain/Tag Discovery Commands
 
-Status: `pending`
+Status: `completed`
 
 Tasks:
 

--- a/docs/plan/agent-cli-discovery-prd.md
+++ b/docs/plan/agent-cli-discovery-prd.md
@@ -348,7 +348,7 @@ Completion Rule:
 
 ### Phase 6: Workflow Recipes
 
-Status: `pending`
+Status: `completed`
 
 Tasks:
 

--- a/docs/plan/agent-cli-discovery-prd.md
+++ b/docs/plan/agent-cli-discovery-prd.md
@@ -1,0 +1,466 @@
+# Agent-Friendly CLI Discovery PRD
+
+## Summary
+
+`cluefin-cli`를 고수준 wrapper로 유지하거나 확장하는 대신, Agent가 `cluefin-openapi-cli`와 `cluefin-ta-cli`를 직접 탐색하고 조합해서 사용할 수 있도록 두 CLI를 machine-readable catalog로 강화한다.
+
+핵심 목표는 다음과 같다.
+
+- `cluefin-openapi-cli`의 183개 command 전체에 `domain`, `tag`, `use_case`, `examples`, `agent_notes` metadata를 부여한다.
+- `cluefin-ta-cli`의 11개 command 전체에 `domain`, `tag`, `use_case`, `examples`, `agent_notes` metadata를 부여한다.
+- Agent가 domain/tag 기반으로 필요한 command를 찾을 수 있도록 discovery 명령을 추가한다.
+- Agent가 대표 업무 흐름을 이해할 수 있도록 workflow recipe를 JSON으로 제공한다.
+
+## Problem
+
+현재 두 CLI는 이미 JSON 기반 탐색을 일부 지원한다.
+
+```bash
+uv run cluefin-openapi-cli list --json
+uv run cluefin-openapi-cli describe kis stock current-price --json
+uv run cluefin-ta-cli list --json
+uv run cluefin-ta-cli describe ta rsi --json
+```
+
+하지만 Agent가 실제로 활용하기에는 다음 정보가 부족하다.
+
+- 어떤 command가 `chart`, `statements`, `trading-flow`, `market` 같은 업무 domain에 해당하는지 알기 어렵다.
+- provider SDK 구조의 `category`와 Agent 작업 의도의 `domain`이 다르다.
+- command별 사용 예시와 입력 힌트가 부족하다.
+- 여러 command를 조합하는 대표 workflow가 없다.
+
+## Goals
+
+- Agent가 command catalog를 JSON으로 탐색할 수 있다.
+- Agent가 `domain` 또는 `tag`로 command를 필터링할 수 있다.
+- `describe --json` 결과에 examples와 agent_notes가 포함된다.
+- 모든 command가 최소 1개 이상의 domain과 tag를 가진다.
+- 대표 workflow recipe가 JSON으로 제공된다.
+- 기존 command 실행 표면과 command 수를 유지한다.
+
+## Non-Goals
+
+- 이번 작업에서 `cluefin-cli`를 삭제하지 않는다.
+- 이번 작업에서 workflow recipe를 자동 실행하지 않는다.
+- 이번 작업에서 broker API 응답 스키마를 재설계하지 않는다.
+- 이번 작업에서 실제 API 통합 테스트를 강제하지 않는다.
+
+## Terminology
+
+- `category`: provider SDK 또는 기존 CLI command 구조의 분류. 예: `kis analysis`, `kiwoom ranking`.
+- `domain`: Agent 작업 의도 기준 분류. 예: `chart`, `trading-flow`, `corporate-actions`.
+- `tag`: 세부 기능 키워드. 예: `ohlcv`, `foreign`, `dividend`, `momentum`.
+- `recipe`: Agent가 여러 command를 조합할 때 참고하는 workflow guide. 실행 기능이 아니라 discovery metadata다.
+
+## Target CLI UX
+
+### cluefin-openapi-cli
+
+```bash
+uv run cluefin-openapi-cli domains --json
+uv run cluefin-openapi-cli tags --json
+uv run cluefin-openapi-cli list --domain chart --json
+uv run cluefin-openapi-cli list --tag ohlcv --json
+uv run cluefin-openapi-cli list --broker kis --domain market --json
+uv run cluefin-openapi-cli describe kis chart period --json
+uv run cluefin-openapi-cli recipes --json
+uv run cluefin-openapi-cli recipe stock-research --json
+```
+
+### cluefin-ta-cli
+
+```bash
+uv run cluefin-ta-cli domains --json
+uv run cluefin-ta-cli tags --json
+uv run cluefin-ta-cli list --domain technical-indicator --json
+uv run cluefin-ta-cli list --tag momentum --json
+uv run cluefin-ta-cli describe ta rsi --json
+```
+
+## Metadata Schema
+
+`CommandSpec`에 다음 필드를 추가한다.
+
+```python
+domains: tuple[str, ...] = ()
+tags: tuple[str, ...] = ()
+use_cases: tuple[str, ...] = ()
+examples: tuple[dict[str, Any], ...] = ()
+agent_notes: str | None = None
+```
+
+`cluefin-openapi-cli`는 다음 필드를 추가로 가진다.
+
+```python
+required_credentials: tuple[str, ...] = ()
+side_effect: str = "read"
+```
+
+`side_effect`는 v1에서 모든 command를 `read`로 둔다.
+
+## Domain Taxonomy
+
+초기 domain 목록은 다음을 기본값으로 한다.
+
+- `statements`
+- `chart`
+- `news`
+- `trading-flow`
+- `market`
+- `quote`
+- `sector`
+- `theme`
+- `corporate-actions`
+- `market-calendar`
+- `etf`
+- `technical-indicator`
+- `risk-metric`
+- `portfolio-metric`
+
+## Tag Taxonomy
+
+초기 tag 목록은 다음을 기본값으로 한다.
+
+- `ohlcv`
+- `daily`
+- `minute`
+- `tick`
+- `current-price`
+- `order-book`
+- `conclusion`
+- `overtime`
+- `financial-statement`
+- `financial-ratio`
+- `dividend`
+- `shareholder`
+- `disclosure`
+- `announcement`
+- `foreign`
+- `institution`
+- `program-trading`
+- `ranking`
+- `volume-rank`
+- `market-cap`
+- `short-selling`
+- `credit`
+- `sector-index`
+- `theme-group`
+- `ipo`
+- `capital-increase`
+- `capital-reduction`
+- `merger-split`
+- `shareholder-meeting`
+- `moving-average`
+- `momentum`
+- `volatility`
+- `volume-indicator`
+- `portfolio-risk`
+
+## Implementation Strategy
+
+### Metadata Location
+
+Handler decorator 183개를 직접 수정하지 않는다. 대신 별도 metadata module을 둔다.
+
+```text
+apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
+apps/cluefin-ta-cli/src/cluefin_ta_cli/metadata.py
+```
+
+`cluefin-openapi-cli`는 command 수가 많기 때문에 rule + override 방식으로 구성한다.
+
+- broker/category 기반 default rule
+- command path 기반 override
+- 모든 command coverage 테스트
+
+`cluefin-ta-cli`는 11개 command만 있으므로 수동 metadata map을 둔다.
+
+## Phases
+
+### Phase 1: CommandSpec Metadata Foundation
+
+Status: `completed`
+
+Tasks:
+
+- `cluefin-openapi-cli` `CommandSpec`에 metadata 필드를 추가한다.
+- `cluefin-ta-cli` `CommandSpec`에 metadata 필드를 추가한다.
+- `_command_summary()`가 metadata 필드를 JSON에 포함하도록 수정한다.
+- 기존 `list --json`, `describe --json` 동작과 command count를 유지한다.
+
+Acceptance Criteria:
+
+- 기존 openapi CLI command count `183` 유지.
+- 기존 ta CLI command count `11` 유지.
+- `describe --json`에 `domains`, `tags`, `use_cases`, `examples`, `agent_notes` 필드가 포함된다.
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-openapi-cli/tests -v
+uv run pytest apps/cluefin-ta-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- 수정 코드 검증 테스트를 추가한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+### Phase 2: cluefin-openapi-cli Domain/Tag Metadata
+
+Status: `pending`
+
+Tasks:
+
+- `cluefin_openapi_cli/metadata.py`를 추가한다.
+- 183개 command 전체에 최소 1개 domain과 tag가 부여되도록 rule과 override를 작성한다.
+- KIS, Kiwoom, DART command별 domain/tag 분류를 정리한다.
+- required credentials와 side effect metadata를 추가한다.
+
+Acceptance Criteria:
+
+- 모든 openapi command가 `domains`와 `tags`를 가진다.
+- category와 domain이 분리되어 표현된다.
+- 주요 command가 기대 domain에 매핑된다.
+  - `kis.chart.period` -> `chart`
+  - `kis.market.announcement` -> `news`, `market`
+  - `kis.schedule.dividend` -> `corporate-actions`
+  - `kiwoom.theme.group` -> `theme`, `market`
+  - `dart.disclosure-search` -> `news`, `statements`
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-openapi-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- 모든 command metadata coverage 테스트를 추가한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+### Phase 3: cluefin-ta-cli Domain/Tag Metadata
+
+Status: `pending`
+
+Tasks:
+
+- `cluefin_ta_cli/metadata.py`를 추가한다.
+- 11개 command 전체에 domain/tag/use_case/examples/agent_notes를 부여한다.
+- TA command별 입력 요구사항을 agent_notes에 명확히 기록한다.
+
+Acceptance Criteria:
+
+- 모든 TA command가 `domains`와 `tags`를 가진다.
+- `sma`, `ema`는 `moving-average`, `trend` 태그를 가진다.
+- `rsi`, `macd`, `stoch`, `adx`는 `momentum` 또는 `trend` 태그를 가진다.
+- `bbands`, `atr`은 `volatility` 태그를 가진다.
+- `obv`는 `volume-indicator` 태그를 가진다.
+- `mdd`, `sharpe`는 `portfolio-risk` 또는 `portfolio-metric` domain을 가진다.
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-ta-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- 모든 TA command metadata coverage 테스트를 추가한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+### Phase 4: Domain/Tag Discovery Commands
+
+Status: `pending`
+
+Tasks:
+
+- `cluefin-openapi-cli list --domain`, `list --tag` 필터를 추가한다.
+- `cluefin-ta-cli list --domain`, `list --tag` 필터를 추가한다.
+- 두 CLI에 `domains --json`, `tags --json` 명령을 추가한다.
+- 필터 조합은 AND 조건으로 처리한다.
+
+Acceptance Criteria:
+
+- 아래 명령이 JSON으로 동작한다.
+
+```bash
+uv run cluefin-openapi-cli list --domain chart --json
+uv run cluefin-openapi-cli list --tag ohlcv --json
+uv run cluefin-openapi-cli domains --json
+uv run cluefin-openapi-cli tags --json
+uv run cluefin-ta-cli list --domain technical-indicator --json
+uv run cluefin-ta-cli list --tag momentum --json
+uv run cluefin-ta-cli domains --json
+uv run cluefin-ta-cli tags --json
+```
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-openapi-cli/tests -v
+uv run pytest apps/cluefin-ta-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- CLI JSON output 테스트를 추가한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+### Phase 5: Examples and Agent Notes
+
+Status: `pending`
+
+Tasks:
+
+- `describe --json` 결과에 examples와 agent_notes를 포함한다.
+- openapi command는 provider별 params-json 예시를 포함한다.
+- ta command는 배열 입력이 `--params-json`으로 들어가야 함을 예시에 포함한다.
+- root/help JSON에 discovery 명령 사용법을 갱신한다.
+
+Acceptance Criteria:
+
+- `describe kis chart period --json`에 실행 가능한 example skeleton이 포함된다.
+- `describe ta rsi --json`에 close 배열 입력 예시가 포함된다.
+- `agent_notes`는 Agent가 API 선택 시 주의해야 할 조건을 설명한다.
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-openapi-cli/tests -v
+uv run pytest apps/cluefin-ta-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- describe metadata 테스트를 추가한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+### Phase 6: Workflow Recipes
+
+Status: `pending`
+
+Tasks:
+
+- `cluefin-openapi-cli`에 recipe metadata를 추가한다.
+- `recipes --json` 명령을 추가한다.
+- `recipe <name> --json` 명령을 추가한다.
+- recipe가 참조하는 command가 실제 registry에 존재하는지 테스트한다.
+
+Initial Recipes:
+
+- `stock-research`
+- `technical-analysis`
+- `market-scan`
+- `corporate-actions`
+- `disclosure-monitoring`
+
+Acceptance Criteria:
+
+- 아래 명령이 JSON으로 동작한다.
+
+```bash
+uv run cluefin-openapi-cli recipes --json
+uv run cluefin-openapi-cli recipe stock-research --json
+```
+
+- 각 recipe는 steps, command references, purpose, expected inputs를 포함한다.
+- recipe는 실행하지 않고 Agent guide 역할만 한다.
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-openapi-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- recipe command와 reference 검증 테스트를 추가한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+### Phase 7: Documentation and Migration Guidance
+
+Status: `pending`
+
+Tasks:
+
+- `cluefin-openapi-cli` README에 domain/tag discovery 사용법을 추가한다.
+- `cluefin-ta-cli` README에 domain/tag discovery 사용법을 추가한다.
+- Agent가 두 CLI를 조합하는 예시 workflow를 문서화한다.
+- `cluefin-cli` 삭제 또는 deprecation은 후속 PR로 분리한다.
+
+Acceptance Criteria:
+
+- README에 `list --domain`, `list --tag`, `domains`, `tags`, `recipes`, `recipe` 예시가 포함된다.
+- `cluefin-cli` 삭제는 이번 PR 범위가 아님을 명시한다.
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-openapi-cli/tests -v
+uv run pytest apps/cluefin-ta-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- 문서 예시와 CLI 명령이 어긋나지 않도록 smoke test를 추가한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+## Test Requirements
+
+각 phase는 수정 범위에 맞는 테스트를 반드시 추가한다.
+
+Minimum Tests:
+
+- command count 유지 테스트
+- 모든 command metadata coverage 테스트
+- `list --domain` 필터 테스트
+- `list --tag` 필터 테스트
+- `domains --json` 테스트
+- `tags --json` 테스트
+- `describe --json` metadata 테스트
+- recipe 목록/상세 테스트
+- recipe command reference 유효성 테스트
+
+## Phase Completion Policy
+
+각 phase가 끝날 때 반드시 아래 순서를 따른다.
+
+1. 수정된 코드를 검증할 수 있는 테스트 코드 추가
+2. 관련 테스트 실행
+3. 전체 포맷 및 린트 실행
+
+```bash
+uvx ruff format .
+uvx ruff check .
+```
+
+4. 모든 검증 통과 확인
+5. `/commit` 실행
+
+검증 실패 시 `/commit`을 실행하지 않는다.
+
+## Tracking
+
+진행 상태는 [feature_list.json](./feature_list.json)에서 관리한다.
+
+상태 값:
+
+- `pending`: 아직 시작하지 않음
+- `in_progress`: 진행 중
+- `blocked`: 외부 결정 또는 선행 작업이 필요함
+- `completed`: 구현, 테스트, format/check, commit 완료

--- a/docs/plan/agent-cli-discovery-prd.md
+++ b/docs/plan/agent-cli-discovery-prd.md
@@ -392,7 +392,7 @@ Completion Rule:
 
 ### Phase 7: Documentation and Migration Guidance
 
-Status: `pending`
+Status: `completed`
 
 Tasks:
 

--- a/docs/plan/agent-cli-discovery-prd.md
+++ b/docs/plan/agent-cli-discovery-prd.md
@@ -210,7 +210,7 @@ Completion Rule:
 
 ### Phase 2: cluefin-openapi-cli Domain/Tag Metadata
 
-Status: `pending`
+Status: `completed`
 
 Tasks:
 

--- a/docs/plan/agent-cli-discovery-prd.md
+++ b/docs/plan/agent-cli-discovery-prd.md
@@ -317,7 +317,7 @@ Completion Rule:
 
 ### Phase 5: Examples and Agent Notes
 
-Status: `pending`
+Status: `completed`
 
 Tasks:
 

--- a/docs/plan/agent-cli-taxonomy-discovery-prd.md
+++ b/docs/plan/agent-cli-taxonomy-discovery-prd.md
@@ -1,0 +1,342 @@
+# Agent CLI Taxonomy Discovery PRD
+
+## Summary
+
+`cluefin-openapi-cli`와 `cluefin-ta-cli`는 현재 `domains --json`, `tags --json`를 제공하지만 각 항목은 `name`과 `command_count` 중심이다. Agent가 domain/tag 이름만 보고도 어느 정도 추론할 수는 있으나, `ohlcv`, `program-trading`, `corporate-actions`, `portfolio-risk`처럼 약어 또는 시장 용어가 섞이면 오해 가능성이 있다.
+
+이번 개선은 domain/tag catalog 자체를 Agent가 해석 가능한 지식 베이스로 만드는 것이다. `domains --json`, `tags --json`에 설명, 사용 시점, 관련 분류, 대표 command, 예시 필터를 추가한다. 기존 command 실행 표면은 유지한다.
+
+## Problem
+
+현재 discovery 흐름은 다음처럼 동작한다.
+
+```bash
+uv run cluefin-openapi-cli domains --json
+uv run cluefin-openapi-cli tags --json
+uv run cluefin-ta-cli domains --json
+uv run cluefin-ta-cli tags --json
+```
+
+하지만 응답이 사실상 아래 정보에 머문다.
+
+```json
+{
+  "name": "chart",
+  "command_count": 8
+}
+```
+
+Agent 입장에서 부족한 점은 다음과 같다.
+
+- `domain`과 `tag`의 의미 차이를 응답만 보고 확정하기 어렵다.
+- `tag`는 세부 키워드라 이름만으로 사용 시점을 알기 어렵다.
+- `tags --json`에서 어떤 domain과 연결되는지 바로 알 수 없다.
+- Agent가 다음 탐색 명령을 만들기 위한 `example_filter`가 없다.
+- 잘못된 domain/tag 선택을 줄여 줄 `when_to_use`, `avoid_when` 같은 힌트가 없다.
+
+## Goals
+
+- `domains --json`이 각 domain의 의미와 사용 시점을 설명한다.
+- `tags --json`이 각 tag의 의미, 관련 domain, 사용 시점을 설명한다.
+- Agent가 응답만 보고 다음 `list --domain` 또는 `list --tag` 명령을 구성할 수 있다.
+- 기존 `domains --json`, `tags --json`의 `name`, `command_count` 호환성을 유지한다.
+- `cluefin-openapi-cli`와 `cluefin-ta-cli`가 같은 taxonomy schema를 사용한다.
+- 모든 실제 domain/tag가 taxonomy 설명 metadata를 가진다는 테스트를 추가한다.
+
+## Non-Goals
+
+- command별 domain/tag 재분류는 이번 범위가 아니다.
+- recipe 자동 실행은 이번 범위가 아니다.
+- API 응답 데이터 스키마 정규화는 이번 범위가 아니다.
+- `apps/cluefin-cli` 삭제는 이번 범위가 아니다.
+
+## Target CLI UX
+
+### Domains
+
+```bash
+uv run cluefin-openapi-cli domains --json
+uv run cluefin-ta-cli domains --json
+```
+
+예상 응답 형태:
+
+```json
+{
+  "domains": [
+    {
+      "name": "chart",
+      "description": "가격, 거래량, OHLCV 시계열 데이터를 조회하는 command 그룹",
+      "when_to_use": "기술적 분석, 가격 추세, 거래량 분석 전 원천 시계열 데이터가 필요할 때 사용",
+      "avoid_when": "이미 OHLCV 배열을 확보했고 지표 계산만 필요하면 cluefin-ta-cli의 technical-indicator domain을 사용",
+      "related_tags": ["ohlcv", "daily", "minute", "tick"],
+      "example_filter": "uv run cluefin-openapi-cli list --domain chart --json",
+      "command_count": 8
+    }
+  ],
+  "count": 1
+}
+```
+
+### Tags
+
+```bash
+uv run cluefin-openapi-cli tags --json
+uv run cluefin-ta-cli tags --json
+```
+
+예상 응답 형태:
+
+```json
+{
+  "tags": [
+    {
+      "name": "ohlcv",
+      "description": "open, high, low, close, volume 형태의 가격/거래량 데이터",
+      "when_to_use": "TA 지표 계산에 필요한 원천 가격 배열을 찾을 때 사용",
+      "avoid_when": "이미 지표 값만 필요하고 가격 데이터 조회가 필요 없으면 moving-average, momentum 같은 TA tag 사용",
+      "related_domains": ["chart", "technical-indicator"],
+      "example_filter": "uv run cluefin-openapi-cli list --tag ohlcv --json",
+      "command_count": 6
+    }
+  ],
+  "count": 1
+}
+```
+
+## Metadata Schema
+
+두 CLI에서 공유할 taxonomy item shape:
+
+```python
+name: str
+description: str
+when_to_use: str
+avoid_when: str | None
+related_domains: tuple[str, ...]
+related_tags: tuple[str, ...]
+example_filter: str
+command_count: int
+```
+
+`domains --json`에서는 `related_tags`가 중요하고, `tags --json`에서는 `related_domains`가 중요하다. 호환성을 위해 두 필드는 모두 포함한다.
+
+## Taxonomy Coverage
+
+초기 구현은 현재 사용 중인 domain/tag 전체를 대상으로 한다.
+
+Domain examples:
+
+- `statements`
+- `chart`
+- `news`
+- `trading-flow`
+- `market`
+- `quote`
+- `sector`
+- `theme`
+- `corporate-actions`
+- `market-calendar`
+- `etf`
+- `technical-indicator`
+- `risk-metric`
+- `portfolio-metric`
+
+Tag examples:
+
+- `ohlcv`
+- `daily`
+- `minute`
+- `tick`
+- `current-price`
+- `order-book`
+- `financial-statement`
+- `financial-ratio`
+- `dividend`
+- `disclosure`
+- `announcement`
+- `foreign`
+- `institution`
+- `program-trading`
+- `ranking`
+- `volume-rank`
+- `market-cap`
+- `short-selling`
+- `credit`
+- `sector-index`
+- `theme-group`
+- `moving-average`
+- `momentum`
+- `volatility`
+- `volume-indicator`
+- `portfolio-risk`
+
+## Implementation Strategy
+
+### Shared Shape, Local Modules
+
+두 앱은 별도 패키지이므로 공통 package를 새로 만들지 않는다. 대신 각 앱의 metadata module에 taxonomy catalog를 둔다.
+
+```text
+apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
+apps/cluefin-ta-cli/src/cluefin_ta_cli/metadata.py
+```
+
+각 module은 다음 기능을 제공한다.
+
+- domain taxonomy lookup
+- tag taxonomy lookup
+- command 목록에서 실제 count 계산
+- 누락 taxonomy 검증 helper
+
+### Response Construction
+
+`domains --json`, `tags --json`는 기존처럼 registry의 실제 command를 기준으로 count를 계산한다. 여기에 taxonomy catalog 설명을 merge한다.
+
+기존 필드:
+
+- `name`
+- `command_count`
+
+추가 필드:
+
+- `description`
+- `when_to_use`
+- `avoid_when`
+- `related_domains`
+- `related_tags`
+- `example_filter`
+
+## Phases
+
+### Phase 1: Taxonomy Metadata Foundation
+
+Status: `completed`
+
+Tasks:
+
+- OpenAPI CLI taxonomy item dataclass 또는 typed dict를 추가한다.
+- TA CLI taxonomy item dataclass 또는 typed dict를 추가한다.
+- `domains --json`, `tags --json` 응답 shape를 확장한다.
+- 기존 `name`, `command_count`, `count` 필드 호환성을 유지한다.
+
+Acceptance Criteria:
+
+- 두 CLI의 `domains --json`가 `description`, `when_to_use`, `example_filter`를 포함한다.
+- 두 CLI의 `tags --json`가 `description`, `when_to_use`, `related_domains`, `example_filter`를 포함한다.
+- 기존 테스트가 깨지지 않는다.
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-openapi-cli/tests -v
+uv run pytest apps/cluefin-ta-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- 수정 코드 검증 테스트를 추가한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+### Phase 2: OpenAPI Domain/Tag Descriptions
+
+Status: `pending`
+
+Tasks:
+
+- `cluefin-openapi-cli`의 실제 domain 전체에 설명을 추가한다.
+- `cluefin-openapi-cli`의 실제 tag 전체에 설명을 추가한다.
+- domain별 `related_tags`를 정리한다.
+- tag별 `related_domains`를 정리한다.
+- 모든 실제 domain/tag가 catalog에 존재하는 coverage 테스트를 추가한다.
+
+Acceptance Criteria:
+
+- OpenAPI CLI의 모든 실제 domain에 설명 metadata가 있다.
+- OpenAPI CLI의 모든 실제 tag에 설명 metadata가 있다.
+- `ohlcv`, `program-trading`, `corporate-actions`, `market-calendar`, `sector-index`, `theme-group` 설명이 명확하다.
+- `example_filter`가 실제 실행 가능한 command 형태다.
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-openapi-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- coverage 테스트와 대표 응답 테스트를 추가한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+### Phase 3: TA Domain/Tag Descriptions
+
+Status: `pending`
+
+Tasks:
+
+- `cluefin-ta-cli`의 실제 domain 전체에 설명을 추가한다.
+- `cluefin-ta-cli`의 실제 tag 전체에 설명을 추가한다.
+- `technical-indicator`, `risk-metric`, `portfolio-metric`의 차이를 명확히 한다.
+- `moving-average`, `momentum`, `volatility`, `volume-indicator`, `portfolio-risk` 설명을 추가한다.
+- 모든 실제 domain/tag가 catalog에 존재하는 coverage 테스트를 추가한다.
+
+Acceptance Criteria:
+
+- TA CLI의 모든 실제 domain에 설명 metadata가 있다.
+- TA CLI의 모든 실제 tag에 설명 metadata가 있다.
+- Agent가 `technical-indicator`와 `portfolio-metric`을 혼동하지 않도록 `when_to_use`와 `avoid_when`이 제공된다.
+- `moving-average`, `momentum`, `volatility`는 OHLCV 입력과의 관계가 설명된다.
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-ta-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- coverage 테스트와 대표 응답 테스트를 추가한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+### Phase 4: Agent-Focused Response Tests and Docs
+
+Status: `pending`
+
+Tasks:
+
+- README에 enhanced taxonomy discovery 예시를 추가한다.
+- `domains --json`, `tags --json` smoke test를 README 예시와 연결한다.
+- Agent workflow 문서에서 `domains`, `tags`, `recipes`의 역할 차이를 명확히 한다.
+- 기존 recipe 설명과 taxonomy 설명이 서로 충돌하지 않는지 점검한다.
+
+Acceptance Criteria:
+
+- README 예시가 실제 CLI에서 실행된다.
+- 문서에 `domains = 업무 영역`, `tags = 세부 기능`, `recipes = workflow guide`가 명시된다.
+- Agent가 domain/tag catalog 응답만 보고 다음 `list` 명령을 만들 수 있다.
+
+Verification:
+
+```bash
+uv run pytest apps/cluefin-openapi-cli/tests -v
+uv run pytest apps/cluefin-ta-cli/tests -v
+uvx ruff format .
+uvx ruff check .
+```
+
+Completion Rule:
+
+- README smoke test를 추가하거나 기존 테스트를 확장한다.
+- 모든 테스트와 format/check가 통과하면 `/commit`을 실행한다.
+
+## Open Questions
+
+- `avoid_when`을 필수 필드로 둘지, 값이 없을 때 `null`을 허용할지 결정해야 한다.
+- OpenAPI CLI와 TA CLI의 taxonomy 설명을 완전히 동일한 문구로 맞출지, 앱별 맥락에 맞춰 다르게 둘지 결정해야 한다.
+- 향후 `recipes --json`에도 관련 `domains`, `tags`의 상세 설명을 embed할지 검토가 필요하다.

--- a/docs/plan/agent-cli-taxonomy-discovery-prd.md
+++ b/docs/plan/agent-cli-taxonomy-discovery-prd.md
@@ -242,7 +242,7 @@ Completion Rule:
 
 ### Phase 2: OpenAPI Domain/Tag Descriptions
 
-Status: `pending`
+Status: `completed`
 
 Tasks:
 

--- a/docs/plan/agent-cli-taxonomy-discovery-prd.md
+++ b/docs/plan/agent-cli-taxonomy-discovery-prd.md
@@ -306,7 +306,7 @@ Completion Rule:
 
 ### Phase 4: Agent-Focused Response Tests and Docs
 
-Status: `pending`
+Status: `completed`
 
 Tasks:
 

--- a/docs/plan/agent-cli-taxonomy-discovery-prd.md
+++ b/docs/plan/agent-cli-taxonomy-discovery-prd.md
@@ -274,7 +274,7 @@ Completion Rule:
 
 ### Phase 3: TA Domain/Tag Descriptions
 
-Status: `pending`
+Status: `completed`
 
 Tasks:
 

--- a/docs/plan/feature_list.json
+++ b/docs/plan/feature_list.json
@@ -90,7 +90,7 @@
     {
       "id": "phase-3",
       "title": "cluefin-ta-cli domain and tag metadata",
-      "status": "pending",
+      "status": "completed",
       "scope": [
         "metadata.py for 11 TA commands",
         "technical-indicator, risk-metric, portfolio-metric domains",
@@ -100,17 +100,17 @@
         {
           "id": "phase-3-task-1",
           "title": "Add ta metadata module",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-3-task-2",
           "title": "Add metadata for all 11 TA commands",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-3-task-3",
           "title": "Add TA metadata coverage tests",
-          "status": "pending"
+          "status": "completed"
         }
       ],
       "verification": [

--- a/docs/plan/feature_list.json
+++ b/docs/plan/feature_list.json
@@ -165,7 +165,7 @@
     {
       "id": "phase-5",
       "title": "Examples and agent notes",
-      "status": "pending",
+      "status": "completed",
       "scope": [
         "examples in describe JSON",
         "agent_notes in describe JSON",
@@ -175,22 +175,22 @@
         {
           "id": "phase-5-task-1",
           "title": "Add executable example skeletons to openapi metadata",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-5-task-2",
           "title": "Add params-json examples to ta metadata",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-5-task-3",
           "title": "Update root/help JSON discovery usage",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-5-task-4",
           "title": "Add describe metadata tests",
-          "status": "pending"
+          "status": "completed"
         }
       ],
       "verification": [

--- a/docs/plan/feature_list.json
+++ b/docs/plan/feature_list.json
@@ -53,7 +53,7 @@
     {
       "id": "phase-2",
       "title": "cluefin-openapi-cli domain and tag metadata",
-      "status": "pending",
+      "status": "completed",
       "scope": [
         "metadata.py with rule and override mapping",
         "183 openapi commands covered by at least one domain and tag",
@@ -63,22 +63,22 @@
         {
           "id": "phase-2-task-1",
           "title": "Add openapi metadata module",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-2-task-2",
           "title": "Add default broker/category metadata rules",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-2-task-3",
           "title": "Add command-level overrides for ambiguous APIs",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-2-task-4",
           "title": "Add all-command domain/tag coverage tests",
-          "status": "pending"
+          "status": "completed"
         }
       ],
       "verification": [

--- a/docs/plan/feature_list.json
+++ b/docs/plan/feature_list.json
@@ -203,7 +203,7 @@
     {
       "id": "phase-6",
       "title": "Workflow recipes",
-      "status": "pending",
+      "status": "completed",
       "scope": [
         "openapi recipe metadata",
         "recipes --json command",
@@ -214,22 +214,22 @@
         {
           "id": "phase-6-task-1",
           "title": "Add recipes module",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-6-task-2",
           "title": "Add recipes list/detail commands",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-6-task-3",
           "title": "Add initial recipes",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-6-task-4",
           "title": "Add recipe reference tests",
-          "status": "pending"
+          "status": "completed"
         }
       ],
       "initial_recipes": [

--- a/docs/plan/feature_list.json
+++ b/docs/plan/feature_list.json
@@ -1,6 +1,6 @@
 {
   "project": "agent-friendly-cli-discovery",
-  "status": "pending",
+  "status": "completed",
   "updated_at": "2026-05-21",
   "completion_policy": {
     "phase_end_commands": [
@@ -248,7 +248,7 @@
     {
       "id": "phase-7",
       "title": "Documentation and migration guidance",
-      "status": "pending",
+      "status": "completed",
       "scope": [
         "openapi CLI README discovery docs",
         "ta CLI README discovery docs",
@@ -259,22 +259,22 @@
         {
           "id": "phase-7-task-1",
           "title": "Update cluefin-openapi-cli README",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-7-task-2",
           "title": "Update cluefin-ta-cli README",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-7-task-3",
           "title": "Add agent workflow examples",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-7-task-4",
           "title": "Add README smoke tests",
-          "status": "pending"
+          "status": "completed"
         }
       ],
       "verification": [

--- a/docs/plan/feature_list.json
+++ b/docs/plan/feature_list.json
@@ -1,0 +1,288 @@
+{
+  "project": "agent-friendly-cli-discovery",
+  "status": "pending",
+  "updated_at": "2026-05-21",
+  "completion_policy": {
+    "phase_end_commands": [
+      "uvx ruff format .",
+      "uvx ruff check ."
+    ],
+    "requires_tests": true,
+    "requires_test_execution": true,
+    "commit_rule": "Run /commit only after phase tests, uvx ruff format ., and uvx ruff check . all pass."
+  },
+  "phases": [
+    {
+      "id": "phase-1",
+      "title": "CommandSpec metadata foundation",
+      "status": "completed",
+      "scope": [
+        "cluefin-openapi-cli CommandSpec metadata fields",
+        "cluefin-ta-cli CommandSpec metadata fields",
+        "describe/list JSON summary metadata output"
+      ],
+      "tasks": [
+        {
+          "id": "phase-1-task-1",
+          "title": "Extend openapi CommandSpec",
+          "status": "completed"
+        },
+        {
+          "id": "phase-1-task-2",
+          "title": "Extend ta CommandSpec",
+          "status": "completed"
+        },
+        {
+          "id": "phase-1-task-3",
+          "title": "Add metadata fields to command summaries",
+          "status": "completed"
+        },
+        {
+          "id": "phase-1-task-4",
+          "title": "Preserve existing command counts and JSON outputs",
+          "status": "completed"
+        }
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-openapi-cli/tests -v",
+        "uv run pytest apps/cluefin-ta-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    },
+    {
+      "id": "phase-2",
+      "title": "cluefin-openapi-cli domain and tag metadata",
+      "status": "pending",
+      "scope": [
+        "metadata.py with rule and override mapping",
+        "183 openapi commands covered by at least one domain and tag",
+        "required credentials and read side effect metadata"
+      ],
+      "tasks": [
+        {
+          "id": "phase-2-task-1",
+          "title": "Add openapi metadata module",
+          "status": "pending"
+        },
+        {
+          "id": "phase-2-task-2",
+          "title": "Add default broker/category metadata rules",
+          "status": "pending"
+        },
+        {
+          "id": "phase-2-task-3",
+          "title": "Add command-level overrides for ambiguous APIs",
+          "status": "pending"
+        },
+        {
+          "id": "phase-2-task-4",
+          "title": "Add all-command domain/tag coverage tests",
+          "status": "pending"
+        }
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-openapi-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    },
+    {
+      "id": "phase-3",
+      "title": "cluefin-ta-cli domain and tag metadata",
+      "status": "pending",
+      "scope": [
+        "metadata.py for 11 TA commands",
+        "technical-indicator, risk-metric, portfolio-metric domains",
+        "TA input requirements in agent notes"
+      ],
+      "tasks": [
+        {
+          "id": "phase-3-task-1",
+          "title": "Add ta metadata module",
+          "status": "pending"
+        },
+        {
+          "id": "phase-3-task-2",
+          "title": "Add metadata for all 11 TA commands",
+          "status": "pending"
+        },
+        {
+          "id": "phase-3-task-3",
+          "title": "Add TA metadata coverage tests",
+          "status": "pending"
+        }
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-ta-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    },
+    {
+      "id": "phase-4",
+      "title": "Domain and tag discovery commands",
+      "status": "pending",
+      "scope": [
+        "list --domain and list --tag filters",
+        "domains --json command",
+        "tags --json command"
+      ],
+      "tasks": [
+        {
+          "id": "phase-4-task-1",
+          "title": "Add openapi list domain/tag filters",
+          "status": "pending"
+        },
+        {
+          "id": "phase-4-task-2",
+          "title": "Add ta list domain/tag filters",
+          "status": "pending"
+        },
+        {
+          "id": "phase-4-task-3",
+          "title": "Add openapi domains/tags commands",
+          "status": "pending"
+        },
+        {
+          "id": "phase-4-task-4",
+          "title": "Add ta domains/tags commands",
+          "status": "pending"
+        },
+        {
+          "id": "phase-4-task-5",
+          "title": "Add CLI JSON discovery tests",
+          "status": "pending"
+        }
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-openapi-cli/tests -v",
+        "uv run pytest apps/cluefin-ta-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    },
+    {
+      "id": "phase-5",
+      "title": "Examples and agent notes",
+      "status": "pending",
+      "scope": [
+        "examples in describe JSON",
+        "agent_notes in describe JSON",
+        "root/help discovery usage updates"
+      ],
+      "tasks": [
+        {
+          "id": "phase-5-task-1",
+          "title": "Add executable example skeletons to openapi metadata",
+          "status": "pending"
+        },
+        {
+          "id": "phase-5-task-2",
+          "title": "Add params-json examples to ta metadata",
+          "status": "pending"
+        },
+        {
+          "id": "phase-5-task-3",
+          "title": "Update root/help JSON discovery usage",
+          "status": "pending"
+        },
+        {
+          "id": "phase-5-task-4",
+          "title": "Add describe metadata tests",
+          "status": "pending"
+        }
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-openapi-cli/tests -v",
+        "uv run pytest apps/cluefin-ta-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    },
+    {
+      "id": "phase-6",
+      "title": "Workflow recipes",
+      "status": "pending",
+      "scope": [
+        "openapi recipe metadata",
+        "recipes --json command",
+        "recipe <name> --json command",
+        "recipe command reference validation"
+      ],
+      "tasks": [
+        {
+          "id": "phase-6-task-1",
+          "title": "Add recipes module",
+          "status": "pending"
+        },
+        {
+          "id": "phase-6-task-2",
+          "title": "Add recipes list/detail commands",
+          "status": "pending"
+        },
+        {
+          "id": "phase-6-task-3",
+          "title": "Add initial recipes",
+          "status": "pending"
+        },
+        {
+          "id": "phase-6-task-4",
+          "title": "Add recipe reference tests",
+          "status": "pending"
+        }
+      ],
+      "initial_recipes": [
+        "stock-research",
+        "technical-analysis",
+        "market-scan",
+        "corporate-actions",
+        "disclosure-monitoring"
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-openapi-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    },
+    {
+      "id": "phase-7",
+      "title": "Documentation and migration guidance",
+      "status": "pending",
+      "scope": [
+        "openapi CLI README discovery docs",
+        "ta CLI README discovery docs",
+        "agent workflow examples",
+        "cluefin-cli deletion deferred note"
+      ],
+      "tasks": [
+        {
+          "id": "phase-7-task-1",
+          "title": "Update cluefin-openapi-cli README",
+          "status": "pending"
+        },
+        {
+          "id": "phase-7-task-2",
+          "title": "Update cluefin-ta-cli README",
+          "status": "pending"
+        },
+        {
+          "id": "phase-7-task-3",
+          "title": "Add agent workflow examples",
+          "status": "pending"
+        },
+        {
+          "id": "phase-7-task-4",
+          "title": "Add README smoke tests",
+          "status": "pending"
+        }
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-openapi-cli/tests -v",
+        "uv run pytest apps/cluefin-ta-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    }
+  ]
+}

--- a/docs/plan/feature_list.json
+++ b/docs/plan/feature_list.json
@@ -122,7 +122,7 @@
     {
       "id": "phase-4",
       "title": "Domain and tag discovery commands",
-      "status": "pending",
+      "status": "completed",
       "scope": [
         "list --domain and list --tag filters",
         "domains --json command",
@@ -132,27 +132,27 @@
         {
           "id": "phase-4-task-1",
           "title": "Add openapi list domain/tag filters",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-4-task-2",
           "title": "Add ta list domain/tag filters",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-4-task-3",
           "title": "Add openapi domains/tags commands",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-4-task-4",
           "title": "Add ta domains/tags commands",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-4-task-5",
           "title": "Add CLI JSON discovery tests",
-          "status": "pending"
+          "status": "completed"
         }
       ],
       "verification": [

--- a/docs/plan/taxonomy_feature_list.json
+++ b/docs/plan/taxonomy_feature_list.json
@@ -1,6 +1,6 @@
 {
   "project": "agent-cli-taxonomy-discovery",
-  "status": "pending",
+  "status": "completed",
   "updated_at": "2026-05-21",
   "completion_policy": {
     "phase_end_commands": [
@@ -130,7 +130,7 @@
     {
       "id": "phase-4",
       "title": "Agent-focused response tests and docs",
-      "status": "pending",
+      "status": "completed",
       "scope": [
         "README enhanced taxonomy examples",
         "README smoke tests",
@@ -141,22 +141,22 @@
         {
           "id": "phase-4-task-1",
           "title": "Update OpenAPI CLI README examples",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-4-task-2",
           "title": "Update TA CLI README examples",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-4-task-3",
           "title": "Document domains/tags/recipes differences",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-4-task-4",
           "title": "Add or extend README smoke tests",
-          "status": "pending"
+          "status": "completed"
         }
       ],
       "verification": [

--- a/docs/plan/taxonomy_feature_list.json
+++ b/docs/plan/taxonomy_feature_list.json
@@ -54,7 +54,7 @@
     {
       "id": "phase-2",
       "title": "OpenAPI domain and tag descriptions",
-      "status": "pending",
+      "status": "completed",
       "scope": [
         "OpenAPI domain descriptions",
         "OpenAPI tag descriptions",
@@ -65,22 +65,22 @@
         {
           "id": "phase-2-task-1",
           "title": "Add descriptions for OpenAPI domains",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-2-task-2",
           "title": "Add descriptions for OpenAPI tags",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-2-task-3",
           "title": "Add related taxonomy mappings",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-2-task-4",
           "title": "Add OpenAPI taxonomy coverage tests",
-          "status": "pending"
+          "status": "completed"
         }
       ],
       "verification": [

--- a/docs/plan/taxonomy_feature_list.json
+++ b/docs/plan/taxonomy_feature_list.json
@@ -92,7 +92,7 @@
     {
       "id": "phase-3",
       "title": "TA domain and tag descriptions",
-      "status": "pending",
+      "status": "completed",
       "scope": [
         "TA domain descriptions",
         "TA tag descriptions",
@@ -103,22 +103,22 @@
         {
           "id": "phase-3-task-1",
           "title": "Add descriptions for TA domains",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-3-task-2",
           "title": "Add descriptions for TA tags",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-3-task-3",
           "title": "Add TA usage and avoid guidance",
-          "status": "pending"
+          "status": "completed"
         },
         {
           "id": "phase-3-task-4",
           "title": "Add TA taxonomy coverage tests",
-          "status": "pending"
+          "status": "completed"
         }
       ],
       "verification": [

--- a/docs/plan/taxonomy_feature_list.json
+++ b/docs/plan/taxonomy_feature_list.json
@@ -1,0 +1,170 @@
+{
+  "project": "agent-cli-taxonomy-discovery",
+  "status": "pending",
+  "updated_at": "2026-05-21",
+  "completion_policy": {
+    "phase_end_commands": [
+      "uvx ruff format .",
+      "uvx ruff check ."
+    ],
+    "requires_tests": true,
+    "requires_test_execution": true,
+    "commit_rule": "Run /commit only after phase tests, uvx ruff format ., and uvx ruff check . all pass."
+  },
+  "phases": [
+    {
+      "id": "phase-1",
+      "title": "Taxonomy metadata foundation",
+      "status": "completed",
+      "scope": [
+        "OpenAPI CLI taxonomy item schema",
+        "TA CLI taxonomy item schema",
+        "domains/tags JSON response expansion",
+        "backward-compatible name and command_count fields"
+      ],
+      "tasks": [
+        {
+          "id": "phase-1-task-1",
+          "title": "Add OpenAPI taxonomy metadata shape",
+          "status": "completed"
+        },
+        {
+          "id": "phase-1-task-2",
+          "title": "Add TA taxonomy metadata shape",
+          "status": "completed"
+        },
+        {
+          "id": "phase-1-task-3",
+          "title": "Expand domains/tags response fields",
+          "status": "completed"
+        },
+        {
+          "id": "phase-1-task-4",
+          "title": "Add backward compatibility tests",
+          "status": "completed"
+        }
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-openapi-cli/tests -v",
+        "uv run pytest apps/cluefin-ta-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    },
+    {
+      "id": "phase-2",
+      "title": "OpenAPI domain and tag descriptions",
+      "status": "pending",
+      "scope": [
+        "OpenAPI domain descriptions",
+        "OpenAPI tag descriptions",
+        "related_tags and related_domains",
+        "all actual OpenAPI domains/tags covered"
+      ],
+      "tasks": [
+        {
+          "id": "phase-2-task-1",
+          "title": "Add descriptions for OpenAPI domains",
+          "status": "pending"
+        },
+        {
+          "id": "phase-2-task-2",
+          "title": "Add descriptions for OpenAPI tags",
+          "status": "pending"
+        },
+        {
+          "id": "phase-2-task-3",
+          "title": "Add related taxonomy mappings",
+          "status": "pending"
+        },
+        {
+          "id": "phase-2-task-4",
+          "title": "Add OpenAPI taxonomy coverage tests",
+          "status": "pending"
+        }
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-openapi-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    },
+    {
+      "id": "phase-3",
+      "title": "TA domain and tag descriptions",
+      "status": "pending",
+      "scope": [
+        "TA domain descriptions",
+        "TA tag descriptions",
+        "technical-indicator/risk-metric/portfolio-metric distinction",
+        "all actual TA domains/tags covered"
+      ],
+      "tasks": [
+        {
+          "id": "phase-3-task-1",
+          "title": "Add descriptions for TA domains",
+          "status": "pending"
+        },
+        {
+          "id": "phase-3-task-2",
+          "title": "Add descriptions for TA tags",
+          "status": "pending"
+        },
+        {
+          "id": "phase-3-task-3",
+          "title": "Add TA usage and avoid guidance",
+          "status": "pending"
+        },
+        {
+          "id": "phase-3-task-4",
+          "title": "Add TA taxonomy coverage tests",
+          "status": "pending"
+        }
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-ta-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    },
+    {
+      "id": "phase-4",
+      "title": "Agent-focused response tests and docs",
+      "status": "pending",
+      "scope": [
+        "README enhanced taxonomy examples",
+        "README smoke tests",
+        "domains/tags/recipes role guidance",
+        "taxonomy and recipe consistency check"
+      ],
+      "tasks": [
+        {
+          "id": "phase-4-task-1",
+          "title": "Update OpenAPI CLI README examples",
+          "status": "pending"
+        },
+        {
+          "id": "phase-4-task-2",
+          "title": "Update TA CLI README examples",
+          "status": "pending"
+        },
+        {
+          "id": "phase-4-task-3",
+          "title": "Document domains/tags/recipes differences",
+          "status": "pending"
+        },
+        {
+          "id": "phase-4-task-4",
+          "title": "Add or extend README smoke tests",
+          "status": "pending"
+        }
+      ],
+      "verification": [
+        "uv run pytest apps/cluefin-openapi-cli/tests -v",
+        "uv run pytest apps/cluefin-ta-cli/tests -v",
+        "uvx ruff format .",
+        "uvx ruff check ."
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Agent가 `cluefin-openapi-cli`와 `cluefin-ta-cli`를 JSON discovery로 탐색할 수 있도록 domain/tag/recipe 메타데이터를 강화했습니다.
- `describe --json`, `domains --json`, `tags --json`, workflow recipe를 통해 command 선택과 실행 skeleton 파악이 쉬워졌습니다.
- 구현 계획과 진행 상태를 `docs/plan` PRD와 feature list로 기록했습니다.

## Related Issue / Context
- N/A

## What Changed
- OpenAPI CLI와 TA CLI에 command metadata, domain/tag 필터, taxonomy 설명 응답을 추가했습니다.
- OpenAPI CLI에 workflow recipe discovery를 추가했습니다.
- `describe --json` 응답에 examples, use_cases, agent_notes, credential/side-effect 정보를 포함했습니다.
- 모든 command가 최소 1개 domain/tag를 갖는지, taxonomy catalog가 실제 domain/tag를 모두 커버하는지 테스트를 추가했습니다.
- README에 agent discovery 흐름과 domains/tags/recipes 역할 차이를 문서화했습니다.

## Verification
- `uv run pytest apps/cluefin-openapi-cli/tests -v`
- Result: pass, 110 passed
- `uv run pytest apps/cluefin-ta-cli/tests -v`
- Result: pass, 27 passed
- `uvx ruff format .`
- Result: pass, 327 files left unchanged
- `uvx ruff check .`
- Result: pass, All checks passed
- `git push -u origin feat/cli-domain-tag`
- Result: pass, pre-push python-test 1407 passed, 476 deselected, 2 warnings

## Breaking Changes / Migration Notes
- None
