### PR TITLE
fix: KIS 토큰 캐시를 환경/앱키별로 분리

### DIFF
--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_auth.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_auth.py
@@ -23,7 +23,7 @@ class Auth:
         self.app_key = app_key
         self.secret_key = secret_key
         self.env = env
-        self.token_manager = token_manager or TokenManager(cache_dir=cache_dir)
+        self.token_manager = token_manager or TokenManager(cache_dir=cache_dir, env=env, app_key=app_key)
         self._token_data: Optional[TokenResponse] = None
 
         if env == "prod":

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_token_manager.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_token_manager.py
@@ -1,5 +1,6 @@
 """Token manager for KIS API authentication with local caching."""
 
+import hashlib
 from datetime import datetime, timedelta
 from pathlib import Path
 from tempfile import gettempdir
@@ -31,17 +32,38 @@ class TokenManager:
         """Return a writable fallback cache directory for token storage."""
         return Path(gettempdir()) / "cluefin-openapi"
 
-    def __init__(self, cache_dir: Optional[str] = None):
+    @staticmethod
+    def _cache_file_name(env: Optional[str], app_key: Optional[str]) -> str:
+        """Build an environment- and credential-scoped cache file name.
+
+        Tokens are not interchangeable between the real (prod) and mock (dev)
+        servers, nor between different app keys. Scoping the cache file prevents
+        a token minted for one environment/credential from being reused against
+        another (which the server rejects with EGW00123 "기간이 만료된 token").
+        """
+        parts = []
+        if env:
+            parts.append(env)
+        if app_key:
+            parts.append(hashlib.sha256(app_key.encode()).hexdigest()[:8])
+        suffix = ("_" + "_".join(parts)) if parts else ""
+        return f".kis_token_cache{suffix}.json"
+
+    def __init__(self, cache_dir: Optional[str] = None, env: Optional[str] = None, app_key: Optional[str] = None):
         """Initialize token manager.
 
         Args:
             cache_dir: Directory to store token cache. Defaults to a writable cache directory.
+            env: Target environment ("dev" or "prod"). Scopes the cache file so
+                dev and prod tokens are never mixed.
+            app_key: KIS app key. Scopes the cache file so different credentials
+                do not share a token.
         """
         if cache_dir is None:
             cache_dir = str(self._default_cache_dir())
 
         self.cache_dir = Path(cache_dir)
-        self.cache_file = self.cache_dir / ".kis_token_cache.json"
+        self.cache_file = self.cache_dir / self._cache_file_name(env, app_key)
 
         # In-memory cache
         self._token_cache: Optional[TokenResponse] = None


### PR DESCRIPTION
## 배경

KIS 통합 테스트를 `KIS_ENV=dev`(모의투자)에서 실행하면 prod 전용 TR(`CT*` 등) 17개가 실패합니다. `KIS_ENV=prod`로 전환해 확인하던 중, 일부 테스트가 `EGW00123 기간이 만료된 token` 오류로 실패하는 **실제 버그**를 발견했습니다.

## 원인

`TokenManager`가 토큰을 `.kis_token_cache.json` **단일 파일**에만 캐싱하고, 환경(dev/prod)이나 app_key로 구분하지 않았습니다. 그 결과 dev에서 발급받은 토큰이 prod 호출에 재사용되어 서버가 거부했습니다.

## 변경

- `_token_manager.py`: 캐시 파일명을 `env` + `app_key` 해시로 스코프 (`.kis_token_cache_{env}_{hash}.json`). env/app_key 미지정 시 기존 파일명 유지(하위 호환).
- `_auth.py`: `TokenManager` 생성 시 `env`, `app_key` 전달.

이제 dev↔prod 전환이나 자격증명 변경 시 토큰이 섞이지 않습니다.

## 검증

- TokenManager / Auth 유닛 테스트 24개 통과
- prod에서 기존 실패 17개 통합 테스트 전부 통과