### PR TITLE
feat: 키움 API 서버 오류코드 관리 및 에러 로깅 추가

### DIFF
--- a/packages/cluefin-openapi-ts/src/core/errors.ts
+++ b/packages/cluefin-openapi-ts/src/core/errors.ts
@@ -3,12 +3,15 @@ export interface ApiErrorDetails {
   responseData?: unknown;
   requestContext?: Record<string, unknown> | undefined;
   retryAfter?: number | undefined;
+  errorCode?: number | string | undefined;
 }
 
 export class ApiError extends Error {
   public readonly statusCode?: number | undefined;
   public readonly responseData?: unknown;
   public readonly requestContext?: Record<string, unknown> | undefined;
+  /** Broker-reported error code (e.g. Kiwoom body return_code), when available. */
+  public readonly errorCode?: number | string | undefined;
 
   public constructor(message: string, details: ApiErrorDetails = {}) {
     super(message);
@@ -16,6 +19,7 @@ export class ApiError extends Error {
     this.statusCode = details.statusCode;
     this.responseData = details.responseData;
     this.requestContext = details.requestContext;
+    this.errorCode = details.errorCode;
   }
 }
 

--- a/packages/cluefin-openapi-ts/src/core/logger.ts
+++ b/packages/cluefin-openapi-ts/src/core/logger.ts
@@ -5,9 +5,15 @@ export interface Logger {
 }
 
 export const consoleLogger: Logger = {
-  debug: (message, context) => console.debug(message, context ?? ''),
-  warn: (message, context) => console.warn(message, context ?? ''),
-  error: (message, context) => console.error(message, context ?? ''),
+  debug: (message, context) => {
+    console.debug(message, context ?? '');
+  },
+  warn: (message, context) => {
+    console.warn(message, context ?? '');
+  },
+  error: (message, context) => {
+    console.error(message, context ?? '');
+  },
 };
 
 export const silentLogger: Logger = {

--- a/packages/cluefin-openapi-ts/src/core/logger.ts
+++ b/packages/cluefin-openapi-ts/src/core/logger.ts
@@ -1,0 +1,17 @@
+export interface Logger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+export const consoleLogger: Logger = {
+  debug: (message, context) => console.debug(message, context ?? ''),
+  warn: (message, context) => console.warn(message, context ?? ''),
+  error: (message, context) => console.error(message, context ?? ''),
+};
+
+export const silentLogger: Logger = {
+  debug: () => undefined,
+  warn: () => undefined,
+  error: () => undefined,
+};

--- a/packages/cluefin-openapi-ts/src/index.ts
+++ b/packages/cluefin-openapi-ts/src/index.ts
@@ -24,6 +24,8 @@ export {
   KiwoomTimeoutError,
   KiwoomValidationError,
 } from './core/errors';
+export type { Logger } from './core/logger';
+export { consoleLogger, silentLogger } from './core/logger';
 export type {
   ApiEnv,
   ApiResponse,

--- a/packages/cluefin-openapi-ts/src/kiwoom/client.ts
+++ b/packages/cluefin-openapi-ts/src/kiwoom/client.ts
@@ -18,6 +18,7 @@ import {
   KiwoomValidationError,
 } from '../core/errors';
 import { BaseHttpClient } from '../core/http';
+import { consoleLogger, type Logger } from '../core/logger';
 import type { ApiEnv, ApiResponse, KiwoomEndpointDefinition } from '../core/types';
 import { createInputSchema, kiwoomEnvelopeSchema } from '../core/validation';
 import { DomesticAccount } from './domestic-account';
@@ -30,6 +31,7 @@ import { DomesticRankInfo } from './domestic-rank-info';
 import { DomesticSector } from './domestic-sector';
 import { DomesticStockInfo } from './domestic-stock-info';
 import { DomesticTheme } from './domestic-theme';
+import { parseKiwoomReturnCode, resolveKiwoomError } from './error-codes';
 
 export interface KiwoomClientOptions {
   token: string;
@@ -40,6 +42,8 @@ export interface KiwoomClientOptions {
   rateLimitRequestsPerSecond?: number;
   rateLimitBurst?: number;
   fetchImpl?: typeof fetch;
+  /** Sink for API error logs. Defaults to the console; pass `silentLogger` to mute. */
+  logger?: Logger;
 }
 
 const getBaseUrl = (env: ApiEnv): string => (env === 'prod' ? 'https://api.kiwoom.com' : 'https://mockapi.kiwoom.com');
@@ -47,7 +51,16 @@ const getBaseUrl = (env: ApiEnv): string => (env === 'prod' ? 'https://api.kiwoo
 const stringifyParam = (value: unknown): string => (typeof value === 'string' ? value : String(value));
 
 const mapKiwoomError = (error: unknown): never => {
-  if (error instanceof KiwoomApiError) {
+  if (
+    error instanceof KiwoomApiError ||
+    error instanceof KiwoomValidationError ||
+    error instanceof KiwoomAuthenticationError ||
+    error instanceof KiwoomAuthorizationError ||
+    error instanceof KiwoomRateLimitError ||
+    error instanceof KiwoomServerError ||
+    error instanceof KiwoomTimeoutError ||
+    error instanceof KiwoomNetworkError
+  ) {
     throw error;
   }
   if (error instanceof ApiValidationError) {
@@ -77,10 +90,33 @@ const mapKiwoomError = (error: unknown): never => {
   throw new KiwoomApiError(error instanceof Error ? error.message : 'Unknown Kiwoom client error');
 };
 
+// HTTP-status errors from the base client may still carry an API 서버 오류코드 in
+// the body; prefer that code's typed error, mirroring the Python client.
+const enrichWithReturnCode = (error: unknown, requestContext: Record<string, unknown>): unknown => {
+  if (!(error instanceof ApiError) || error.errorCode !== undefined) {
+    return error;
+  }
+  const body = error.responseData;
+  if (typeof body !== 'object' || body === null) {
+    return error;
+  }
+  const returnCode = parseKiwoomReturnCode((body as Record<string, unknown>).return_code);
+  if (returnCode === undefined || returnCode === 0) {
+    return error;
+  }
+  const returnMsg = (body as Record<string, unknown>).return_msg;
+  return resolveKiwoomError(returnCode, typeof returnMsg === 'string' ? returnMsg : undefined, {
+    statusCode: error.statusCode,
+    responseData: body,
+    requestContext,
+  });
+};
+
 export class KiwoomClient {
   private readonly baseUrl: string;
   private readonly http: BaseHttpClient;
   private readonly token: string;
+  private readonly logger: Logger;
 
   private domesticAccountInstance?: DomesticAccount;
   private domesticChartInstance?: DomesticChart;
@@ -97,6 +133,7 @@ export class KiwoomClient {
     const env = options.env ?? 'dev';
     this.baseUrl = getBaseUrl(env);
     this.token = options.token;
+    this.logger = options.logger ?? consoleLogger;
     this.http = new BaseHttpClient(
       {
         timeoutMs: options.timeoutMs ?? 30_000,
@@ -230,7 +267,18 @@ export class KiwoomClient {
       });
 
       const rawJson = await response.json();
-      kiwoomEnvelopeSchema.parse(rawJson);
+      const envelope = kiwoomEnvelopeSchema.parse(rawJson);
+
+      // Kiwoom can report API 서버 오류코드 in the body of an HTTP 200 response.
+      const returnCode = parseKiwoomReturnCode(envelope.return_code);
+      if (returnCode !== undefined && returnCode !== 0) {
+        throw resolveKiwoomError(returnCode, envelope.return_msg, {
+          statusCode: response.status,
+          responseData: rawJson,
+          requestContext: { apiId: definition.apiId, path: definition.path },
+        });
+      }
+
       if (definition.responseSchema) {
         definition.responseSchema.parse(rawJson);
       }
@@ -240,7 +288,14 @@ export class KiwoomClient {
         body: camelizeKeys(rawJson),
       };
     } catch (error) {
-      return mapKiwoomError(error);
+      const enriched = enrichWithReturnCode(error, { apiId: definition.apiId, path: definition.path });
+      this.logger.error('Kiwoom API request failed', {
+        apiId: definition.apiId,
+        path: definition.path,
+        message: enriched instanceof Error ? enriched.message : String(enriched),
+        ...(enriched instanceof ApiError && enriched.errorCode !== undefined ? { returnCode: enriched.errorCode } : {}),
+      });
+      return mapKiwoomError(enriched);
     }
   }
 }

--- a/packages/cluefin-openapi-ts/src/kiwoom/error-codes.ts
+++ b/packages/cluefin-openapi-ts/src/kiwoom/error-codes.ts
@@ -16,7 +16,7 @@ import {
  * for both token endpoints and TR endpoints. Placeholders `{?}` are filled by
  * the server in `return_msg`; these entries serve as fallbacks.
  */
-export const KIWOOM_ERROR_CODES: Readonly<Record<number, string>> = {
+export const KIWOOM_ERROR_CODES: Readonly<Partial<Record<number, string>>> = {
   1501: 'API ID가 Null이거나 값이 없습니다',
   1504: '해당 URI에서는 지원하는 API ID가 아닙니다. API ID={?}, URI={?}',
   1505: '해당 API ID는 존재하지 않습니다. API ID={?}',

--- a/packages/cluefin-openapi-ts/src/kiwoom/error-codes.ts
+++ b/packages/cluefin-openapi-ts/src/kiwoom/error-codes.ts
@@ -1,0 +1,108 @@
+import {
+  type ApiError,
+  type ApiErrorDetails,
+  KiwoomApiError,
+  KiwoomAuthenticationError,
+  KiwoomAuthorizationError,
+  KiwoomRateLimitError,
+  KiwoomServerError,
+  KiwoomValidationError,
+} from '../core/errors';
+
+/**
+ * Kiwoom API 서버 오류코드 registry.
+ *
+ * Kiwoom reports these codes in the response body (`return_code` / `return_msg`)
+ * for both token endpoints and TR endpoints. Placeholders `{?}` are filled by
+ * the server in `return_msg`; these entries serve as fallbacks.
+ */
+export const KIWOOM_ERROR_CODES: Readonly<Record<number, string>> = {
+  1501: 'API ID가 Null이거나 값이 없습니다',
+  1504: '해당 URI에서는 지원하는 API ID가 아닙니다. API ID={?}, URI={?}',
+  1505: '해당 API ID는 존재하지 않습니다. API ID={?}',
+  1511: '필수 입력 값에 값이 존재하지 않습니다. 필수입력 파라미터={?}',
+  1512: 'Http header에 값이 설정되지 않았거나 읽을 수 없습니다',
+  1513: 'Http Header에 authorization 필드가 설정되어 있어야 합니다',
+  1514: '입력으로 들어온 Http Header의 authorization 필드 형식이 맞지 않습니다',
+  1515: 'Http Header의 authorization 필드 내 Grant Type이 미리 정의된 형식이 아닙니다',
+  1516: 'Http Header의 authorization 필드 내 Token이 정의되어 있지 않습니다',
+  1517: '입력 값 형식이 올바르지 않습니다. 파라미터={?} 실패사유={?}',
+  1687: '재귀 호출이 발생하여 API 호출을 제한합니다, API ID={?}',
+  1700: '허용된 API 요청 개수를 초과하였습니다. 유량={?}, API ID={?}',
+  1701: '허용된 전체 요청 개수를 초과하였습니다. 총유량={?}',
+  1702: '허용된 그룹 요청 개수를 초과하였습니다. 총유량={?}, API_ID={?}',
+  1901: '시장 코드값이 존재하지 않습니다. 종목코드={?}',
+  1902: '종목 정보가 없습니다. 입력한 종목코드 값을 확인바랍니다. 종목코드={?}',
+  1903: '종목 정보가 없습니다. 입력한 종목코드, 거래소구분 값을 확인바랍니다. 거래소구분={?}, 종목코드={?}',
+  1999: '예기치 못한 에러가 발생했습니다. 실패사유={?}',
+  8001: 'App Key와 Secret Key 검증에 실패했습니다',
+  8002: 'App Key와 Secret Key 검증에 실패했습니다. 실패사유={?}',
+  8003: 'Access Token을 조회하는데 실패했습니다. 실패사유={?}',
+  8005: 'Token이 유효하지 않습니다',
+  8006: 'Access Token을 생성하는데 실패했습니다. 실패사유={?}',
+  8009: 'Access Token을 발급하는데 실패했습니다. 실패사유={?}',
+  8010: 'Token을 발급받은 IP와 서비스를 요청한 IP가 동일하지 않습니다',
+  8011: 'Access Token을 발급하는데 실패했습니다. 입력값에 grant_type이 들어오지 않았습니다',
+  8012: 'Access Token을 발급하는데 실패했습니다. grant_type의 값이 맞지 않습니다',
+  8015: 'Access Token을 폐기하는데 실패했습니다. 실패사유={?}',
+  8016: 'Access Token을 폐기하는데 실패했습니다. 입력값에 Token이 들어오지 않았습니다',
+  8020: '입력파라미터로 appkey 또는 secretkey가 들어오지 않았습니다.',
+  8030: '투자구분(실전/모의)이 달라서 Appkey를 사용할수가 없습니다',
+  8031: '투자구분(실전/모의)이 달라서 Token를 사용할수가 없습니다',
+  8040: '단말기 인증에 실패했습니다',
+  8050: '지정단말기 인증에 실패했습니다',
+  8103: '토큰 인증 또는 단말기인증에 실패했습니다. 실패사유={?}',
+  8104: '모의투자에서 지원하지 않는 API 입니다.',
+  8200: '법인 고객은 해당 API를 지원하지 않습니다. API ID={?}, URI={?}',
+};
+
+const VALIDATION_CODES = new Set([1501, 1504, 1505, 1511, 1512, 1517, 1901, 1902, 1903]);
+const AUTH_CODES = new Set([
+  1513, 1514, 1515, 1516, 8001, 8002, 8003, 8005, 8006, 8009, 8010, 8011, 8012, 8015, 8016, 8020, 8030, 8031, 8040,
+  8050, 8103,
+]);
+const AUTHZ_CODES = new Set([8104, 8200]);
+const RATE_LIMIT_CODES = new Set([1687, 1700, 1701, 1702]);
+const SERVER_CODES = new Set([1999]);
+
+/** Coerce a body return_code (number or numeric string) to a number, else undefined. */
+export const parseKiwoomReturnCode = (value: unknown): number | undefined => {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number.parseInt(value.trim(), 10);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+};
+
+/** Build the typed Kiwoom error for a non-zero body return_code. */
+export const resolveKiwoomError = (
+  returnCode: number,
+  returnMsg?: string | undefined,
+  details: ApiErrorDetails = {},
+): ApiError => {
+  // The server-provided return_msg wins over the registry fallback because it
+  // carries the filled-in placeholders (API ID, 파라미터, 실패사유 등).
+  // eslint-disable-next-line security/detect-object-injection -- returnCode is a parsed number.
+  const message = `Kiwoom API error ${returnCode}: ${returnMsg ?? KIWOOM_ERROR_CODES[returnCode] ?? '알 수 없는 오류입니다'}`;
+  const errorDetails: ApiErrorDetails = { ...details, errorCode: returnCode };
+
+  if (VALIDATION_CODES.has(returnCode)) {
+    return new KiwoomValidationError(message, errorDetails);
+  }
+  if (AUTH_CODES.has(returnCode)) {
+    return new KiwoomAuthenticationError(message, errorDetails);
+  }
+  if (AUTHZ_CODES.has(returnCode)) {
+    return new KiwoomAuthorizationError(message, errorDetails);
+  }
+  if (RATE_LIMIT_CODES.has(returnCode)) {
+    return new KiwoomRateLimitError(message, errorDetails);
+  }
+  if (SERVER_CODES.has(returnCode)) {
+    return new KiwoomServerError(message, errorDetails);
+  }
+  return new KiwoomApiError(message, errorDetails);
+};

--- a/packages/cluefin-openapi-ts/src/kiwoom/index.ts
+++ b/packages/cluefin-openapi-ts/src/kiwoom/index.ts
@@ -2,6 +2,7 @@ export type { KiwoomAuthOptions, KiwoomTokenResponse } from './auth';
 export { KiwoomAuth } from './auth';
 export type { KiwoomClientOptions } from './client';
 export { KiwoomClient } from './client';
+export { KIWOOM_ERROR_CODES, parseKiwoomReturnCode, resolveKiwoomError } from './error-codes';
 export type {
   AccountCurrentDayStatusResponse,
   AccountEvaluationBalanceDetailsResponse,

--- a/packages/cluefin-openapi-ts/tests/kiwoom/error-codes.test.ts
+++ b/packages/cluefin-openapi-ts/tests/kiwoom/error-codes.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  KiwoomApiError,
+  KiwoomAuthenticationError,
+  KiwoomAuthorizationError,
+  KiwoomRateLimitError,
+  KiwoomServerError,
+  KiwoomValidationError,
+} from '../../src/core/errors';
+import type { Logger } from '../../src/core/logger';
+import type { KiwoomEndpointDefinition } from '../../src/core/types';
+import { KiwoomClient } from '../../src/kiwoom/client';
+import { KIWOOM_ERROR_CODES, parseKiwoomReturnCode, resolveKiwoomError } from '../../src/kiwoom/error-codes';
+
+const DOCUMENTED_CODES = [
+  1501, 1504, 1505, 1511, 1512, 1513, 1514, 1515, 1516, 1517, 1687, 1700, 1701, 1702, 1901, 1902, 1903, 1999, 8001,
+  8002, 8003, 8005, 8006, 8009, 8010, 8011, 8012, 8015, 8016, 8020, 8030, 8031, 8040, 8050, 8103, 8104, 8200,
+];
+
+const endpoint: KiwoomEndpointDefinition = {
+  methodName: 'stockInfo',
+  params: [{ name: 'stockCode', required: true }],
+  path: '/api/dostk/stkinfo',
+  apiId: 'ka10001',
+  bodyMap: { stk_cd: 'stockCode' },
+  headerParamMap: {},
+};
+
+const createRecordingLogger = (): { logger: Logger; errors: Array<Record<string, unknown> | undefined> } => {
+  const errors: Array<Record<string, unknown> | undefined> = [];
+  return {
+    errors,
+    logger: {
+      debug: () => undefined,
+      warn: () => undefined,
+      error: (_message, context) => {
+        errors.push(context);
+      },
+    },
+  };
+};
+
+const createClient = (fetchImpl: typeof fetch, logger: Logger): KiwoomClient =>
+  new KiwoomClient({
+    token: 'token',
+    env: 'dev',
+    maxRetries: 0,
+    rateLimitRequestsPerSecond: 1_000,
+    rateLimitBurst: 1_000,
+    fetchImpl,
+    logger,
+  });
+
+const jsonResponse = (body: Record<string, unknown>, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('KIWOOM_ERROR_CODES registry', () => {
+  test('covers every documented API 서버 오류코드', () => {
+    expect(Object.keys(KIWOOM_ERROR_CODES).map(Number).sort()).toEqual([...DOCUMENTED_CODES].sort());
+  });
+
+  test('parseKiwoomReturnCode coerces numbers and numeric strings', () => {
+    expect(parseKiwoomReturnCode(0)).toBe(0);
+    expect(parseKiwoomReturnCode('1700')).toBe(1700);
+    expect(parseKiwoomReturnCode(' 8005 ')).toBe(8005);
+    expect(parseKiwoomReturnCode(undefined)).toBeUndefined();
+    expect(parseKiwoomReturnCode('OK')).toBeUndefined();
+  });
+
+  test.each([
+    [1501, KiwoomValidationError],
+    [1902, KiwoomValidationError],
+    [1513, KiwoomAuthenticationError],
+    [8005, KiwoomAuthenticationError],
+    [8104, KiwoomAuthorizationError],
+    [8200, KiwoomAuthorizationError],
+    [1687, KiwoomRateLimitError],
+    [1700, KiwoomRateLimitError],
+    [1999, KiwoomServerError],
+    [4242, KiwoomApiError],
+  ])('resolveKiwoomError maps %i to the expected error class', (code, expectedClass) => {
+    const error = resolveKiwoomError(code);
+    expect(error).toBeInstanceOf(expectedClass);
+    expect(error.errorCode).toBe(code);
+  });
+
+  test('resolveKiwoomError prefers the server return_msg over the registry fallback', () => {
+    const error = resolveKiwoomError(1511, '필수입력 파라미터=stk_cd');
+    expect(error.message).toContain('필수입력 파라미터=stk_cd');
+
+    const fallback = resolveKiwoomError(8005);
+    expect(fallback.message).toContain(KIWOOM_ERROR_CODES[8005]);
+  });
+});
+
+describe('KiwoomClient return_code handling', () => {
+  test('throws a typed error and logs when HTTP 200 carries an error return_code', async () => {
+    const { logger, errors } = createRecordingLogger();
+    const client = createClient(
+      async () => jsonResponse({ return_code: 1902, return_msg: '종목 정보가 없습니다. 종목코드=999999' }),
+      logger,
+    );
+
+    const promise = client.invokeEndpoint(endpoint, { stockCode: '999999' });
+    await expect(promise).rejects.toBeInstanceOf(KiwoomValidationError);
+    await expect(promise).rejects.toMatchObject({ errorCode: 1902, statusCode: 200 });
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ apiId: 'ka10001', path: '/api/dostk/stkinfo', returnCode: 1902 });
+  });
+
+  test('promotes HTTP-status errors to the return_code error type', async () => {
+    const { logger, errors } = createRecordingLogger();
+    const client = createClient(
+      async () => jsonResponse({ return_code: 8005, return_msg: 'Token이 유효하지 않습니다' }, 401),
+      logger,
+    );
+
+    const promise = client.invokeEndpoint(endpoint, { stockCode: '005930' });
+    await expect(promise).rejects.toBeInstanceOf(KiwoomAuthenticationError);
+    await expect(promise).rejects.toMatchObject({ errorCode: 8005, statusCode: 401 });
+    expect(errors[0]).toMatchObject({ returnCode: 8005 });
+  });
+
+  test('resolves normally when return_code is 0', async () => {
+    const { logger, errors } = createRecordingLogger();
+    const client = createClient(
+      async () => jsonResponse({ return_code: 0, return_msg: 'ok', stk_nm: '삼성전자' }),
+      logger,
+    );
+
+    const response = await client.invokeEndpoint(endpoint, { stockCode: '005930' });
+    expect(response.body.returnCode).toBe(0);
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/__init__.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/__init__.py
@@ -2,6 +2,7 @@
 
 from ._auth import Auth
 from ._client import Client
+from ._error_codes import KIWOOM_ERROR_CODES, error_type_for_code, resolve_kiwoom_error
 from ._exceptions import (
     KiwoomAPIError,
     KiwoomAuthenticationError,
@@ -14,6 +15,7 @@ from ._exceptions import (
 )
 
 __all__ = [
+    "KIWOOM_ERROR_CODES",
     "Auth",
     "Client",
     "KiwoomAPIError",
@@ -24,6 +26,8 @@ __all__ = [
     "KiwoomServerError",
     "KiwoomTimeoutError",
     "KiwoomValidationError",
+    "error_type_for_code",
+    "resolve_kiwoom_error",
 ]
 
 

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_auth.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_auth.py
@@ -9,10 +9,34 @@ from __future__ import annotations
 from typing import Literal, Optional
 
 import requests
+from loguru import logger
 from pydantic import SecretStr
 
 from ._auth_types import TokenResponse
+from ._error_codes import KIWOOM_ERROR_CODES, parse_return_code
 from ._token_manager import TokenManager
+
+
+def _log_error_body(response: requests.Response, endpoint: str) -> None:
+    """Log the Kiwoom 오류코드 (body return_code/return_msg) of a failed response."""
+    if response.ok:
+        return
+    try:
+        data = response.json()
+    except ValueError:
+        data = None
+    if isinstance(data, dict):
+        return_code = parse_return_code(data.get("return_code"))
+        message = data.get("return_msg") or (KIWOOM_ERROR_CODES.get(return_code) if return_code else None)
+        logger.error(
+            "Kiwoom auth request failed ({}): status={}, return_code={}, message={}",
+            endpoint,
+            response.status_code,
+            return_code,
+            message,
+        )
+    else:
+        logger.error("Kiwoom auth request failed ({}): status={}", endpoint, response.status_code)
 
 
 class Auth:
@@ -78,6 +102,7 @@ class Auth:
         }
 
         response = requests.post(f"{self.url}/oauth2/token", headers=headers, json=data)
+        _log_error_body(response, "oauth2/token")
         response.raise_for_status()
 
         token_data = TokenResponse(**response.json())
@@ -103,6 +128,7 @@ class Auth:
         data = {"appkey": self.app_key, "secretkey": self.secret_key.get_secret_value(), "token": token}
 
         response = requests.post(f"{self.url}/oauth2/revoke", headers=headers, json=data)
+        _log_error_body(response, "oauth2/revoke")
         response.raise_for_status()
 
         return True

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_client.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_client.py
@@ -8,6 +8,7 @@ from cluefin_openapi._http_base import BaseHttpClient
 from cluefin_openapi._rate_limiter import TokenBucket
 
 from ._cache import SimpleCache, create_cache_key
+from ._error_codes import parse_return_code, resolve_kiwoom_error
 from ._exceptions import (
     KiwoomAPIError,
     KiwoomAuthenticationError,
@@ -83,11 +84,10 @@ class Client(BaseHttpClient):
         # Initialize cache if enabled
         self._cache = SimpleCache(default_ttl=cache_ttl) if enable_caching else None
 
-        # Configure logging
+        # Configure logging. Debug chatter is already gated behind `if self.debug`,
+        # so the namespace stays enabled to keep API error/warning logs visible.
         if self.debug:
             logger.enable("cluefin_openapi.kiwoom")
-        else:
-            logger.disable("cluefin_openapi.kiwoom")
 
     @property
     def account(self):
@@ -158,6 +158,42 @@ class Client(BaseHttpClient):
         "api": KiwoomAPIError,
     }
 
+    def _error_from_return_code(self, response, request_context: dict) -> Optional[KiwoomAPIError]:
+        """Map a non-zero body return_code (API 서버 오류코드) to a typed exception.
+
+        Returns None when the body has no return_code or reports success (0).
+        The resolved error is logged before being returned.
+        """
+        data = self._safe_json(response)
+        if not isinstance(data, dict):
+            return None
+        return_code = parse_return_code(data.get("return_code"))
+        if return_code is None or return_code == 0:
+            return None
+
+        exc = resolve_kiwoom_error(
+            return_code,
+            return_msg=data.get("return_msg"),
+            status_code=response.status_code,
+            response_data=data,
+            request_context=request_context,
+        )
+        logger.error(
+            "Kiwoom API error (return_code={}, api-id={}, path={}): {}",
+            return_code,
+            request_context.get("tr_id"),
+            request_context.get("path"),
+            data.get("return_msg") or exc.message,
+        )
+        return exc
+
+    def _dispatch_kiwoom(self, response, request_context: dict) -> Optional[Exception]:
+        """Prefer body return_code resolution, then fall back to HTTP status dispatch."""
+        exc = self._error_from_return_code(response, request_context)
+        if exc is not None:
+            return exc
+        return self._dispatch_by_status(response, request_context, self._ERROR_TYPES)
+
     def _post(self, path: str, headers: Dict[str, str], body: Dict[str, str], use_cache: bool = True):
         """Make a POST request with improved error handling and logging."""
         # Check cache first if enabled — short-circuit BEFORE rate-limiting/HTTP
@@ -203,7 +239,7 @@ class Client(BaseHttpClient):
             timeout=self.timeout,
             max_retries=self.max_retries,
             request_context=request_context,
-            dispatch=lambda resp: self._dispatch_by_status(resp, request_context, self._ERROR_TYPES),
+            dispatch=lambda resp: self._dispatch_kiwoom(resp, request_context),
             rate_limit_error=lambda: KiwoomRateLimitError(
                 "Rate limit timeout - could not acquire token within timeout period",
                 request_context={"url": url, "path": path},
@@ -211,6 +247,11 @@ class Client(BaseHttpClient):
             timeout_error_cls=KiwoomTimeoutError,
             network_error_cls=KiwoomNetworkError,
         )
+
+        # Kiwoom can report API 서버 오류코드 in the body of an HTTP 200 response
+        error = self._error_from_return_code(response, request_context)
+        if error is not None:
+            raise error
 
         # Cache successful 200 responses (dispatch may accept non-200 without raising)
         if self._cache and use_cache and cache_key and response.status_code == 200:

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_error_codes.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_error_codes.py
@@ -1,0 +1,142 @@
+"""Kiwoom API server error-code registry.
+
+Maps the documented ``return_code`` values (API 서버 오류코드) to human-readable
+messages and typed exceptions. Kiwoom reports these codes in the response body
+(``return_code`` / ``return_msg``) for both token endpoints and TR endpoints.
+"""
+
+from typing import Any, Dict, Optional, Type
+
+from ._exceptions import (
+    KiwoomAPIError,
+    KiwoomAuthenticationError,
+    KiwoomAuthorizationError,
+    KiwoomRateLimitError,
+    KiwoomServerError,
+    KiwoomValidationError,
+)
+
+# return_code -> documented message (placeholders {?} are filled by the server
+# in return_msg; these serve as fallbacks when return_msg is absent).
+KIWOOM_ERROR_CODES: Dict[int, str] = {
+    1501: "API ID가 Null이거나 값이 없습니다",
+    1504: "해당 URI에서는 지원하는 API ID가 아닙니다. API ID={?}, URI={?}",
+    1505: "해당 API ID는 존재하지 않습니다. API ID={?}",
+    1511: "필수 입력 값에 값이 존재하지 않습니다. 필수입력 파라미터={?}",
+    1512: "Http header에 값이 설정되지 않았거나 읽을 수 없습니다",
+    1513: "Http Header에 authorization 필드가 설정되어 있어야 합니다",
+    1514: "입력으로 들어온 Http Header의 authorization 필드 형식이 맞지 않습니다",
+    1515: "Http Header의 authorization 필드 내 Grant Type이 미리 정의된 형식이 아닙니다",
+    1516: "Http Header의 authorization 필드 내 Token이 정의되어 있지 않습니다",
+    1517: "입력 값 형식이 올바르지 않습니다. 파라미터={?} 실패사유={?}",
+    1687: "재귀 호출이 발생하여 API 호출을 제한합니다, API ID={?}",
+    1700: "허용된 API 요청 개수를 초과하였습니다. 유량={?}, API ID={?}",
+    1701: "허용된 전체 요청 개수를 초과하였습니다. 총유량={?}",
+    1702: "허용된 그룹 요청 개수를 초과하였습니다. 총유량={?}, API_ID={?}",
+    1901: "시장 코드값이 존재하지 않습니다. 종목코드={?}",
+    1902: "종목 정보가 없습니다. 입력한 종목코드 값을 확인바랍니다. 종목코드={?}",
+    1903: "종목 정보가 없습니다. 입력한 종목코드, 거래소구분 값을 확인바랍니다. 거래소구분={?}, 종목코드={?}",
+    1999: "예기치 못한 에러가 발생했습니다. 실패사유={?}",
+    8001: "App Key와 Secret Key 검증에 실패했습니다",
+    8002: "App Key와 Secret Key 검증에 실패했습니다. 실패사유={?}",
+    8003: "Access Token을 조회하는데 실패했습니다. 실패사유={?}",
+    8005: "Token이 유효하지 않습니다",
+    8006: "Access Token을 생성하는데 실패했습니다. 실패사유={?}",
+    8009: "Access Token을 발급하는데 실패했습니다. 실패사유={?}",
+    8010: "Token을 발급받은 IP와 서비스를 요청한 IP가 동일하지 않습니다",
+    8011: "Access Token을 발급하는데 실패했습니다. 입력값에 grant_type이 들어오지 않았습니다",
+    8012: "Access Token을 발급하는데 실패했습니다. grant_type의 값이 맞지 않습니다",
+    8015: "Access Token을 폐기하는데 실패했습니다. 실패사유={?}",
+    8016: "Access Token을 폐기하는데 실패했습니다. 입력값에 Token이 들어오지 않았습니다",
+    8020: "입력파라미터로 appkey 또는 secretkey가 들어오지 않았습니다.",
+    8030: "투자구분(실전/모의)이 달라서 Appkey를 사용할수가 없습니다",
+    8031: "투자구분(실전/모의)이 달라서 Token를 사용할수가 없습니다",
+    8040: "단말기 인증에 실패했습니다",
+    8050: "지정단말기 인증에 실패했습니다",
+    8103: "토큰 인증 또는 단말기인증에 실패했습니다. 실패사유={?}",
+    8104: "모의투자에서 지원하지 않는 API 입니다.",
+    8200: "법인 고객은 해당 API를 지원하지 않습니다. API ID={?}, URI={?}",
+}
+
+_VALIDATION_CODES = frozenset({1501, 1504, 1505, 1511, 1512, 1517, 1901, 1902, 1903})
+_AUTH_CODES = frozenset(
+    {
+        1513,
+        1514,
+        1515,
+        1516,
+        8001,
+        8002,
+        8003,
+        8005,
+        8006,
+        8009,
+        8010,
+        8011,
+        8012,
+        8015,
+        8016,
+        8020,
+        8030,
+        8031,
+        8040,
+        8050,
+        8103,
+    }
+)
+_AUTHZ_CODES = frozenset({8104, 8200})
+_RATE_LIMIT_CODES = frozenset({1687, 1700, 1701, 1702})
+_SERVER_CODES = frozenset({1999})
+
+
+def parse_return_code(value: Any) -> Optional[int]:
+    """Coerce a body return_code (int or numeric string) to int, else None."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value.strip())
+        except ValueError:
+            return None
+    return None
+
+
+def error_type_for_code(return_code: int) -> Type[KiwoomAPIError]:
+    """Return the exception class for a Kiwoom server error code."""
+    if return_code in _VALIDATION_CODES:
+        return KiwoomValidationError
+    if return_code in _AUTH_CODES:
+        return KiwoomAuthenticationError
+    if return_code in _AUTHZ_CODES:
+        return KiwoomAuthorizationError
+    if return_code in _RATE_LIMIT_CODES:
+        return KiwoomRateLimitError
+    if return_code in _SERVER_CODES:
+        return KiwoomServerError
+    return KiwoomAPIError
+
+
+def resolve_kiwoom_error(
+    return_code: int,
+    return_msg: Optional[str] = None,
+    status_code: Optional[int] = None,
+    response_data: Optional[Dict[str, Any]] = None,
+    request_context: Optional[Dict[str, Any]] = None,
+) -> KiwoomAPIError:
+    """Build a typed exception for a non-zero Kiwoom ``return_code``.
+
+    The server-provided ``return_msg`` wins over the registry fallback because
+    it carries the filled-in placeholders (API ID, 파라미터, 실패사유 등).
+    """
+    message = return_msg or KIWOOM_ERROR_CODES.get(return_code, "알 수 없는 오류입니다")
+    error_cls = error_type_for_code(return_code)
+    exc = error_cls(
+        f"Kiwoom API error {return_code}: {message}",
+        status_code=status_code,
+        response_data=response_data,
+        request_context=request_context,
+    )
+    exc.return_code = return_code
+    return exc

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_exceptions.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_exceptions.py
@@ -6,6 +6,10 @@ from typing import Any, Dict, Optional
 class KiwoomAPIError(Exception):
     """Base exception for all Kiwoom API errors."""
 
+    # Kiwoom server error code (body return_code), set when the error originates
+    # from a documented API 서버 오류코드 (see _error_codes.py).
+    return_code: Optional[int] = None
+
     def __init__(
         self,
         message: str,

--- a/packages/cluefin-openapi/tests/kiwoom/test_error_codes_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_error_codes_unit.py
@@ -1,0 +1,142 @@
+"""Tests for Kiwoom API 서버 오류코드 registry and client return_code handling."""
+
+import pytest
+import requests_mock
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._error_codes import (
+    KIWOOM_ERROR_CODES,
+    error_type_for_code,
+    parse_return_code,
+    resolve_kiwoom_error,
+)
+from cluefin_openapi.kiwoom._exceptions import (
+    KiwoomAPIError,
+    KiwoomAuthenticationError,
+    KiwoomAuthorizationError,
+    KiwoomRateLimitError,
+    KiwoomServerError,
+    KiwoomValidationError,
+)
+
+
+@pytest.fixture
+def client():
+    return Client(token="test_token", env="dev")
+
+
+def test_registry_covers_documented_codes():
+    documented = {
+        1501, 1504, 1505, 1511, 1512, 1513, 1514, 1515, 1516, 1517,
+        1687, 1700, 1701, 1702, 1901, 1902, 1903, 1999,
+        8001, 8002, 8003, 8005, 8006, 8009, 8010, 8011, 8012, 8015, 8016,
+        8020, 8030, 8031, 8040, 8050, 8103, 8104, 8200,
+    }  # fmt: skip
+    assert set(KIWOOM_ERROR_CODES) == documented
+
+
+def test_parse_return_code():
+    assert parse_return_code(0) == 0
+    assert parse_return_code("1700") == 1700
+    assert parse_return_code(" 8005 ") == 8005
+    assert parse_return_code(None) is None
+    assert parse_return_code("OK") is None
+    assert parse_return_code(True) is None
+
+
+@pytest.mark.parametrize(
+    "code,expected_cls",
+    [
+        (1501, KiwoomValidationError),
+        (1517, KiwoomValidationError),
+        (1902, KiwoomValidationError),
+        (1513, KiwoomAuthenticationError),
+        (8005, KiwoomAuthenticationError),
+        (8103, KiwoomAuthenticationError),
+        (8104, KiwoomAuthorizationError),
+        (8200, KiwoomAuthorizationError),
+        (1687, KiwoomRateLimitError),
+        (1700, KiwoomRateLimitError),
+        (1999, KiwoomServerError),
+        (4242, KiwoomAPIError),  # unknown code falls back to the base error
+    ],
+)
+def test_error_type_for_code(code, expected_cls):
+    assert error_type_for_code(code) is expected_cls
+
+
+def test_resolve_kiwoom_error_prefers_server_message():
+    exc = resolve_kiwoom_error(1511, return_msg="필수입력 파라미터=stk_cd", status_code=200)
+    assert isinstance(exc, KiwoomValidationError)
+    assert exc.return_code == 1511
+    assert "필수입력 파라미터=stk_cd" in str(exc)
+
+
+def test_resolve_kiwoom_error_falls_back_to_registry_message():
+    exc = resolve_kiwoom_error(8005)
+    assert isinstance(exc, KiwoomAuthenticationError)
+    assert KIWOOM_ERROR_CODES[8005] in str(exc)
+
+
+def test_post_raises_on_error_return_code_with_http_200(client):
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://mockapi.kiwoom.com/api/dostk/stkinfo",
+            json={"return_code": 1902, "return_msg": "종목 정보가 없습니다. 종목코드=999999"},
+            status_code=200,
+        )
+
+        with pytest.raises(KiwoomValidationError) as exc_info:
+            client._post("/api/dostk/stkinfo", {"api-id": "ka10001"}, {"stk_cd": "999999"})
+
+    assert exc_info.value.return_code == 1902
+    assert exc_info.value.status_code == 200
+    assert "종목코드=999999" in str(exc_info.value)
+
+
+def test_post_maps_error_return_code_on_http_4xx(client):
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://mockapi.kiwoom.com/api/dostk/stkinfo",
+            json={"return_code": 8005, "return_msg": "Token이 유효하지 않습니다"},
+            status_code=401,
+        )
+
+        with pytest.raises(KiwoomAuthenticationError) as exc_info:
+            client._post("/api/dostk/stkinfo", {"api-id": "ka10001"}, {"stk_cd": "005930"})
+
+    assert exc_info.value.return_code == 8005
+    assert exc_info.value.status_code == 401
+
+
+def test_post_succeeds_when_return_code_is_zero(client):
+    with requests_mock.Mocker() as m:
+        m.post(
+            "https://mockapi.kiwoom.com/api/dostk/stkinfo",
+            json={"return_code": 0, "return_msg": "정상적으로 처리되었습니다"},
+            status_code=200,
+        )
+
+        response = client._post("/api/dostk/stkinfo", {"api-id": "ka10001"}, {"stk_cd": "005930"})
+
+    assert response.status_code == 200
+
+
+def test_error_return_code_is_logged(client):
+    records = []
+    from loguru import logger
+
+    sink_id = logger.add(lambda message: records.append(message), level="ERROR")
+    try:
+        with requests_mock.Mocker() as m:
+            m.post(
+                "https://mockapi.kiwoom.com/api/dostk/stkinfo",
+                json={"return_code": 1700, "return_msg": "허용된 API 요청 개수를 초과하였습니다"},
+                status_code=200,
+            )
+            with pytest.raises(KiwoomRateLimitError):
+                client._post("/api/dostk/stkinfo", {"api-id": "ka10001"}, {"stk_cd": "005930"})
+    finally:
+        logger.remove(sink_id)
+
+    assert any("return_code=1700" in str(record) for record in records)


### PR DESCRIPTION
## 관련 이슈

없음

## 변경 사항

키움 REST API가 응답 본문 `return_code`/`return_msg`로 알리는 API 서버 오류코드(1501~8200, 37종)를 Python·TypeScript 클라이언트 양쪽에서 관리하고 로그에 남기도록 했습니다.

- 문서화된 오류코드 전체를 코드 → 메시지 레지스트리로 등록하고, 코드 성격에 따라 기존 타입 예외(Validation / Authentication / Authorization / RateLimit / Server)로 매핑
- HTTP 200이어도 본문 `return_code`가 0이 아니면 타입 예외를 발생시키고 `api-id`/`path`/`return_code`를 포함해 error 로그 기록
- HTTP 4xx/5xx 응답도 본문에 오류코드가 있으면 상태코드 기반 매핑보다 우선 적용
- Python: 토큰 발급/폐기(`_auth.py`) 실패 시 본문 오류코드 로깅 추가, `debug=False`에서도 에러 로그가 남도록 `logger.disable` 제거
- TypeScript: `KiwoomClient`에 `Logger` 주입 지원(기본 console, `silentLogger`로 무음화), `ApiError`에 `errorCode` 필드 추가

## 변경 유형

- [ ] 버그 수정 (`fix`)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 기존 기능 개선 (`feat`)
- [ ] 리팩토링 (`refactor`)
- [ ] 테스트 추가/수정 (`test`)
- [ ] 문서 수정 (`docs`)
- [ ] 의존성 업데이트 (`chore`)
- [ ] CI/CD (`ci`)

## 영향 범위

- [x] cluefin-openapi
- [x] cluefin-openapi-ts
- [ ] cluefin-ta
- [ ] cluefin-xbrl
- [ ] cluefin-cli
- [ ] cluefin-desk
- [ ] 루트 프로젝트 설정

## 테스트

- Python: `uv run pytest packages/cluefin-openapi -m "not integration"` — 960 passed
- TypeScript: `npm run test:unit` — 384 passed, `npm run lint`/`npm run build` 통과
- 오류코드 레지스트리 커버리지, 코드별 예외 매핑, HTTP 200 에러 본문 처리, 4xx 승격, 로그 기록을 검증하는 단위 테스트 추가

- [x] 단위 테스트 통과 (`uv run pytest -m "not integration"`)
- [ ] 통합 테스트 통과 (`uv run pytest -m "integration"`)
- [ ] 테스트 불필요 (문서, 설정 변경 등)

## 체크리스트

- [x] `uv run ruff format . && uv run ruff check . --fix` 실행
- [x] 커밋 메시지가 컨벤션을 따름 (`type(scope): 설명`)
- [x] `.env`, 시크릿, 인증 정보 미포함
- [ ] 관련 문서 업데이트 완료 (해당 시)

## 참고 사항 (선택)

동작 변경: 기존에는 HTTP 200 + 에러 본문이 성공 응답으로 그대로 반환됐지만, 이제 양쪽 클라이언트 모두 타입 예외를 던집니다. TypeScript는 기본적으로 에러를 console에 기록하므로 무음이 필요하면 `logger: silentLogger`를 전달하면 됩니다.
