### PR TITLE
feat(kiwoom): 미국주식 API 지원 추가

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,82 +1,64 @@
 # AGENTS.md
 
-## Project
+Cluefin is a research toolkit for Korean financial markets. The Python side is a `uv`
+workspace; `packages/cluefin-openapi-ts` is a separate TypeScript client in the same repo.
+This file records only things that aren't obvious from reading the code — layout, tooling,
+and command lists are discoverable, so they're not repeated here.
 
-Cluefin is a research-oriented toolkit for Korean financial markets. The Python side is a `uv` workspace; the TypeScript OpenAPI client is a separate package under the same repo.
+## Secrets
 
-## Repository Layout
+- Real credentials live in `.env` (and `.env.test`) at the repo root — **never echo, print,
+  or commit their values**.
+- For setup, copy a `*.env.sample` (e.g. `packages/cluefin-openapi/.env.sample`,
+  `apps/cluefin-cli/.env.sample`) to `.env`.
 
-- `packages/cluefin-openapi`: Kiwoom, KIS, and DART Python clients
-- `packages/cluefin-ta`: technical analysis indicators
-- `packages/cluefin-xbrl`: DART XBRL parsing
-- `packages/cluefin-openapi-ts`: TypeScript OpenAPI client, Node 20+
-- `apps/cluefin-cli`: user-facing CLI
-- `apps/cluefin-openapi-cli`: broker command CLI
-- `apps/cluefin-desk`: TUI dashboard
+## Testing policy
 
-Keep reusable libraries under `packages/` and runnable tools under `apps/`. Do not restructure the workspace unless a task explicitly asks for it.
+- Unit tests use mocks and hit no network. Real API keys are used **only** for tests marked
+  `integration`.
+- Markers: `integration`, `realtime` (requires market hours, 09:00–15:30 KST), `slow`.
+- Fast local check: `uv run pytest -m "not integration and not slow"`.
 
-## Working Rules
+## Environment gotchas
 
-- Use `uv run` for Python commands.
-- Target Python 3.10+.
-- Set API keys in `.env`; do not commit local credentials or token caches.
-- On macOS, install LightGBM with `brew install lightgbm`.
-- Leave unrelated worktree changes alone.
+- macOS needs `brew install lightgbm`; TA-Lib requires its C library as a system dep.
+- Git hooks run via **lefthook** (`uv run lefthook install`) — not the `pre-commit` framework.
 
-## Verification
+## Broker CLI discovery
 
-Prefer fast local verification before broader checks:
-
-```bash
-uv run pytest -m "not integration and not slow"
-uv run ruff format . --check
-uv run ruff check .
-```
-
-For all non-integration tests:
-
-```bash
-uv run pytest -m "not integration"
-```
-
-For the TypeScript package:
-
-```bash
-cd packages/cluefin-openapi-ts
-npm run check
-npm run typecheck
-npm run test:unit
-```
-
-## Broker CLI Discovery
-
-For broker command discovery, prefer JSON-friendly commands:
+Prefer the JSON output when discovering broker commands:
 
 ```bash
 uv run cluefin-openapi-cli list --json
 uv run cluefin-openapi-cli describe <broker> <category> <method> --json
-uv run cluefin-openapi-cli describe dart <method> --json
 ```
 
-## Local Agent Files
+## Commits & PRs
 
-- `.entire/` is local Entire state and is ignored by git.
-- `.codex/` may be needed for local Codex hooks, but do not commit it unless the task explicitly asks to make Codex/Entire hooks part of the project workflow.
-- Do not add repo-local `.pi/` or `SYSTEM.md` files unless a task explicitly asks for Pi package/runtime customization.
+- Conventional Commits with **Korean** messages: `type(scope): 설명`.
+- Fill out `.github/PULL_REQUEST_TEMPLATE.md` when opening a PR.
 
-## Common Commands
+## Local agent files
 
-```bash
-uv sync --all-packages
-uv run lefthook install
-uv run ruff format .
-uv run ruff check . --fix
-```
+- `.entire/` is local Entire state and is git-ignored.
+- Don't commit `.codex/`, or add repo-local `.pi/` / `SYSTEM.md`, unless a task explicitly
+  asks to make those part of the project workflow.
 
-## Quick Usage
+## Kiwoom 미국주식 (overseas)
 
-```bash
-uv run cluefin-cli ta 005930
-uv run cluefin-cli ta 005930 --chart --ml-predict --shap-analysis
-```
+The active US-stock work (branch `feat/kiwoom-overseas`) is **Python-only** — the
+`cluefin-openapi-ts` package is out of scope (its `overseas-*` files are KIS, not Kiwoom).
+
+- **Modules** (under `packages/cluefin-openapi/src/cluefin_openapi/kiwoom/`): each category is
+  a pair — `_overseas_<category>.py` (impl class `Overseas<Category>`) and
+  `_overseas_<category>_types.py` (Pydantic v2 models `Overseas<Category><Thing>` that inherit
+  `(BaseModel, KiwoomHttpBody)`, set `ConfigDict(title="미국주식 …")`, and name fields by the
+  raw Kiwoom field codes). Mirrors the existing `_domestic_*` set.
+- **Client wiring** (`_client.py`): no separate client — lazy `@property` accessors on the
+  single `Client`, with `overseas_`-prefixed names (`overseas_account`, `overseas_order`, …).
+  `_overseas_condition_search` and `_overseas_realtime` exist but are **not yet wired**
+  (WebSocket/streaming, in progress) and are unit-test-only.
+- **Tests** (`packages/cluefin-openapi/tests/kiwoom/`): `test_overseas_<category>_unit.py`
+  (table-driven via `_helpers.py` `EndpointCase` / `run_post_case`, no marker) plus
+  `test_overseas_<category>_integration.py` (`@pytest.mark.integration`, using the `client`
+  fixture in `conftest.py` that skips when `KIWOOM_*` env is absent).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,40 +1,7 @@
 # CLAUDE.md
 
-## Project
+See @AGENTS.md for project guidance — it is the source of truth for working in this repo.
 
-Cluefin is a Korean market analysis monorepo.
+## Claude-specific
 
-- `packages/cluefin-openapi`: Kiwoom, KIS, DART clients
-- `packages/cluefin-ta`: technical indicators
-- `packages/cluefin-xbrl`: XBRL / DART statement parsing
-- `packages/cluefin-openapi-ts`: TypeScript OpenAPI client
-- `apps/cluefin-cli`: analysis CLI
-- `apps/cluefin-openapi-cli`: broker command CLI
-- `apps/cluefin-desk`: TUI app
-
-## Rules
-
-- Use `uv run` for Python commands
-- Keep secrets in `.env`
-- Use mocks for unit tests
-- Use real API keys or external provider sites only for `integration` tests
-
-## Common Commands
-
-```bash
-uv sync --all-packages
-uv run pytest -m "not integration"
-uv run pytest -m integration
-uv run ruff format .
-uv run ruff check . --fix
-```
-
-## TypeScript
-
-```bash
-cd packages/cluefin-openapi-ts
-npm install
-npm run test:unit
-npm run lint
-npm run build
-```
+<!-- Only notes specific to Claude Code go here; general project rules live in AGENTS.md. -->

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_client.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_client.py
@@ -149,6 +149,66 @@ class Client(object):
 
         return DomesticTheme(self)
 
+    @property
+    def overseas_account(self):
+        from ._overseas_account import OverseasAccount
+
+        return OverseasAccount(self)
+
+    @property
+    def overseas_chart(self):
+        from ._overseas_chart import OverseasChart
+
+        return OverseasChart(self)
+
+    @property
+    def overseas_exchange(self):
+        from ._overseas_exchange import OverseasExchange
+
+        return OverseasExchange(self)
+
+    @property
+    def overseas_investment_info(self):
+        from ._overseas_investment_info import OverseasInvestmentInfo
+
+        return OverseasInvestmentInfo(self)
+
+    @property
+    def overseas_market_condition(self):
+        from ._overseas_market_condition import OverseasMarketCondition
+
+        return OverseasMarketCondition(self)
+
+    @property
+    def overseas_order(self):
+        from ._overseas_order import OverseasOrder
+
+        return OverseasOrder(self)
+
+    @property
+    def overseas_rank_info(self):
+        from ._overseas_rank_info import OverseasRankInfo
+
+        return OverseasRankInfo(self)
+
+    @property
+    def overseas_sector(self):
+        from ._overseas_sector import OverseasSector
+
+        return OverseasSector(self)
+
+    @property
+    def overseas_stock_info(self):
+        from ._overseas_stock_info import OverseasStockInfo
+
+        return OverseasStockInfo(self)
+
+    @property
+    def overseas_watchlist(self):
+        from ._overseas_watchlist import OverseasWatchlist
+
+        return OverseasWatchlist(self)
+
     def _post(self, path: str, headers: Dict[str, str], body: Dict[str, str], use_cache: bool = True):
         """Make a POST request with improved error handling and logging."""
         # Check cache first if enabled

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_account.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_account.py
@@ -44,14 +44,16 @@ class OverseasAccount:
 
     def get_daily_account_profit_rate(
         self,
-        body: dict[str, str],
+        from_dt: str,
+        to: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountDailyProfitRate]:
         """미국주식 일별계좌수익률현황 (usa21670)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            from_dt (str): from 일자. YYYYMMDD
+            to (str): to 일자. YYYYMMDD
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -66,6 +68,10 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "usa21670",
         }
+        body = {
+            "from": from_dt,
+            "to": to,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -77,14 +83,16 @@ class OverseasAccount:
 
     def get_monthly_account_profit_rate(
         self,
-        body: dict[str, str],
+        from_dt: str,
+        to: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountMonthlyProfitRate]:
         """미국주식 월별계좌수익률현황 (usa21680)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            from_dt (str): from 년월. YYYYMM
+            to (str): to 년월. YYYYMM
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -99,6 +107,10 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "usa21680",
         }
+        body = {
+            "from": from_dt,
+            "to": to,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -110,14 +122,16 @@ class OverseasAccount:
 
     def get_yearly_account_profit_rate(
         self,
-        body: dict[str, str],
+        from_dt: str,
+        to: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountYearlyProfitRate]:
         """미국주식 연도별계좌수익률현황 (usa21690)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            from_dt (str): from 년도. YYYY
+            to (str): to 년도. YYYY
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -132,6 +146,10 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "usa21690",
         }
+        body = {
+            "from": from_dt,
+            "to": to,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -143,14 +161,20 @@ class OverseasAccount:
 
     def get_daily_stock_profit_rate(
         self,
-        body: dict[str, str],
+        from_dt: str,
+        to: str,
+        stk_cd: str,
+        stex_tp: Literal["", "NA", "ND", "NY"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountDailyStockProfitRate]:
         """미국주식 일별종목수익률현황 (usa21730)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            from_dt (str): from 일자. YYYYMMDD
+            to (str): to 일자. YYYYMMDD
+            stk_cd (str): 종목코드
+            stex_tp (Literal["", "NA", "ND", "NY"], optional): 거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -165,6 +189,12 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "usa21730",
         }
+        body = {
+            "from": from_dt,
+            "to": to,
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -176,14 +206,20 @@ class OverseasAccount:
 
     def get_monthly_stock_profit_rate(
         self,
-        body: dict[str, str],
+        from_dt: str,
+        to: str,
+        stk_cd: str,
+        stex_tp: Literal["", "NA", "ND", "NY"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountMonthlyStockProfitRate]:
         """미국주식 월별종목수익률현황 (usa21731)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            from_dt (str): from 년월. YYYYMM
+            to (str): to 년월. YYYYMM
+            stk_cd (str): 종목코드
+            stex_tp (Literal["", "NA", "ND", "NY"], optional): 거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -198,6 +234,12 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "usa21731",
         }
+        body = {
+            "from": from_dt,
+            "to": to,
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -209,14 +251,20 @@ class OverseasAccount:
 
     def get_yearly_stock_profit_rate(
         self,
-        body: dict[str, str],
+        from_dt: str,
+        to: str,
+        stk_cd: str,
+        stex_tp: Literal["", "NA", "ND", "NY"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountYearlyStockProfitRate]:
         """미국주식 연도별종목수익률현황 (usa21732)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            from_dt (str): from 년도. YYYY
+            to (str): to 년도. YYYY
+            stk_cd (str): 종목코드
+            stex_tp (Literal["", "NA", "ND", "NY"], optional): 거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -231,6 +279,12 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "usa21732",
         }
+        body = {
+            "from": from_dt,
+            "to": to,
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -242,14 +296,20 @@ class OverseasAccount:
 
     def get_ledger_unfilled_orders(
         self,
-        body: dict[str, str],
+        ord_dt: str = "",
+        slby_tp: Literal["", "0", "1", "2"] = "",
+        stex_tp: Literal["", "ND", "NY", "NA"] = "",
+        stk_cd: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountLedgerUnfilledOrders]:
         """미국주식 원장 미체결 (ust21050)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            ord_dt (str, optional): 주문일자. 미입력시 오늘 날짜로 조회. Defaults to "".
+            slby_tp (Literal["", "0", "1", "2"], optional): 매도매수구분. 0:전체(기본값),1:매도,2:매수. Defaults to "".
+            stex_tp (Literal["", "ND", "NY", "NA"], optional): 거래소구분. 미입력시 전체, ND:NASDAQ,NY:NYSE,NA:AMEX. Defaults to "".
+            stk_cd (str, optional): 종목코드. 미입력시 전체. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -264,6 +324,12 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21050",
         }
+        body = {
+            "ord_dt": ord_dt,
+            "slby_tp": slby_tp,
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -275,14 +341,16 @@ class OverseasAccount:
 
     def get_ledger_balance(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "ND", "NY", "NA"] = "",
+        stk_cd: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountLedgerBalance]:
         """미국주식 원장잔고확인 (ust21070)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "ND", "NY", "NA"], optional): 거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX. Defaults to "".
+            stk_cd (str, optional): 종목코드. 미입력시 전체. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -297,6 +365,10 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21070",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -308,14 +380,24 @@ class OverseasAccount:
 
     def get_transaction_history(
         self,
-        body: dict[str, str],
+        strt_dt: str = "",
+        end_dt: str = "",
+        tp: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "F", "M", "G", "H", "I", "J", "K"] = "",
+        stex_tp: Literal["", "ND", "NY", "NA"] = "",
+        stk_cd: str = "",
+        krw_repl_skip_yn: Literal["", "Y", "N"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountTransactionHistory]:
         """미국주식 거래내역 (ust21100)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            strt_dt (str, optional): 시작일자. YYYYMMDD. Defaults to "".
+            end_dt (str, optional): 종료일자. YYYYMMDD. Defaults to "".
+            tp (Literal, optional): 구분. 0:전체,1:입출금,2:입출고,3:매매,4:매수,5:매도,F:환전, M:입출금+환전(매체전용), G:환전매수, H:환전매도, I:환전정산입금, J:환전정산출금, 6:입금, 7:출금 8:배당금입금 K:환전+환전정산입출금. Defaults to "".
+            stex_tp (Literal["", "ND", "NY", "NA"], optional): 거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX. Defaults to "".
+            stk_cd (str, optional): 종목코드. Defaults to "".
+            krw_repl_skip_yn (Literal["", "Y", "N"], optional): 원화대용입출금제외여부. Y:제외,N:비제외. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -330,6 +412,14 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21100",
         }
+        body = {
+            "strt_dt": strt_dt,
+            "end_dt": end_dt,
+            "tp": tp,
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "krw_repl_skip_yn": krw_repl_skip_yn,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -341,14 +431,12 @@ class OverseasAccount:
 
     def get_deposit(
         self,
-        body: dict[str, str],
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountDeposit]:
         """해외주식 예수금 (ust21110)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -363,6 +451,7 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21110",
         }
+        body: dict[str, str] = {}
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -374,14 +463,12 @@ class OverseasAccount:
 
     def get_krw_withdrawable_amount(
         self,
-        body: dict[str, str],
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountKrwWithdrawableAmount]:
         """원화출금가능 금액 조회(원화대용 포함) (ust21111)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -396,6 +483,7 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21111",
         }
+        body: dict[str, str] = {}
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -407,14 +495,16 @@ class OverseasAccount:
 
     def get_deposit_and_securities_valuation_by_currency(
         self,
-        body: dict[str, str],
+        cmsn_incl_tp: Literal["", "0", "1"] = "",
+        exrt_tp: Literal["", "0", "1", "2"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountDepositAndSecuritiesValuationByCurrency]:
         """통화별 예수금 및 증권 평가금현황 (ust21120)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cmsn_incl_tp (Literal["", "0", "1"], optional): 수수료포함구분. 0:미포함,1:포함. Defaults to "".
+            exrt_tp (Literal["", "0", "1", "2"], optional): 환율구분. 0:기준환율,1:계좌적용환율,2:전일최종환율. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -429,6 +519,10 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21120",
         }
+        body = {
+            "cmsn_incl_tp": cmsn_incl_tp,
+            "exrt_tp": exrt_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -440,14 +534,16 @@ class OverseasAccount:
 
     def get_ledger_valuation_amount(
         self,
-        body: dict[str, str],
+        cmsn_incl_tp: Literal["", "0", "1"] = "",
+        exrt_tp: Literal["", "0", "1", "2"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountLedgerValuationAmount]:
         """해외증권 원장 평가금액현황 (ust21121)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cmsn_incl_tp (Literal["", "0", "1"], optional): 수수료포함구분. 0:미포함,1:포함. Defaults to "".
+            exrt_tp (Literal["", "0", "1", "2"], optional): 환율구분. 0:기준환율,1:계좌적용환율,2:전일최종환율. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -462,6 +558,10 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21121",
         }
+        body = {
+            "cmsn_incl_tp": cmsn_incl_tp,
+            "exrt_tp": exrt_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -473,14 +573,14 @@ class OverseasAccount:
 
     def get_valuation_amount_by_date(
         self,
-        body: dict[str, str],
+        base_dt: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountValuationAmountByDate]:
         """해외증권 특정일 평가금액 (ust21131)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            base_dt (str): 기준일자. YYYYMMDD
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -495,6 +595,9 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21131",
         }
+        body = {
+            "base_dt": base_dt,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -506,14 +609,14 @@ class OverseasAccount:
 
     def get_deposit_and_securities_valuation_by_currency_on_date(
         self,
-        body: dict[str, str],
+        base_dt: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountDepositAndSecuritiesValuationByCurrencyByDate]:
         """특정일 통화별 예수금 및 증권 평가금 (ust21132)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            base_dt (str): 기준일자. YYYYMMDD
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -528,6 +631,9 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21132",
         }
+        body = {
+            "base_dt": base_dt,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -539,14 +645,26 @@ class OverseasAccount:
 
     def get_daily_order_execution_history(
         self,
-        body: dict[str, str],
+        query_tp: Literal["1", "2", "3", "4", "5", "6"],
+        slby_tp: Literal["0", "1", "2"],
+        ord_dt: str = "",
+        stex_tp: Literal["", "ND", "NY", "NA"] = "",
+        stk_cd: str = "",
+        oppo_trde_tp: Literal["", "%", "0", "1"] = "",
+        fr_ord_no: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountDailyOrderExecutionHistory]:
         """미국주식 일별 주문체결내역 (ust21150)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            query_tp (Literal["1", "2", "3", "4", "5", "6"]): 조회구분. 1:주문순,2:주문역순,3:미체결주문순,4:미체결역순,5:체결주문순,6:체결역순
+            slby_tp (Literal["0", "1", "2"]): 매도수구분. 0:전체,1:매도,2:매수
+            ord_dt (str, optional): 주문일자. 미입력시 오늘 날짜로 조회. Defaults to "".
+            stex_tp (Literal["", "ND", "NY", "NA"], optional): 거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX. Defaults to "".
+            stk_cd (str, optional): 종목코드. 미입력시 전체. Defaults to "".
+            oppo_trde_tp (Literal["", "%", "0", "1"], optional): 반대매매구분. %:전체,0:일반,1:반대매매. Defaults to "".
+            fr_ord_no (str, optional): 시작주문번호. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -561,6 +679,15 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21150",
         }
+        body = {
+            "ord_dt": ord_dt,
+            "query_tp": query_tp,
+            "slby_tp": slby_tp,
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "oppo_trde_tp": oppo_trde_tp,
+            "fr_ord_no": fr_ord_no,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -572,14 +699,12 @@ class OverseasAccount:
 
     def get_deposit_detail(
         self,
-        body: dict[str, str],
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountDepositDetail]:
         """미국주식 예수금 상세 (ust21160)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -594,6 +719,7 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21160",
         }
+        body: dict[str, str] = {}
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -605,14 +731,14 @@ class OverseasAccount:
 
     def get_today_realized_profit_loss_by_stock(
         self,
-        body: dict[str, str],
+        fc_krw_tp: Literal["0", "1"],
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountTodayRealizedProfitLossByStock]:
         """미국주식 당일 종목별 실현손익 (ust21170)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            fc_krw_tp (Literal["0", "1"]): 외화원화구분. 0:외화,1:원화
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -627,6 +753,9 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21170",
         }
+        body = {
+            "fc_krw_tp": fc_krw_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -638,14 +767,24 @@ class OverseasAccount:
 
     def get_order_history_by_period(
         self,
-        body: dict[str, str],
+        strt_dt: str,
+        end_dt: str,
+        slby_tp: Literal["", "0", "1", "2"] = "",
+        stex_tp: Literal["", "ND", "NY", "NA"] = "",
+        stk_cd: str = "",
+        oppo_trde_tp: Literal["", "%", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountOrderHistoryByPeriod]:
         """미국주식 기간별 주문내역 (ust21180)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            strt_dt (str): 시작주문일자. YYYYMMDD
+            end_dt (str): 종료주문일자. YYYYMMDD
+            slby_tp (Literal["", "0", "1", "2"], optional): 매도수구분. 0:전체(기본값),1:매도,2:매수. Defaults to "".
+            stex_tp (Literal["", "ND", "NY", "NA"], optional): 거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX. Defaults to "".
+            stk_cd (str, optional): 종목코드. 미입력시 전체. Defaults to "".
+            oppo_trde_tp (Literal["", "%", "0", "1"], optional): 반대매매구분. %:전체,0:일반,1:반대매매. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -660,6 +799,14 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21180",
         }
+        body = {
+            "strt_dt": strt_dt,
+            "end_dt": end_dt,
+            "slby_tp": slby_tp,
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "oppo_trde_tp": oppo_trde_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -671,14 +818,18 @@ class OverseasAccount:
 
     def get_today_order_execution(
         self,
-        body: dict[str, str],
+        slby_tp: Literal["", "0", "1", "2"] = "",
+        stex_tp: Literal["", "ND", "NY", "NA"] = "",
+        stk_cd: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountTodayOrderExecution]:
         """미국주식 당일 주문체결 확인 (ust21510)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            slby_tp (Literal["", "0", "1", "2"], optional): 매도매수구분. 0:전체,1:매도,2:매수. Defaults to "".
+            stex_tp (Literal["", "ND", "NY", "NA"], optional): 거래소구분. 종목코드 입력시. Defaults to "".
+            stk_cd (str, optional): 종목코드. 미입력시 전체. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -693,6 +844,11 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21510",
         }
+        body = {
+            "slby_tp": slby_tp,
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -704,14 +860,18 @@ class OverseasAccount:
 
     def get_realized_profit_loss(
         self,
-        body: dict[str, str],
+        strt_dt: str = "",
+        end_dt: str = "",
+        fc_krw_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountRealizedProfitLoss]:
         """미국주식 실현손익 (ust21530)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            strt_dt (str, optional): 시작일자. YYYYMMDD. Defaults to "".
+            end_dt (str, optional): 종료일자. YYYYMMDD. Defaults to "".
+            fc_krw_tp (Literal["", "0", "1"], optional): 외화원화구분. 0:외화,1:원화. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -726,6 +886,11 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21530",
         }
+        body = {
+            "strt_dt": strt_dt,
+            "end_dt": end_dt,
+            "fc_krw_tp": fc_krw_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -737,14 +902,18 @@ class OverseasAccount:
 
     def get_today_trading(
         self,
-        body: dict[str, str],
+        qry_tp: Literal["0", "1"],
+        fc_krw_tp: Literal["0", "1"],
+        base_dt: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountTodayTrading]:
         """미국주식 당일매매 (ust21610)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            qry_tp (Literal["0", "1"]): 조회구분. 0:당일매수에대한당일매도,1:당일매도전체
+            fc_krw_tp (Literal["0", "1"]): 외화원화구분. 0:외화,1:원화
+            base_dt (str, optional): 기준일자. YYYYMMDD. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -759,6 +928,11 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21610",
         }
+        body = {
+            "base_dt": base_dt,
+            "qry_tp": qry_tp,
+            "fc_krw_tp": fc_krw_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -770,14 +944,18 @@ class OverseasAccount:
 
     def get_today_trading_summary(
         self,
-        body: dict[str, str],
+        fc_krw_tp: Literal["0", "1"],
+        stex_tp: Literal["", "NA", "ND", "NY"] = "",
+        stk_cd: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountTodayTradingSummary]:
         """미국주식 당일매매정리 (ust21620)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            fc_krw_tp (Literal["0", "1"]): 외화원화구분. 0:외화,1:원화
+            stex_tp (Literal["", "NA", "ND", "NY"], optional): 거래소구분. NA:AMEX, ND:NASDAQ, NY:NYSE. Defaults to "".
+            stk_cd (str, optional): 종목코드. 기본값 전체. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -792,6 +970,11 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21620",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "fc_krw_tp": fc_krw_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -803,14 +986,18 @@ class OverseasAccount:
 
     def get_today_realized_profit_loss(
         self,
-        body: dict[str, str],
+        fc_krw_tp: Literal["0", "1"],
+        stex_tp: Literal["", "ND", "NY", "NA"] = "",
+        stk_cd: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountTodayRealizedProfitLoss]:
         """미국주식 당일 실현손익 (ust21630)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            fc_krw_tp (Literal["0", "1"]): 외화원화구분. 0:외화,1:원화
+            stex_tp (Literal["", "ND", "NY", "NA"], optional): 거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX. Defaults to "".
+            stk_cd (str, optional): 종목코드. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -825,6 +1012,11 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21630",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "fc_krw_tp": fc_krw_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -836,14 +1028,20 @@ class OverseasAccount:
 
     def get_daily_realized_profit_loss_by_stock(
         self,
-        body: dict[str, str],
+        cntr_dt: str,
+        fc_krw_tp: Literal["0", "1"],
+        stex_tp: Literal["", "ND", "NY", "NA"] = "",
+        stk_cd: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountDailyRealizedProfitLossByStock]:
         """미국주식 일별 종목별 실현손익 (ust21640)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cntr_dt (str): 체결일자. YYYYMMDD
+            fc_krw_tp (Literal["0", "1"]): 외화원화구분. 0:외화,1:원화
+            stex_tp (Literal["", "ND", "NY", "NA"], optional): 거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX. Defaults to "".
+            stk_cd (str, optional): 종목코드. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -858,6 +1056,12 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21640",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "cntr_dt": cntr_dt,
+            "fc_krw_tp": fc_krw_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -869,14 +1073,16 @@ class OverseasAccount:
 
     def get_profit_rate_by_period(
         self,
-        body: dict[str, str],
+        fr_dt: str = "",
+        to_dt: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountProfitRateByPeriod]:
         """미국주식 기간별 수익률 현황 (ust21650)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            fr_dt (str, optional): 조회시작일자. YYYYMMDD. Defaults to "".
+            to_dt (str, optional): 조회종료일자. YYYYMMDD. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -891,6 +1097,10 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21650",
         }
+        body = {
+            "fr_dt": fr_dt,
+            "to_dt": to_dt,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -902,14 +1112,16 @@ class OverseasAccount:
 
     def get_daily_realized_profit_loss(
         self,
-        body: dict[str, str],
+        strt_dt: str = "",
+        end_dt: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountDailyRealizedProfitLoss]:
         """미국주식 일별 실현손익 (ust21660)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            strt_dt (str, optional): 시작일자. YYYYMMDD. Defaults to "".
+            end_dt (str, optional): 종료일자. YYYYMMDD. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -924,6 +1136,10 @@ class OverseasAccount:
             "next-key": next_key,
             "api-id": "ust21660",
         }
+        body = {
+            "strt_dt": strt_dt,
+            "end_dt": end_dt,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -935,14 +1151,16 @@ class OverseasAccount:
 
     def get_monthly_realized_profit_loss(
         self,
-        body: dict[str, str],
+        strt_dt: str = "",
+        end_dt: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasAccountMonthlyRealizedProfitLoss]:
         """미국주식 월별 실현손익 (ust21661)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            strt_dt (str, optional): 시작일자. YYYYMM. Defaults to "".
+            end_dt (str, optional): 종료일자. YYYYMM. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -956,6 +1174,10 @@ class OverseasAccount:
             "cont-yn": cont_yn,
             "next-key": next_key,
             "api-id": "ust21661",
+        }
+        body = {
+            "strt_dt": strt_dt,
+            "end_dt": end_dt,
         }
 
         response = self.client._post(self.path, headers, body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_account.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_account.py
@@ -1,0 +1,967 @@
+from typing import Literal
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._model import (
+    KiwoomHttpHeader,
+    KiwoomHttpResponse,
+)
+from cluefin_openapi.kiwoom._overseas_account_types import (
+    OverseasAccountDailyOrderExecutionHistory,
+    OverseasAccountDailyProfitRate,
+    OverseasAccountDailyRealizedProfitLoss,
+    OverseasAccountDailyRealizedProfitLossByStock,
+    OverseasAccountDailyStockProfitRate,
+    OverseasAccountDeposit,
+    OverseasAccountDepositAndSecuritiesValuationByCurrency,
+    OverseasAccountDepositAndSecuritiesValuationByCurrencyByDate,
+    OverseasAccountDepositDetail,
+    OverseasAccountKrwWithdrawableAmount,
+    OverseasAccountLedgerBalance,
+    OverseasAccountLedgerUnfilledOrders,
+    OverseasAccountLedgerValuationAmount,
+    OverseasAccountMonthlyProfitRate,
+    OverseasAccountMonthlyRealizedProfitLoss,
+    OverseasAccountMonthlyStockProfitRate,
+    OverseasAccountOrderHistoryByPeriod,
+    OverseasAccountProfitRateByPeriod,
+    OverseasAccountRealizedProfitLoss,
+    OverseasAccountTodayOrderExecution,
+    OverseasAccountTodayRealizedProfitLoss,
+    OverseasAccountTodayRealizedProfitLossByStock,
+    OverseasAccountTodayTrading,
+    OverseasAccountTodayTradingSummary,
+    OverseasAccountTransactionHistory,
+    OverseasAccountValuationAmountByDate,
+    OverseasAccountYearlyProfitRate,
+    OverseasAccountYearlyStockProfitRate,
+)
+
+
+class OverseasAccount:
+    def __init__(self, client: Client):
+        self.client = client
+        self.path = "/api/us/acnt"
+
+    def get_daily_account_profit_rate(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountDailyProfitRate]:
+        """미국주식 일별계좌수익률현황 (usa21670)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountDailyProfitRate]: 미국주식 일별계좌수익률현황 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa21670",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching daily account profit rate: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountDailyProfitRate.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_monthly_account_profit_rate(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountMonthlyProfitRate]:
+        """미국주식 월별계좌수익률현황 (usa21680)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountMonthlyProfitRate]: 미국주식 월별계좌수익률현황 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa21680",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching monthly account profit rate: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountMonthlyProfitRate.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_yearly_account_profit_rate(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountYearlyProfitRate]:
+        """미국주식 연도별계좌수익률현황 (usa21690)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountYearlyProfitRate]: 미국주식 연도별계좌수익률현황 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa21690",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching yearly account profit rate: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountYearlyProfitRate.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_daily_stock_profit_rate(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountDailyStockProfitRate]:
+        """미국주식 일별종목수익률현황 (usa21730)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountDailyStockProfitRate]: 미국주식 일별종목수익률현황 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa21730",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching daily stock profit rate: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountDailyStockProfitRate.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_monthly_stock_profit_rate(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountMonthlyStockProfitRate]:
+        """미국주식 월별종목수익률현황 (usa21731)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountMonthlyStockProfitRate]: 미국주식 월별종목수익률현황 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa21731",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching monthly stock profit rate: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountMonthlyStockProfitRate.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_yearly_stock_profit_rate(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountYearlyStockProfitRate]:
+        """미국주식 연도별종목수익률현황 (usa21732)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountYearlyStockProfitRate]: 미국주식 연도별종목수익률현황 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa21732",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching yearly stock profit rate: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountYearlyStockProfitRate.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_ledger_unfilled_orders(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountLedgerUnfilledOrders]:
+        """미국주식 원장 미체결 (ust21050)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountLedgerUnfilledOrders]: 미국주식 원장 미체결 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21050",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching ledger unfilled orders: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountLedgerUnfilledOrders.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_ledger_balance(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountLedgerBalance]:
+        """미국주식 원장잔고확인 (ust21070)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountLedgerBalance]: 미국주식 원장잔고확인 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21070",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching ledger balance: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountLedgerBalance.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_transaction_history(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountTransactionHistory]:
+        """미국주식 거래내역 (ust21100)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountTransactionHistory]: 미국주식 거래내역 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21100",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching transaction history: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountTransactionHistory.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_deposit(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountDeposit]:
+        """해외주식 예수금 (ust21110)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountDeposit]: 해외주식 예수금 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21110",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching deposit: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountDeposit.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_krw_withdrawable_amount(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountKrwWithdrawableAmount]:
+        """원화출금가능 금액 조회(원화대용 포함) (ust21111)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountKrwWithdrawableAmount]: 원화출금가능 금액 조회(원화대용 포함) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21111",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching krw withdrawable amount: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountKrwWithdrawableAmount.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_deposit_and_securities_valuation_by_currency(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountDepositAndSecuritiesValuationByCurrency]:
+        """통화별 예수금 및 증권 평가금현황 (ust21120)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountDepositAndSecuritiesValuationByCurrency]: 통화별 예수금 및 증권 평가금현황 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21120",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching deposit and securities valuation by currency: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountDepositAndSecuritiesValuationByCurrency.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_ledger_valuation_amount(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountLedgerValuationAmount]:
+        """해외증권 원장 평가금액현황 (ust21121)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountLedgerValuationAmount]: 해외증권 원장 평가금액현황 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21121",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching ledger valuation amount: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountLedgerValuationAmount.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_valuation_amount_by_date(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountValuationAmountByDate]:
+        """해외증권 특정일 평가금액 (ust21131)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountValuationAmountByDate]: 해외증권 특정일 평가금액 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21131",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching valuation amount by date: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountValuationAmountByDate.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_deposit_and_securities_valuation_by_currency_on_date(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountDepositAndSecuritiesValuationByCurrencyByDate]:
+        """특정일 통화별 예수금 및 증권 평가금 (ust21132)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountDepositAndSecuritiesValuationByCurrencyByDate]: 특정일 통화별 예수금 및 증권 평가금 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21132",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching deposit and securities valuation by currency on date: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountDepositAndSecuritiesValuationByCurrencyByDate.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_daily_order_execution_history(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountDailyOrderExecutionHistory]:
+        """미국주식 일별 주문체결내역 (ust21150)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountDailyOrderExecutionHistory]: 미국주식 일별 주문체결내역 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21150",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching daily order execution history: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountDailyOrderExecutionHistory.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_deposit_detail(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountDepositDetail]:
+        """미국주식 예수금 상세 (ust21160)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountDepositDetail]: 미국주식 예수금 상세 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21160",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching deposit detail: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountDepositDetail.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_today_realized_profit_loss_by_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountTodayRealizedProfitLossByStock]:
+        """미국주식 당일 종목별 실현손익 (ust21170)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountTodayRealizedProfitLossByStock]: 미국주식 당일 종목별 실현손익 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21170",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching today realized profit loss by stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountTodayRealizedProfitLossByStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_order_history_by_period(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountOrderHistoryByPeriod]:
+        """미국주식 기간별 주문내역 (ust21180)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountOrderHistoryByPeriod]: 미국주식 기간별 주문내역 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21180",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching order history by period: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountOrderHistoryByPeriod.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_today_order_execution(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountTodayOrderExecution]:
+        """미국주식 당일 주문체결 확인 (ust21510)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountTodayOrderExecution]: 미국주식 당일 주문체결 확인 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21510",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching today order execution: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountTodayOrderExecution.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_realized_profit_loss(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountRealizedProfitLoss]:
+        """미국주식 실현손익 (ust21530)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountRealizedProfitLoss]: 미국주식 실현손익 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21530",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching realized profit loss: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountRealizedProfitLoss.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_today_trading(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountTodayTrading]:
+        """미국주식 당일매매 (ust21610)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountTodayTrading]: 미국주식 당일매매 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21610",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching today trading: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountTodayTrading.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_today_trading_summary(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountTodayTradingSummary]:
+        """미국주식 당일매매정리 (ust21620)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountTodayTradingSummary]: 미국주식 당일매매정리 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21620",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching today trading summary: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountTodayTradingSummary.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_today_realized_profit_loss(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountTodayRealizedProfitLoss]:
+        """미국주식 당일 실현손익 (ust21630)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountTodayRealizedProfitLoss]: 미국주식 당일 실현손익 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21630",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching today realized profit loss: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountTodayRealizedProfitLoss.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_daily_realized_profit_loss_by_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountDailyRealizedProfitLossByStock]:
+        """미국주식 일별 종목별 실현손익 (ust21640)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountDailyRealizedProfitLossByStock]: 미국주식 일별 종목별 실현손익 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21640",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching daily realized profit loss by stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountDailyRealizedProfitLossByStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_profit_rate_by_period(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountProfitRateByPeriod]:
+        """미국주식 기간별 수익률 현황 (ust21650)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountProfitRateByPeriod]: 미국주식 기간별 수익률 현황 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21650",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching profit rate by period: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountProfitRateByPeriod.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_daily_realized_profit_loss(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountDailyRealizedProfitLoss]:
+        """미국주식 일별 실현손익 (ust21660)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountDailyRealizedProfitLoss]: 미국주식 일별 실현손익 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21660",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching daily realized profit loss: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountDailyRealizedProfitLoss.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_monthly_realized_profit_loss(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasAccountMonthlyRealizedProfitLoss]:
+        """미국주식 월별 실현손익 (ust21661)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasAccountMonthlyRealizedProfitLoss]: 미국주식 월별 실현손익 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust21661",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching monthly realized profit loss: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasAccountMonthlyRealizedProfitLoss.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_account_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_account_types.py
@@ -1,172 +1,850 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 
 from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 
 
+class OverseasAccountDailyProfitRateItem(BaseModel):
+    base_dt: str = Field(default="", description="기준일")
+    stk_evlta: str = Field(default="", description="주식평가금")
+    pl_amt: str = Field(default="", description="손익금액")
+    dvid_amt: str = Field(default="", description="배당금액")
+    cmsn_tax: str = Field(default="", description="수수료+세금")
+    acum_pl_amt: str = Field(default="", description="누적손익")
+    pymn_amt: str = Field(default="", description="출금금액")
+    dast: str = Field(default="", description="예탁자산")
+    dly_amt: str = Field(default="", description="연체금액")
+    sell_amt: str = Field(default="", description="매도금액")
+    buy_amt: str = Field(default="", description="매수금액")
+    prft_rt: str = Field(default="", description="수익률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    frgn_stk_outq_amt: str = Field(default="", description="출고금액")
+    frgn_stk_inq_amt: str = Field(default="", description="입고금액")
+    ina_amt: str = Field(default="", description="입금금액")
+    exrt: str = Field(default="", description="환율")
+
+
 class OverseasAccountDailyProfitRate(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 일별계좌수익률현황 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountDailyProfitRateItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountMonthlyProfitRateItem(BaseModel):
+    base_dt: str = Field(default="", description="기준일")
+    stk_evlta: str = Field(default="", description="주식평가금")
+    pl_amt: str = Field(default="", description="손익금액")
+    dvid_amt: str = Field(default="", description="배당금액")
+    cmsn_tax: str = Field(default="", description="수수료+세금")
+    acum_pl_amt: str = Field(default="", description="누적손익")
+    pymn_amt: str = Field(default="", description="출금금액")
+    dast: str = Field(default="", description="예탁자산")
+    dly_amt: str = Field(default="", description="연체금액")
+    sell_amt: str = Field(default="", description="매도금액")
+    buy_amt: str = Field(default="", description="매수금액")
+    prft_rt: str = Field(default="", description="수익률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    frgn_stk_outq_amt: str = Field(default="", description="출고금액")
+    frgn_stk_inq_amt: str = Field(default="", description="입고금액")
+    ina_amt: str = Field(default="", description="입금금액")
+    exrt: str = Field(default="", description="환율")
 
 
 class OverseasAccountMonthlyProfitRate(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 월별계좌수익률현황 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountMonthlyProfitRateItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountYearlyProfitRateItem(BaseModel):
+    base_dt: str = Field(default="", description="기준일")
+    stk_evlta: str = Field(default="", description="주식평가금")
+    pl_amt: str = Field(default="", description="손익금액")
+    dvid_amt: str = Field(default="", description="배당금액")
+    cmsn_tax: str = Field(default="", description="수수료+세금")
+    acum_pl_amt: str = Field(default="", description="누적손익")
+    pymn_amt: str = Field(default="", description="출금금액")
+    dast: str = Field(default="", description="예탁자산")
+    dly_amt: str = Field(default="", description="연체금액")
+    sell_amt: str = Field(default="", description="매도금액")
+    buy_amt: str = Field(default="", description="매수금액")
+    prft_rt: str = Field(default="", description="수익률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    frgn_stk_outq_amt: str = Field(default="", description="출고금액")
+    frgn_stk_inq_amt: str = Field(default="", description="입고금액")
+    ina_amt: str = Field(default="", description="입금금액")
+    exrt: str = Field(default="", description="환율")
 
 
 class OverseasAccountYearlyProfitRate(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 연도별계좌수익률현황 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountYearlyProfitRateItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountDailyStockProfitRateItem(BaseModel):
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    frst_base_dt: str = Field(default="", description="최초기준일")
+    last_base_dt: str = Field(default="", description="최종기준일")
+    pl_amt: str = Field(default="", description="매매수익")
+    prft_rt: str = Field(default="", description="수익률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    frst_stk_evlta: str = Field(default="", description="최초주식평가금")
+    last_stk_evlta: str = Field(default="", description="최종주식평가금")
+    frst_qty: str = Field(default="", description="최초수량")
+    last_qty: str = Field(default="", description="최종수량")
+    buy_qty: str = Field(default="", description="매수수량. 단위: 1주")
+    sell_qty: str = Field(default="", description="매도수량. 단위: 1주")
+    buy_amt: str = Field(default="", description="매수금. 단위: 1주")
+    sell_amt: str = Field(default="", description="매도금. 단위: 1주")
+    frgn_stk_inq_amt: str = Field(default="", description="입고평가금")
+    frgn_stk_outq_amt: str = Field(default="", description="출고평가금")
+    cmsn_tax: str = Field(default="", description="수수료+세금")
+    dvid_amt: str = Field(default="", description="배당금")
+    crnc_code: str = Field(default="", description="통화코드")
 
 
 class OverseasAccountDailyStockProfitRate(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 일별종목수익률현황 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountDailyStockProfitRateItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountMonthlyStockProfitRateItem(BaseModel):
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    frst_base_dt: str = Field(default="", description="최초기준일")
+    last_base_dt: str = Field(default="", description="최종기준일")
+    pl_amt: str = Field(default="", description="매매수익")
+    prft_rt: str = Field(default="", description="수익률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    frst_stk_evlta: str = Field(default="", description="최초주식평가금")
+    last_stk_evlta: str = Field(default="", description="최종주식평가금")
+    frst_qty: str = Field(default="", description="최초수량")
+    last_qty: str = Field(default="", description="최종수량")
+    buy_qty: str = Field(default="", description="매수수량. 단위: 1주")
+    sell_qty: str = Field(default="", description="매도수량. 단위: 1주")
+    buy_amt: str = Field(default="", description="매수금. 단위: 1주")
+    sell_amt: str = Field(default="", description="매도금. 단위: 1주")
+    frgn_stk_inq_amt: str = Field(default="", description="입고평가금")
+    frgn_stk_outq_amt: str = Field(default="", description="출고평가금")
+    cmsn_tax: str = Field(default="", description="수수료+세금")
+    dvid_amt: str = Field(default="", description="배당금")
+    crnc_code: str = Field(default="", description="통화코드")
 
 
 class OverseasAccountMonthlyStockProfitRate(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 월별종목수익률현황 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountMonthlyStockProfitRateItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountYearlyStockProfitRateItem(BaseModel):
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    frst_base_dt: str = Field(default="", description="최초기준일")
+    last_base_dt: str = Field(default="", description="최종기준일")
+    pl_amt: str = Field(default="", description="매매수익")
+    prft_rt: str = Field(default="", description="수익률")
+    frst_stk_evlta: str = Field(default="", description="최초주식평가금")
+    last_stk_evlta: str = Field(default="", description="최종주식평가금")
+    frst_qty: str = Field(default="", description="최초수량")
+    last_qty: str = Field(default="", description="최종수량")
+    buy_qty: str = Field(default="", description="매수수량. 단위: 1주")
+    sell_qty: str = Field(default="", description="매도수량. 단위: 1주")
+    buy_amt: str = Field(default="", description="매수금. 단위: 1주")
+    sell_amt: str = Field(default="", description="매도금. 단위: 1주")
+    frgn_stk_inq_amt: str = Field(default="", description="입고평가금")
+    frgn_stk_outq_amt: str = Field(default="", description="출고평가금")
+    cmsn_tax: str = Field(default="", description="수수료+세금")
+    dvid_amt: str = Field(default="", description="배당금")
+    crnc_code: str = Field(default="", description="통화코드")
 
 
 class OverseasAccountYearlyStockProfitRate(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 연도별종목수익률현황 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountYearlyStockProfitRateItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountLedgerUnfilledOrdersItem(BaseModel):
+    ord_cntr_tp: str = Field(default="", description="주문종류. 10:원주문,11:정정주문,12:취소주문")
+    ord_no: str = Field(default="", description="주문번호")
+    orig_ord_no: str = Field(default="", description="원주문번호. 원 주문이 없는 경우 '000000000'으로 출력")
+    stex_nm: str = Field(default="", description="거래소명")
+    crnc_code: str = Field(default="", description="통화코드. USD")
+    stk_cd: str = Field(default="", description="종목코드")
+    frgn_stk_nm: str = Field(default="", description="종목명")
+    frgn_trde_tp: str = Field(
+        default="",
+        description="매매구분. 00:지정가,03:시장가,11:Enhanced Limit Order,12:Special Limit Order,30:Limit On Close,33:Market On Close,34:Stop Limit,35:Stop Market,36:VWAP,37:TWAP",
+    )
+    frgn_trde_nm: str = Field(
+        default="",
+        description="매매구분명. 00:지정가,03:시장가,11:Enhanced Limit Order,12:Special Limit Order,30:Limit On Close,33:Market On Close,34:Stop Limit,35:Stop Market,36:VWAP,37:TWAP",
+    )
+    slby_tp: str = Field(default="", description="매도매수구분. 1:매도,2:매수")
+    slby_tp_nm: str = Field(default="", description="매도매수구분명. 1:매도,2:매수")
+    ord_qty: str = Field(default="", description="주문수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    ord_uv: str = Field(default="", description="주문단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    stop_pric: str = Field(default="", description="STOP가격. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cntr_qty: str = Field(default="", description="체결수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    cntr_uv: str = Field(default="", description="체결단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    mdfy_qty: str = Field(default="", description="정정수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    mdfy_uv: str = Field(default="", description="정정단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cncl_qty: str = Field(default="", description="취소수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    ord_remnq: str = Field(default="", description="주문잔량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    ord_time: str = Field(default="", description="주문시간. HH:mm:ss")
+    ord_resp_time: str = Field(default="", description="주문응답시간. HH:mm:ss")
+    ord_stat: str = Field(default="", description="주문상태명")
+    rsrv_tp: str = Field(default="", description="예약주문구분. 0:일반,1:예약")
+    natn_nm: str = Field(default="", description="국가명")
 
 
 class OverseasAccountLedgerUnfilledOrders(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 원장 미체결 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountLedgerUnfilledOrdersItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountLedgerBalanceItem(BaseModel):
+    stex_nm: str = Field(default="", description="거래소명")
+    crnc_code: str = Field(default="", description="통화코드")
+    stk_cd: str = Field(default="", description="종목코드")
+    frgn_stk_nm: str = Field(default="", description="종목명")
+    qty: str = Field(default="", description="결제기준수량")
+    poss_qty: str = Field(default="", description="보유수량")
+    sell_alowq: str = Field(default="", description="매도가능수량")
+    pred_cntr_sellq: str = Field(default="", description="전일매도수량")
+    pred_cntr_buyq: str = Field(default="", description="전일매수수량")
+    tdy_cntr_sellq: str = Field(default="", description="금일매도수량")
+    tdy_cntr_buyq: str = Field(default="", description="금일매수수량")
+    frgn_stk_book_uv: str = Field(default="", description="매입단가")
+    now_pric: str = Field(default="", description="현재가")
+    evlt_amt: str = Field(default="", description="평가금액")
+    pl_amt: str = Field(default="", description="손익금액")
+    pl_rt: str = Field(default="", description="손익율(%)")
+    evlt_amt_krw: str = Field(default="", description="평가금액(원)")
+    pl_amt_krw: str = Field(default="", description="손익금액(원)")
+    natn_nm: str = Field(default="", description="국가명")
+    exch_rate: str = Field(default="", description="환율")
+    frgn_stk_book_uv_krw: str = Field(default="", description="매입단가(원)")
+    now_pric_krw: str = Field(default="", description="현재가(원)")
+    frgn_stk_book_amt: str = Field(default="", description="매입금액")
+    frgn_stk_book_amt_krw: str = Field(default="", description="매입금액(원)")
 
 
 class OverseasAccountLedgerBalance(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 원장잔고확인 응답")
 
-    # TODO: 응답 필드 정의
+    crnc_code: str = Field(default="", description="통화코드. USD")
+    tot_evlt_amt: str = Field(default="", description="총평가금액")
+    tot_prch_amt: str = Field(default="", description="총매입금액")
+    tot_pl_amt: str = Field(default="", description="총손익금액")
+    tot_pl_rt: str = Field(default="", description="총수익율")
+    tdy_book_amt: str = Field(default="", description="당일실현손익매입금액")
+    tdy_pl_amt: str = Field(default="", description="당일실현손익")
+    tdy_pl_rt: str = Field(default="", description="당일실현손익율(%)")
+    tot_evlt_amt_krw: str = Field(default="", description="총평가금액(원)")
+    tot_prch_amt_krw: str = Field(default="", description="총매입금액(원)")
+    tot_pl_amt_krw: str = Field(default="", description="총손익금액(원)")
+    tdy_book_amt_krw: str = Field(default="", description="당일실현손익매입금액(원)")
+    tdy_pl_amt_krw: str = Field(default="", description="당일실현손익(원)")
+    result_list: list[OverseasAccountLedgerBalanceItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountTransactionHistoryItem(BaseModel):
+    deal_dt: str = Field(default="", description="거래일자")
+    deal_kind_nm: str = Field(default="", description="거래종류명")
+    rmrk_nm: str = Field(default="", description="적요명")
+    deal_amt: str = Field(default="", description="거래금액")
+    tax_tot_amt: str = Field(default="", description="소득/주민세. 기존:세금합")
+    exct_amt: str = Field(default="", description="정산금액")
+    uncl_ocr: str = Field(default="", description="미수(원/주)")
+    fc_uncl_ocr: str = Field(default="", description="미수(외)")
+    entra_remn: str = Field(default="", description="예수금잔고")
+    deal_no: str = Field(default="", description="거래번호")
+    stk_nm: str = Field(default="", description="종목명")
+    deal_qty: str = Field(default="", description="거래수량")
+    fc_deal_tax: str = Field(default="", description="거래세(외)")
+    frgn_pay_txam: str = Field(default="", description="외국납부세액(외)")
+    rpym_sum: str = Field(default="", description="변제합")
+    fc_rpym_sum: str = Field(default="", description="변제합(외)")
+    fc_entra: str = Field(default="", description="외화예수금잔고")
+    mdia_nm: str = Field(default="", description="메체구분명")
+    orig_deal_no: str = Field(default="", description="원거래번호")
+    stk_cd: str = Field(default="", description="종목코드")
+    uv_exrt: str = Field(default="", description="거래단가/환율")
+    fc_cmsn: str = Field(default="", description="수수료(외)")
+    fc_exct_amt: str = Field(default="", description="정산금액(외)")
+    dly_sum: str = Field(default="", description="연체합")
+    fc_dly_sum: str = Field(default="", description="연체합(외)")
+    vlbl_nowrm: str = Field(default="", description="유가금잔")
+    stex_nm: str = Field(default="", description="거래소구분명")
+    fc_deal_amt: str = Field(default="", description="거래금액(외)")
+    proc_time: str = Field(default="", description="처리시간")
+    crnc_code: str = Field(default="", description="통화코드")
 
 
 class OverseasAccountTransactionHistory(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 거래내역 응답")
 
-    # TODO: 응답 필드 정의
+    acnt_print: str = Field(default="", description="계좌번호. 계좌번호 출력용")
+    sell_sum: str = Field(default="", description="매도합계")
+    buy_sum: str = Field(default="", description="매수합계")
+    result_list: list[OverseasAccountTransactionHistoryItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountDepositItem(BaseModel):
+    crnc_code: str = Field(default="", description="통화코드")
+    crnc_nm: str = Field(default="", description="통화명")
+    fc_entra: str = Field(default="", description="외화예수금")
+    fc_pymn_alowa: str = Field(default="", description="외화출금가능금액")
+    futr_repl_profa: str = Field(default="", description="선물대용증거금")
+    fc_booka: str = Field(default="", description="외화장부금액")
+    fc_ord_alowa: str = Field(default="", description="외화주문가능금액")
+    futr_profa_booka: str = Field(default="", description="선물증거금장부금액")
+    fc_ch_uncla: str = Field(default="", description="외화현금미수금")
+    fc_etc_loana: str = Field(default="", description="외화기타대여금")
 
 
 class OverseasAccountDeposit(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="해외주식 예수금 응답")
 
-    # TODO: 응답 필드 정의
+    krw_entra: str = Field(default="", description="원화예수금")
+    ch_uncla: str = Field(default="", description="현금미수금")
+    etc_loana: str = Field(default="", description="기타대여금")
+    result_list: list[OverseasAccountDepositItem] = Field(default_factory=list, description="결과리스트")
 
 
 class OverseasAccountKrwWithdrawableAmount(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="원화출금가능 금액 조회(원화대용 포함) 응답")
 
-    # TODO: 응답 필드 정의
+    rgst_abnd_tp: str = Field(
+        default="", description="원화대용등록해지구분. 원화대용약정등록상태 1:신청,2:해지 또는 미신청"
+    )
+    krw_pymn_alow_amt: str = Field(default="", description="원화출금가능금액. 원화대용포함한 원화출금가능금액")
+    krw_repl_abnd_amt: str = Field(default="", description="원화대용해지가능금액")
+
+
+class OverseasAccountDepositAndSecuritiesValuationByCurrencyItem(BaseModel):
+    crnc_code: str = Field(default="", description="통화코드")
+    fx_entr: str = Field(default="", description="외화예수금. 소수점 및 소수점 이하2자리 포함")
+    evlt_amt: str = Field(default="", description="해외증권평가금. 소수점 및 소수점 이하2자리 포함")
+    crnc_rt: str = Field(default="", description="기준환율. 소수점 및 소수점 이하2자리 포함")
+    chg_entr: str = Field(default="", description="환전예수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    chg_evlt_amt: str = Field(default="", description="환전평가금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    evlt_amt_wght: str = Field(default="", description="평가금액비중. 소수점 둘째 자리까지 포맷된 숫자")
 
 
 class OverseasAccountDepositAndSecuritiesValuationByCurrency(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="통화별 예수금 및 증권 평가금현황 응답")
 
-    # TODO: 응답 필드 정의
+    won_entr: str = Field(default="", description="예수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    aset_evlt_amt: str = Field(default="", description="원화추정자산. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    result_list: list[OverseasAccountDepositAndSecuritiesValuationByCurrencyItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasAccountLedgerValuationAmountItem(BaseModel):
+    natn_nm: str = Field(default="", description="국가명")
+    stex_nm: str = Field(default="", description="거래소코드명")
+    crnc_code: str = Field(default="", description="통화코드")
+    crnc_nm: str = Field(default="", description="통화코드명")
+    evlt_amt: str = Field(default="", description="평가금액")
+    chg_evlt_amt: str = Field(
+        default="", description="환전평가금액. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자"
+    )
+    pl_rt: str = Field(default="", description="평가수익율(%). 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    pl_amt: str = Field(default="", description="평가손익")
+    chg_profit_amt: str = Field(
+        default="", description="환전평가손익. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자"
+    )
+    evlt_amt_wght: str = Field(default="", description="평가금액비중. 소수점 둘째 자리까지 포맷된 숫자")
 
 
 class OverseasAccountLedgerValuationAmount(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="해외증권 원장 평가금액현황 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountLedgerValuationAmountItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountValuationAmountByDateItem(BaseModel):
+    natn_nm: str = Field(default="", description="국가명")
+    stex_nm: str = Field(default="", description="거래소코드명")
+    crnc_code: str = Field(default="", description="통화코드")
+    crnc_nm: str = Field(default="", description="통화코드명")
+    evlt_amt: str = Field(default="", description="평가금액. 단위: USD, 소수점 둘째 자리까지 포맷된 숫자")
+    chg_evlt_amt: str = Field(
+        default="", description="환전평가금액. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자"
+    )
+    pl_rt: str = Field(default="", description="평가수익율(%). 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    pl_amt: str = Field(default="", description="평가손익. 단위: USD, 소수점 둘째 자리까지 포맷된 숫자")
+    chg_profit_amt: str = Field(
+        default="", description="환전평가손익. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자"
+    )
+    evlt_amt_wght: str = Field(default="", description="평가금액비중. 소수점 둘째 자리까지 포맷된 숫자")
 
 
 class OverseasAccountValuationAmountByDate(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="해외증권 특정일 평가금액 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountValuationAmountByDateItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountDepositAndSecuritiesValuationByCurrencyByDateItem(BaseModel):
+    crnc_code: str = Field(default="", description="통화코드")
+    fx_entr: str = Field(default="", description="외화예수금. 소수점 및 소수점 이하2자리 포함")
+    evlt_amt: str = Field(default="", description="해외증권평가금. 소수점 및 소수점 이하2자리 포함")
+    crnc_rt: str = Field(default="", description="기준환율. 소수점 및 소수점 이하2자리 포함")
+    chg_entr: str = Field(default="", description="환전예수금. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자")
+    chg_evlt_amt: str = Field(
+        default="", description="환전평가금. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자"
+    )
+    evlt_amt_wght: str = Field(default="", description="평가금액비중. 소수점 둘째 자리까지 포맷된 숫자")
 
 
 class OverseasAccountDepositAndSecuritiesValuationByCurrencyByDate(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="특정일 통화별 예수금 및 증권 평가금 응답")
 
-    # TODO: 응답 필드 정의
+    won_entr: str = Field(default="", description="예수금. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자")
+    tot_evlt_amt: str = Field(
+        default="", description="총평가금액. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자"
+    )
+    book_amt: str = Field(default="", description="총매입금액. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자")
+    tot_pl: str = Field(default="", description="총손익금액. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자")
+    tot_pl_rt: str = Field(default="", description="총수익률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    aset_evlt_amt: str = Field(
+        default="", description="원화추정자산. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자"
+    )
+    result_list: list[OverseasAccountDepositAndSecuritiesValuationByCurrencyByDateItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasAccountDailyOrderExecutionHistoryItem(BaseModel):
+    ord_no: str = Field(default="", description="주문번호")
+    crnc_code: str = Field(default="", description="통화코드")
+    stk_cd: str = Field(default="", description="종목코드")
+    isin_code: str = Field(default="", description="국제표준코드")
+    frgn_trde_tp: str = Field(default="", description="매매구분")
+    ord_qty: str = Field(default="", description="주문수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    cntr_qty: str = Field(default="", description="체결수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    mdfy_qty: str = Field(default="", description="정정수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    cncl_qty: str = Field(default="", description="취소수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    frgn_msg_code: str = Field(default="", description="해외메세지코드")
+    rsrv_tp: str = Field(default="", description="예약구분")
+    oppo_trde_tp_nm: str = Field(default="", description="반대매매구분명")
+    comm_ord_tp_nm: str = Field(default="", description="통신주문구분명")
+    ord_time: str = Field(default="", description="주문시간. HH:mm:ss")
+    crnc_nm: str = Field(default="", description="통화코드명")
+    stex_nm: str = Field(default="", description="거래소코드명")
+    frgn_stk_nm: str = Field(default="", description="종목명")
+    slby_tp_nm: str = Field(default="", description="매도매수구분명")
+    ord_uv: str = Field(default="", description="주문단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    stop_pric: str = Field(default="", description="STOP가격. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cntr_uv: str = Field(default="", description="체결단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    mdfy_uv: str = Field(default="", description="정정단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    ord_remnq: str = Field(default="", description="주문잔량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    ord_stat_nm: str = Field(default="", description="주문상태명")
+    text1: str = Field(default="", description="거부사유")
+    inpt_chnl_tp: str = Field(default="", description="입력매체구분명")
+    ord_resp_time: str = Field(default="", description="주문응답수신시간. HH:mm:ss")
+    cntr_time: str = Field(default="", description="체결시간")
 
 
 class OverseasAccountDailyOrderExecutionHistory(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 일별 주문체결내역 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountDailyOrderExecutionHistoryItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
 
 
 class OverseasAccountDepositDetail(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 예수금 상세 응답")
 
-    # TODO: 응답 필드 정의
+    won_entr: str = Field(default="", description="원화 예수금. 단위: 원, 좌측 0-padding 처리된 부호 포함 15자리 숫자")
+    won_dfr_amt: str = Field(default="", description="미수금. 단위: 원, 좌측 0-padding 처리된 부호 포함 15자리 숫자")
+    won_etc_loana: str = Field(
+        default="", description="기타 대여금. 단위: 원, 좌측 0-padding 처리된 부호 포함 15자리 숫자"
+    )
+    krw_ord_set_amt: str = Field(
+        default="", description="해외원화주문설정금. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자"
+    )
+    usd_exch_rate: str = Field(default="", description="매도환율(USD). 세자릿수 콤마, 소수점 둘째 자리까지 포맷된 숫자")
+    d0_setl_dt: str = Field(default="", description="D0 국내결제일자. YYYYMMDD")
+    d0_won_conv_alow_ch: str = Field(
+        default="", description="D0 원화환산추정인출가능금. 단위: 원, 좌측 0-padding 처리된 부호 포함 15자리 숫자"
+    )
+    d0_usd_fx_entr: str = Field(default="", description="D0 외화예수금(USD)")
+    d1_setl_dt: str = Field(default="", description="D1 국내결제일자")
+    d1_won_conv_alow_ch: str = Field(default="", description="D1 원화환산추정인출가능금")
+    d1_usd_fx_entr: str = Field(default="", description="D1 외화예수금(USD)")
+    d1_usd_exct_amt: str = Field(default="", description="D1 해외정산금(USD)")
+    d1_usd_buy_excta: str = Field(default="", description="D1 해외매수정산금(USD)")
+    d1_usd_sell_excta: str = Field(default="", description="D1 해외매도정산금(USD)")
+    d2_setl_dt: str = Field(default="", description="D2 국내결제일자. YYYYMMDD")
+    d2_won_conv_alow_ch: str = Field(
+        default="", description="D2 원화환산추정인출가능금. 단위: 원, 좌측 0-padding 처리된 부호 포함 15자리 숫자"
+    )
+    d2_usd_fx_entr: str = Field(default="", description="D2 외화예수금(USD)")
+    d2_usd_exct_amt: str = Field(default="", description="D2 해외정산금(USD)")
+    d2_usd_buy_excta: str = Field(default="", description="D2 해외매수정산금(USD)")
+    d2_usd_sell_excta: str = Field(default="", description="D2 해외매도정산금(USD)")
+    d3_setl_dt: str = Field(default="", description="D3 국내결제일자. YYYYMMDD")
+    d3_won_conv_alow_ch: str = Field(
+        default="", description="D3 원화환산추정인출가능금. 단위: 원, 좌측 0-padding 처리된 부호 포함 15자리 숫자"
+    )
+    d3_usd_fx_entr: str = Field(default="", description="D3 외화예수금(USD)")
+    d3_usd_exct_amt: str = Field(default="", description="D3 해외정산금(USD)")
+    d3_usd_buy_excta: str = Field(default="", description="D3 해외매수정산금(USD)")
+    d3_usd_sell_excta: str = Field(default="", description="D3 해외매도정산금(USD)")
+    d4_setl_dt: str = Field(default="", description="D4 국내결제일자. YYYYMMDD")
+    d4_won_conv_alow_ch: str = Field(
+        default="", description="D4 원화환산추정인출가능금. 단위: 원, 좌측 0-padding 처리된 부호 포함 15자리 숫자"
+    )
+    d4_usd_fx_entr: str = Field(default="", description="D4 외화예수금(USD)")
+    d4_usd_exct_amt: str = Field(default="", description="D4 해외정산금(USD)")
+    d4_usd_buy_excta: str = Field(default="", description="D4 해외매수정산금(USD)")
+    d4_usd_sell_excta: str = Field(default="", description="D4 해외매도정산금(USD)")
+
+
+class OverseasAccountTodayRealizedProfitLossByStockItem(BaseModel):
+    stex_nm: str = Field(default="", description="거래소명")
+    crnc_code: str = Field(default="", description="통화코드")
+    stk_cd: str = Field(default="", description="종목코드")
+    frgn_stk_nm: str = Field(default="", description="종목명")
+    tdy_pl_amt: str = Field(default="", description="당일실현손익금액. 소수점 넷째 자리까지 포맷된 숫자")
+    evlt_pl_amt: str = Field(default="", description="평가손익금액. 소수점 넷째 자리까지 포맷된 숫자")
+    evlt_pl_rt: str = Field(
+        default="", description="평가수익율(%). 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    prch_uv: str = Field(default="", description="매입단가. 소수점 넷째 자리까지 포맷된 숫자")
+    poss_qty: str = Field(default="", description="보유수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    sell_alowq: str = Field(default="", description="매도가능수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    now_pric: str = Field(default="", description="현재가. 소수점 넷째 자리까지 포맷된 숫자")
+    prch_amt: str = Field(default="", description="매입금액. 소수점 넷째 자리까지 포맷된 숫자")
+    evlt_amt: str = Field(default="", description="평가금액. 소수점 넷째 자리까지 포맷된 숫자")
+    prch_exrt: str = Field(default="", description="매입환율. 소수점 둘째 자리까지 포맷된 숫자")
+    sell_exrt: str = Field(default="", description="매도환율. 소수점 둘째 자리까지 포맷된 숫자")
+    krw_chg_dfrn_pl_amt: str = Field(
+        default="", description="환차손익(원). 단위: 원, 좌측 0-padding 처리된 15자리 숫자"
+    )
+    krw_chg_pl_amt: str = Field(default="", description="환실현손익(원). 단위: 원, 좌측 0-padding 처리된 15자리 숫자")
+    evlt_amt_cmsn: str = Field(default="", description="평가금액수수료. 소수점 넷째 자리까지 포맷된 숫자")
+    evlt_amt_tax: str = Field(default="", description="평가금액세금. 소수점 넷째 자리까지 포맷된 숫자")
+    natn_nm: str = Field(default="", description="국가명")
 
 
 class OverseasAccountTodayRealizedProfitLossByStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 당일 종목별 실현손익 응답")
 
-    # TODO: 응답 필드 정의
+    crnc_code: str = Field(default="", description="통화코드. 거래소전체 KRW")
+    tot_evlt_amt: str = Field(default="", description="총평가금액. 소수점 넷째 자리까지 포맷된 숫자")
+    tot_prch_amt: str = Field(default="", description="총매입금액. 소수점 넷째 자리까지 포맷된 숫자")
+    tot_pl_amt: str = Field(default="", description="총손익금액. 소수점 넷째 자리까지 포맷된 숫자")
+    tot_pl_rt: str = Field(default="", description="총수익율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    tdy_pl_amt: str = Field(default="", description="당일실현손익. 소수점 넷째 자리까지 포맷된 숫자")
+    prsm_aseta_krw: str = Field(default="", description="추정자산(원). 단위: 원, 좌측 0-padding 처리된 15자리 숫자")
+    result_list: list[OverseasAccountTodayRealizedProfitLossByStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasAccountOrderHistoryByPeriodItem(BaseModel):
+    ord_dt: str = Field(default="", description="주문일. YYYYMMDD")
+    ord_no: str = Field(default="", description="주문번호")
+    crnc_code: str = Field(default="", description="해당통화코드")
+    stk_cd: str = Field(default="", description="종목코드")
+    trde_tp: str = Field(default="", description="매매구분")
+    ord_qty: str = Field(default="", description="주문수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    cntr_qty: str = Field(default="", description="체결수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    mdfy_qty: str = Field(default="", description="정정수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    cncl_qty: str = Field(default="", description="취소수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    rsrv_tp: str = Field(default="", description="예약구분")
+    oppo_trde_tp_nm: str = Field(default="", description="반대매매구분명")
+    inpt_chnl_tp_nm: str = Field(default="", description="입력매체명")
+    ord_time: str = Field(default="", description="주문시간. HH:mm:ss")
+    crnc_nm: str = Field(default="", description="통화명")
+    stex_nm: str = Field(default="", description="거래소명")
+    stk_nm: str = Field(default="", description="종목명")
+    slby_tp_nm: str = Field(default="", description="매도매수구분명")
+    ord_uv: str = Field(default="", description="주문단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    stop_pric: str = Field(default="", description="STOP가격. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cntr_uv: str = Field(default="", description="체결단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    mdfy_uv: str = Field(default="", description="정정단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    ord_remnq: str = Field(default="", description="주문잔량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    cntr_amt: str = Field(default="", description="체결금액")
+    comm_ord_tp_nm: str = Field(default="", description="통신주문구분명")
 
 
 class OverseasAccountOrderHistoryByPeriod(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 기간별 주문내역 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountOrderHistoryByPeriodItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountTodayOrderExecutionItem(BaseModel):
+    ord_no: str = Field(default="", description="주문번호")
+    orig_ord_no: str = Field(default="", description="원주문번호")
+    stex_nm: str = Field(default="", description="거래소명")
+    crnc_code: str = Field(default="", description="통화코드")
+    stk_cd: str = Field(default="", description="종목코드")
+    frgn_stk_nm: str = Field(default="", description="종목명")
+    frgn_trde_tp: str = Field(
+        default="",
+        description="매매구분. 00:지정가,03:시장가,11:Enhanced Limit Order,12:Special Limit Order,30:Limit On Close,33:Market On Close,34:Stop Limit,35:Stop Market,36:VWAP,37:TWAP",
+    )
+    frgn_trde_nm: str = Field(default="", description="매매구분명")
+    slby_tp: str = Field(default="", description="매도매수구분. 1:매도,2:매수")
+    slby_tp_nm: str = Field(default="", description="매도매수구분명")
+    ord_qty: str = Field(default="", description="주문수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    ord_uv: str = Field(default="", description="주문단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    stop_pric: str = Field(default="", description="STOP가격. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cntr_qty: str = Field(default="", description="체결수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    cntr_uv: str = Field(default="", description="체결단가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cnfm_qty: str = Field(default="", description="확인수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    ord_remnq: str = Field(default="", description="주문잔량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자")
+    ord_time: str = Field(default="", description="주문시간. HH:mm:ss")
+    ord_resp_time: str = Field(default="", description="주문응답시간. HH:mm:ss")
+    ord_stat: str = Field(default="", description="주문상태명")
+    rsrv_tp: str = Field(default="", description="예약주문구분. 0:일반, 1:예약")
+    natn_nm: str = Field(default="", description="국가명")
+    cntr_time: str = Field(default="", description="체결시간")
 
 
 class OverseasAccountTodayOrderExecution(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 당일 주문체결 확인 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountTodayOrderExecutionItem] = Field(
+        default_factory=list, description="조회결과리스트"
+    )
+
+
+class OverseasAccountRealizedProfitLossItem(BaseModel):
+    sell_dt: str = Field(default="", description="매도일자")
+    stk_cd: str = Field(default="", description="종목코드")
+    frgn_stk_nm: str = Field(default="", description="종목명")
+    sell_qty: str = Field(default="", description="청산수량")
+    avg_buy_uv: str = Field(default="", description="매입평균가")
+    buy_amt: str = Field(default="", description="매입금액")
+    avg_sell_uv: str = Field(default="", description="매도평균가")
+    sell_amt: str = Field(default="", description="매도금액")
+    cmsn_tax: str = Field(default="", description="수수료제세금")
+    pl_amt: str = Field(default="", description="손익금액")
+    pl_rt: str = Field(default="", description="실현수익률(%)")
+    prch_exrt: str = Field(default="", description="매입환율")
+    sell_exrt: str = Field(default="", description="매도환율")
+    krw_chg_dfrn_pl_amt: str = Field(default="", description="환차손익(원)")
+    krw_chg_pl_amt: str = Field(default="", description="환실현손익(원)")
+    comm_ord_tp: str = Field(default="", description="매체구분")
+    stex_nm: str = Field(default="", description="거래소명")
+    natn_nm: str = Field(default="", description="국가명")
 
 
 class OverseasAccountRealizedProfitLoss(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 실현손익 응답")
 
-    # TODO: 응답 필드 정의
+    tot_sell_amt: str = Field(default="", description="총매도금액")
+    tot_buy_amt: str = Field(default="", description="총매수금액")
+    tot_cmsn_tax: str = Field(default="", description="총수수료제세금")
+    tot_exct_amt: str = Field(default="", description="총정산금액")
+    tot_pl_amt: str = Field(default="", description="총손익금액")
+    tot_pl_rt: str = Field(default="", description="총실현수익률(%)")
+    result_list: list[OverseasAccountRealizedProfitLossItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountTodayTradingItem(BaseModel):
+    stex_nm: str = Field(default="", description="거래소코드명")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    tdy_avg_buy_uv: str = Field(default="", description="금일매수평균가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    tdy_buyq: str = Field(
+        default="", description="금일매수수량. 단위: 1주, 좌측 0-padding 처리된 부호 포함 15자리 숫자"
+    )
+    tdy_buy_amt: str = Field(default="", description="금일매입금액. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    tdy_avg_sell_uv: str = Field(default="", description="금일매도평균가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    tdy_sellq: str = Field(
+        default="", description="금일매도수량. 단위: 1주, 좌측 0-padding 처리된 부호 포함 15자리 숫자"
+    )
+    tdy_sell_amt: str = Field(default="", description="금일매도금액. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cmsn_altx: str = Field(default="", description="수수료제세금. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    pl_amt: str = Field(default="", description="실현손익. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    pl_rt: str = Field(default="", description="실현손익률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    bf_prch_uv: str = Field(default="", description="이전매입가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    exch_rate: str = Field(default="", description="기준환율. 소수점 둘째 자리까지 포맷된 숫자")
 
 
 class OverseasAccountTodayTrading(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 당일매매 응답")
 
-    # TODO: 응답 필드 정의
+    tot_sell_amt: str = Field(default="", description="총매도금액. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    tot_buy_amt: str = Field(default="", description="총매수금액. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    tot_cmsn_altx: str = Field(default="", description="총수수료제세금. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    tot_exct_amt: str = Field(default="", description="총정산금액. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    tot_pl_amt: str = Field(default="", description="총실현손익. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    tot_pl_rt: str = Field(
+        default="", description="총실현손익률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    exch_rate: str = Field(default="", description="기준환율. 소수점 둘째 자리까지 포맷된 숫자")
+    result_list: list[OverseasAccountTodayTradingItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountTodayTradingSummaryItem(BaseModel):
+    stex_nm: str = Field(default="", description="거래소코드명")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    slby_tp_nm: str = Field(default="", description="매도수구분명. 매수인경우'+',매도인경우'-'")
+    crnc_code: str = Field(default="", description="통화코드")
+    cntr_uv: str = Field(default="", description="체결단가")
+    cntr_qty: str = Field(default="", description="체결수량")
+    engg_amt: str = Field(default="", description="약정금액")
+    cmsn: str = Field(default="", description="수수료")
+    altx: str = Field(default="", description="제세금")
+    exct_amt: str = Field(default="", description="정산금액")
+    exch_rate: str = Field(default="", description="환율")
+    natn_nm: str = Field(default="", description="국가명")
 
 
 class OverseasAccountTodayTradingSummary(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 당일매매정리 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasAccountTodayTradingSummaryItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasAccountTodayRealizedProfitLossItem(BaseModel):
+    stex_nm: str = Field(default="", description="거래소코드명")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    crnc_code: str = Field(default="", description="통화코드")
+    cntr_sellq: str = Field(default="", description="체결매도수량")
+    avg_buy_uv: str = Field(default="", description="매입평균가")
+    cntr_sella: str = Field(default="", description="체결매도가")
+    tdy_pl_amt: str = Field(default="", description="당일실현손익")
+    pl_rt: str = Field(default="", description="실현수익률")
+    cmsn: str = Field(default="", description="수수료")
+    altx: str = Field(default="", description="제세금")
+    exch_rate: str = Field(default="", description="환율")
+    natn_nm: str = Field(default="", description="국가명")
 
 
 class OverseasAccountTodayRealizedProfitLoss(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 당일 실현손익 응답")
 
-    # TODO: 응답 필드 정의
+    tot_tdy_pl_amt: str = Field(default="", description="총당일실현손익")
+    tot_tdy_pl_amt_krw: str = Field(default="", description="총당일실현손익(원)")
+    result_list: list[OverseasAccountTodayRealizedProfitLossItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasAccountDailyRealizedProfitLossByStockItem(BaseModel):
+    stex_nm: str = Field(default="", description="거래소코드명")
+    stk_nm: str = Field(default="", description="종목명")
+    crnc_code: str = Field(default="", description="통화코드")
+    cntr_sellq: str = Field(default="", description="체결매도수량")
+    avg_buy_uv: str = Field(default="", description="매입평균가")
+    cntr_sella: str = Field(default="", description="체결매도가")
+    pl_amt: str = Field(default="", description="실현손익")
+    pl_rt: str = Field(default="", description="실현수익률")
+    stk_cd: str = Field(default="", description="종목코드")
+    cmsn: str = Field(default="", description="수수료")
+    altx: str = Field(default="", description="제세금")
+    exch_rate: str = Field(default="", description="환율")
+    natn_nm: str = Field(default="", description="국가명")
 
 
 class OverseasAccountDailyRealizedProfitLossByStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 일별 종목별 실현손익 응답")
 
-    # TODO: 응답 필드 정의
+    tot_pl_amt: str = Field(default="", description="총실현손익")
+    tot_pl_amt_krw: str = Field(default="", description="총실현손익(원)")
+    result_list: list[OverseasAccountDailyRealizedProfitLossByStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
 
 
 class OverseasAccountProfitRateByPeriod(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 기간별 수익률 현황 응답")
 
-    # TODO: 응답 필드 정의
+    fr_entr: str = Field(default="", description="기간초예수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    fr_dfr_amt: str = Field(default="", description="기간초현금미수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    fr_etc_loana: str = Field(default="", description="기간초기타대여금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    fr_fc_entr: str = Field(default="", description="기간초외화예수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    fr_fc_dfr_amt: str = Field(default="", description="기간초외화미수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    fr_fc_etc_loana: str = Field(
+        default="", description="기간초외화기타대여금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    fr_frgn_stk_evltv: str = Field(
+        default="", description="기간초해외증권평가금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    fr_tot_evltv: str = Field(default="", description="기간초순자산액계. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    to_entr: str = Field(default="", description="기간말예수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    to_dfr_amt: str = Field(default="", description="기간말현금미수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    to_etc_loana: str = Field(default="", description="기간말기타대여금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    to_fc_entr: str = Field(default="", description="기간말외화예수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    to_fc_dfr_amt: str = Field(default="", description="기간말외화미수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    to_fc_etc_loana: str = Field(
+        default="", description="기간말외화기타대여금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    to_frgn_stk_evltv: str = Field(
+        default="", description="기간말해외증권평가금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    to_tot_evltv: str = Field(default="", description="기간말순자산액계. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    fc_rcpta: str = Field(default="", description="기간내총외화입금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    fc_payma: str = Field(default="", description="기간내총외화출금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    chg_rcpta: str = Field(default="", description="기간내외화매도. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    chg_payma: str = Field(default="", description="기간내외화매수. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    frgn_stk_inqa: str = Field(
+        default="", description="기간내해외증권입고. 단위: 원, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    frgn_stk_outqa: str = Field(
+        default="", description="기간내해외증권출고. 단위: 원, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    invt_bsamt: str = Field(default="", description="투자원금평잔. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    evlt_profit: str = Field(default="", description="평가손익. 단위: 원, 좌측 0-padding 처리된 부호 포함 12자리 숫자")
+    profit_rate: str = Field(default="", description="수익율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    io_bsamt: str = Field(default="", description="기간내총입출금고평잔. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    tern_rt: str = Field(default="", description="회전율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+
+
+class OverseasAccountDailyRealizedProfitLossItem(BaseModel):
+    trde_dt: str = Field(default="", description="매매일자")
+    buy_amt: str = Field(default="", description="매수금액")
+    sell_amt: str = Field(default="", description="매도금액")
+    pl_amt: str = Field(default="", description="실현손익금액")
+    cmsn: str = Field(default="", description="수수료")
+    tax: str = Field(default="", description="세금")
 
 
 class OverseasAccountDailyRealizedProfitLoss(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 일별 실현손익 응답")
 
-    # TODO: 응답 필드 정의
+    tot_buy_amt: str = Field(default="", description="총매수금액")
+    tot_sell_amt: str = Field(default="", description="총매도금액")
+    tot_pl_amt: str = Field(default="", description="총실현손익금액")
+    tot_cmsn: str = Field(default="", description="수수료합")
+    tot_tax: str = Field(default="", description="세금합")
+    result_list: list[OverseasAccountDailyRealizedProfitLossItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasAccountMonthlyRealizedProfitLossItem(BaseModel):
+    trde_dt: str = Field(default="", description="매매일자")
+    buy_amt: str = Field(default="", description="매수금액")
+    sell_amt: str = Field(default="", description="매도금액")
+    pl_amt: str = Field(default="", description="실현손익금액")
+    cmsn: str = Field(default="", description="수수료")
+    tax: str = Field(default="", description="세금")
 
 
 class OverseasAccountMonthlyRealizedProfitLoss(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 월별 실현손익 응답")
 
-    # TODO: 응답 필드 정의
+    tot_buy_amt: str = Field(default="", description="총매수금액")
+    tot_sell_amt: str = Field(default="", description="총매도금액")
+    tot_pl_amt: str = Field(default="", description="총실현손익금액")
+    tot_cmsn: str = Field(default="", description="수수료합")
+    tot_tax: str = Field(default="", description="세금합")
+    result_list: list[OverseasAccountMonthlyRealizedProfitLossItem] = Field(
+        default_factory=list, description="결과리스트"
+    )

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_account_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_account_types.py
@@ -1,0 +1,172 @@
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+from cluefin_openapi.kiwoom._model import KiwoomHttpBody
+
+
+class OverseasAccountDailyProfitRate(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 일별계좌수익률현황 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountMonthlyProfitRate(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 월별계좌수익률현황 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountYearlyProfitRate(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 연도별계좌수익률현황 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountDailyStockProfitRate(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 일별종목수익률현황 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountMonthlyStockProfitRate(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 월별종목수익률현황 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountYearlyStockProfitRate(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 연도별종목수익률현황 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountLedgerUnfilledOrders(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 원장 미체결 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountLedgerBalance(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 원장잔고확인 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountTransactionHistory(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 거래내역 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountDeposit(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="해외주식 예수금 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountKrwWithdrawableAmount(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="원화출금가능 금액 조회(원화대용 포함) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountDepositAndSecuritiesValuationByCurrency(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="통화별 예수금 및 증권 평가금현황 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountLedgerValuationAmount(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="해외증권 원장 평가금액현황 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountValuationAmountByDate(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="해외증권 특정일 평가금액 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountDepositAndSecuritiesValuationByCurrencyByDate(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="특정일 통화별 예수금 및 증권 평가금 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountDailyOrderExecutionHistory(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 일별 주문체결내역 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountDepositDetail(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 예수금 상세 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountTodayRealizedProfitLossByStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 당일 종목별 실현손익 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountOrderHistoryByPeriod(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 기간별 주문내역 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountTodayOrderExecution(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 당일 주문체결 확인 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountRealizedProfitLoss(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 실현손익 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountTodayTrading(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 당일매매 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountTodayTradingSummary(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 당일매매정리 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountTodayRealizedProfitLoss(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 당일 실현손익 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountDailyRealizedProfitLossByStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 일별 종목별 실현손익 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountProfitRateByPeriod(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 기간별 수익률 현황 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountDailyRealizedProfitLoss(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 일별 실현손익 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasAccountMonthlyRealizedProfitLoss(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 월별 실현손익 응답")
+
+    # TODO: 응답 필드 정의

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_chart.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_chart.py
@@ -1,0 +1,253 @@
+from typing import Literal
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._model import (
+    KiwoomHttpHeader,
+    KiwoomHttpResponse,
+)
+from cluefin_openapi.kiwoom._overseas_chart_types import (
+    OverseasChartDaily,
+    OverseasChartMinute,
+    OverseasChartMonthly,
+    OverseasChartQuarterly,
+    OverseasChartTick,
+    OverseasChartWeekly,
+    OverseasChartYearly,
+)
+
+
+class OverseasChart:
+    def __init__(self, client: Client):
+        self.client = client
+        self.path = "/api/us/chart"
+
+    def get_tick_chart(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasChartTick]:
+        """미국주식 틱 차트 (usa06010)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasChartTick]: 미국주식 틱 차트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa06010",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching tick chart: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasChartTick.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_minute_chart(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasChartMinute]:
+        """미국주식 분 차트 (usa06011)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasChartMinute]: 미국주식 분 차트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa06011",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching minute chart: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasChartMinute.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_daily_chart(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasChartDaily]:
+        """미국주식 일 차트 (usa06012)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasChartDaily]: 미국주식 일 차트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa06012",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching daily chart: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasChartDaily.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_weekly_chart(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasChartWeekly]:
+        """미국주식 주 차트 (usa06013)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasChartWeekly]: 미국주식 주 차트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa06013",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching weekly chart: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasChartWeekly.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_monthly_chart(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasChartMonthly]:
+        """미국주식 월 차트 (usa06014)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasChartMonthly]: 미국주식 월 차트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa06014",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching monthly chart: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasChartMonthly.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_yearly_chart(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasChartYearly]:
+        """미국주식 년 차트 (usa06015)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasChartYearly]: 미국주식 년 차트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa06015",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching yearly chart: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasChartYearly.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_quarterly_chart(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasChartQuarterly]:
+        """미국주식 분기 차트 (usa06016)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasChartQuarterly]: 미국주식 분기 차트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa06016",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching quarterly chart: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasChartQuarterly.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_chart.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_chart.py
@@ -23,14 +23,22 @@ class OverseasChart:
 
     def get_tick_chart(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str,
+        tic_scope: str = "",
+        upd_stkpc_tp: Literal["", "0", "1"] = "",
+        exrt_appl_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasChartTick]:
         """미국주식 틱 차트 (usa06010)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA:AMEX,ND:NASDAQ,NY:NYSE
+            stk_cd (str): 종목코드
+            tic_scope (str, optional): 틱범위. Defaults to "".
+            upd_stkpc_tp (Literal["", "0", "1"], optional): 수정주가구분. 0:미적용,1:적용. Defaults to "".
+            exrt_appl_tp (Literal["", "0", "1"], optional): 환율적용구분. 0:미적용,1:적용. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -45,6 +53,13 @@ class OverseasChart:
             "next-key": next_key,
             "api-id": "usa06010",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "tic_scope": tic_scope,
+            "upd_stkpc_tp": upd_stkpc_tp,
+            "exrt_appl_tp": exrt_appl_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -56,14 +71,24 @@ class OverseasChart:
 
     def get_minute_chart(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str = "",
+        strt_dt: str = "",
+        tic_scope: str = "",
+        upd_stkpc_tp: Literal["", "0", "1"] = "",
+        exrt_appl_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasChartMinute]:
         """미국주식 분 차트 (usa06011)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA:AMEX,ND:NASDAQ,NY:NYSE
+            stk_cd (str, optional): 종목코드. Defaults to "".
+            strt_dt (str, optional): 시작일자. YYYYMMDD. Defaults to "".
+            tic_scope (str, optional): XX분봉. Defaults to "".
+            upd_stkpc_tp (Literal["", "0", "1"], optional): 수정주가구분. 0:미적용,1:적용. Defaults to "".
+            exrt_appl_tp (Literal["", "0", "1"], optional): 환율적용구분. 0:미적용,1:적용. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -78,6 +103,14 @@ class OverseasChart:
             "next-key": next_key,
             "api-id": "usa06011",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "strt_dt": strt_dt,
+            "tic_scope": tic_scope,
+            "upd_stkpc_tp": upd_stkpc_tp,
+            "exrt_appl_tp": exrt_appl_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -89,14 +122,22 @@ class OverseasChart:
 
     def get_daily_chart(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str = "",
+        strt_dt: str = "",
+        upd_stkpc_tp: Literal["", "0", "1"] = "",
+        exrt_appl_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasChartDaily]:
         """미국주식 일 차트 (usa06012)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA:AMEX,ND:NASDAQ,NY:NYSE
+            stk_cd (str, optional): 종목코드. Defaults to "".
+            strt_dt (str, optional): 시작일자. YYYYMMDD. Defaults to "".
+            upd_stkpc_tp (Literal["", "0", "1"], optional): 수정주가구분. 0:미적용,1:적용. Defaults to "".
+            exrt_appl_tp (Literal["", "0", "1"], optional): 환율적용구분. 0:미적용,1:적용. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -111,6 +152,13 @@ class OverseasChart:
             "next-key": next_key,
             "api-id": "usa06012",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "strt_dt": strt_dt,
+            "upd_stkpc_tp": upd_stkpc_tp,
+            "exrt_appl_tp": exrt_appl_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -122,14 +170,22 @@ class OverseasChart:
 
     def get_weekly_chart(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str = "",
+        strt_dt: str = "",
+        upd_stkpc_tp: Literal["", "0", "1"] = "",
+        exrt_appl_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasChartWeekly]:
         """미국주식 주 차트 (usa06013)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA:AMEX,ND:NASDAQ,NY:NYSE
+            stk_cd (str, optional): 종목코드. Defaults to "".
+            strt_dt (str, optional): 시작일자. YYYYMMDD. Defaults to "".
+            upd_stkpc_tp (Literal["", "0", "1"], optional): 수정주가구분. 0:미적용,1:적용. Defaults to "".
+            exrt_appl_tp (Literal["", "0", "1"], optional): 환율적용구분. 0:미적용,1:적용. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -144,6 +200,13 @@ class OverseasChart:
             "next-key": next_key,
             "api-id": "usa06013",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "strt_dt": strt_dt,
+            "upd_stkpc_tp": upd_stkpc_tp,
+            "exrt_appl_tp": exrt_appl_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -155,14 +218,22 @@ class OverseasChart:
 
     def get_monthly_chart(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str = "",
+        strt_dt: str = "",
+        upd_stkpc_tp: Literal["", "0", "1"] = "",
+        exrt_appl_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasChartMonthly]:
         """미국주식 월 차트 (usa06014)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA:AMEX,ND:NASDAQ,NY:NYSE
+            stk_cd (str, optional): 종목코드. Defaults to "".
+            strt_dt (str, optional): 시작일자. YYYYMMDD. Defaults to "".
+            upd_stkpc_tp (Literal["", "0", "1"], optional): 수정주가구분. 0:미적용,1:적용. Defaults to "".
+            exrt_appl_tp (Literal["", "0", "1"], optional): 환율적용구분. 0:미적용,1:적용. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -177,6 +248,13 @@ class OverseasChart:
             "next-key": next_key,
             "api-id": "usa06014",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "strt_dt": strt_dt,
+            "upd_stkpc_tp": upd_stkpc_tp,
+            "exrt_appl_tp": exrt_appl_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -188,14 +266,22 @@ class OverseasChart:
 
     def get_yearly_chart(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str = "",
+        strt_dt: str = "",
+        upd_stkpc_tp: Literal["", "0", "1"] = "",
+        exrt_appl_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasChartYearly]:
         """미국주식 년 차트 (usa06015)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA:AMEX,ND:NASDAQ,NY:NYSE
+            stk_cd (str, optional): 종목코드. Defaults to "".
+            strt_dt (str, optional): 시작일자. YYYYMMDD. Defaults to "".
+            upd_stkpc_tp (Literal["", "0", "1"], optional): 수정주가구분. 0:미적용,1:적용. Defaults to "".
+            exrt_appl_tp (Literal["", "0", "1"], optional): 환율적용구분. 0:미적용,1:적용. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -210,6 +296,13 @@ class OverseasChart:
             "next-key": next_key,
             "api-id": "usa06015",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "strt_dt": strt_dt,
+            "upd_stkpc_tp": upd_stkpc_tp,
+            "exrt_appl_tp": exrt_appl_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -221,14 +314,22 @@ class OverseasChart:
 
     def get_quarterly_chart(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str = "",
+        strt_dt: str = "",
+        upd_stkpc_tp: Literal["", "0", "1"] = "",
+        exrt_appl_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasChartQuarterly]:
         """미국주식 분기 차트 (usa06016)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA:AMEX,ND:NASDAQ,NY:NYSE
+            stk_cd (str, optional): 종목코드. Defaults to "".
+            strt_dt (str, optional): 시작일자. YYYYMMDD. Defaults to "".
+            upd_stkpc_tp (Literal["", "0", "1"], optional): 수정주가구분. 0:미적용,1:적용. Defaults to "".
+            exrt_appl_tp (Literal["", "0", "1"], optional): 환율적용구분. 0:미적용,1:적용. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -242,6 +343,13 @@ class OverseasChart:
             "cont-yn": cont_yn,
             "next-key": next_key,
             "api-id": "usa06016",
+        }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "strt_dt": strt_dt,
+            "upd_stkpc_tp": upd_stkpc_tp,
+            "exrt_appl_tp": exrt_appl_tp,
         }
 
         response = self.client._post(self.path, headers, body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_chart_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_chart_types.py
@@ -1,0 +1,46 @@
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+from cluefin_openapi.kiwoom._model import KiwoomHttpBody
+
+
+class OverseasChartTick(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 틱 차트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasChartMinute(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 분 차트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasChartDaily(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 일 차트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasChartWeekly(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 주 차트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasChartMonthly(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 월 차트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasChartYearly(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 년 차트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasChartQuarterly(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 분기 차트 응답")
+
+    # TODO: 응답 필드 정의

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_chart_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_chart_types.py
@@ -1,46 +1,132 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 
 from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 
 
+class OverseasChartTickItem(BaseModel):
+    cur_prc: str = Field(default="", description="현재가(종가)")
+    trde_qty: str = Field(default="", description="거래량")
+    open_pric: str = Field(default="", description="시가")
+    high_pric: str = Field(default="", description="고가")
+    low_pric: str = Field(default="", description="저가")
+    cntr_tm: str = Field(default="", description="체결시간")
+    bus_dt: str = Field(default="", description="영업일자")
+    upd_stkpc_tp: str = Field(default="", description="수정주가구분")
+    upd_rt: str = Field(default="", description="수정비율")
+
+
 class OverseasChartTick(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 틱 차트 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasChartTickItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasChartMinuteItem(BaseModel):
+    cur_prc: str = Field(default="", description="현재가(종가). 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    trde_qty: str = Field(default="", description="거래량")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cntr_tm: str = Field(default="", description="체결시간. YYYYMMDDHHmmss")
+    bus_dt: str = Field(default="", description="영업일자. YYYYMMDD")
+    upd_stkpc_tp: str = Field(default="", description="수정주가구분")
+    upd_rt: str = Field(default="", description="수정비율")
 
 
 class OverseasChartMinute(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 분 차트 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasChartMinuteItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasChartDailyItem(BaseModel):
+    cur_prc: str = Field(default="", description="현재가(종가). 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+    acc_trde_prica: str = Field(default="", description="누적거래대금")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    dt: str = Field(default="", description="일자. YYYYMMDD")
+    upd_stkpc_tp: str = Field(default="", description="수정주가구분")
+    upd_rt: str = Field(default="", description="수정비율")
 
 
 class OverseasChartDaily(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 일 차트 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasChartDailyItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasChartWeeklyItem(BaseModel):
+    cur_prc: str = Field(default="", description="현재가(종가). 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+    acc_trde_prica: str = Field(default="", description="누적거래대금")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    dt: str = Field(default="", description="일자. YYYYMMDD")
+    upd_stkpc_tp: str = Field(default="", description="수정주가구분")
+    upd_rt: str = Field(default="", description="수정비율")
 
 
 class OverseasChartWeekly(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 주 차트 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasChartWeeklyItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasChartMonthlyItem(BaseModel):
+    cur_prc: str = Field(default="", description="현재가(종가). 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+    acc_trde_prica: str = Field(default="", description="누적거래대금")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    dt: str = Field(default="", description="일자. YYYYMMDD")
+    upd_stkpc_tp: str = Field(default="", description="수정주가구분")
+    upd_rt: str = Field(default="", description="수정비율")
 
 
 class OverseasChartMonthly(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 월 차트 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasChartMonthlyItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasChartYearlyItem(BaseModel):
+    cur_prc: str = Field(default="", description="현재가(종가). 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+    acc_trde_prica: str = Field(default="", description="누적거래대금")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    dt: str = Field(default="", description="일자. YYYYMMDD")
+    upd_stkpc_tp: str = Field(default="", description="수정주가구분")
+    upd_rt: str = Field(default="", description="수정비율")
 
 
 class OverseasChartYearly(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 년 차트 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasChartYearlyItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasChartQuarterlyItem(BaseModel):
+    cur_prc: str = Field(default="", description="현재가(종가). 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+    acc_trde_prica: str = Field(default="", description="누적거래대금")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    dt: str = Field(default="", description="일자. YYYYMMDD")
+    upd_stkpc_tp: str = Field(default="", description="수정주가구분")
+    upd_rt: str = Field(default="", description="수정비율")
 
 
 class OverseasChartQuarterly(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 분기 차트 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasChartQuarterlyItem] = Field(default_factory=list, description="결과리스트")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_condition_search.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_condition_search.py
@@ -1,6 +1,9 @@
 # 조건검색 (웹소켓)
 # 운영: wss://api.kiwoom.com:10000/api/us/websocket
 # 모의투자: wss://mockapi.kiwoom.com:10000/api/us/websocket
+#
+# 웹소켓 클라이언트 구현은 아직 없음. request/response 모델은
+# _overseas_condition_search_types.py 참고.
 
 
 class OverseasConditionSearch:
@@ -8,6 +11,10 @@ class OverseasConditionSearch:
 
 
 # 미국주식 조건검색 목록조회	usa20280	get_condition_search_list
+#   OverseasConditionSearchListRequest / OverseasConditionSearchListResponse
 # 미국주식 조건검색 요청 일반	usa20281	request_condition_search
+#   OverseasConditionSearchRequest / OverseasConditionSearchResponse
 # 미국주식 조건검색 요청 실시간	usa20290	request_realtime_condition_search
+#   OverseasConditionSearchRealtimeRequest / OverseasConditionSearchRealtimeResponse
 # 미국주식 조건검색 실시간 해제	usa20291	cancel_realtime_condition_search
+#   OverseasConditionSearchRealtimeCancelRequest / OverseasConditionSearchRealtimeCancelResponse

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_condition_search.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_condition_search.py
@@ -1,0 +1,13 @@
+# 조건검색 (웹소켓)
+# 운영: wss://api.kiwoom.com:10000/api/us/websocket
+# 모의투자: wss://mockapi.kiwoom.com:10000/api/us/websocket
+
+
+class OverseasConditionSearch:
+    pass
+
+
+# 미국주식 조건검색 목록조회	usa20280	get_condition_search_list
+# 미국주식 조건검색 요청 일반	usa20281	request_condition_search
+# 미국주식 조건검색 요청 실시간	usa20290	request_realtime_condition_search
+# 미국주식 조건검색 실시간 해제	usa20291	cancel_realtime_condition_search

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_condition_search_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_condition_search_types.py
@@ -1,0 +1,164 @@
+"""미국주식 조건검색 (웹소켓) 요청/응답 모델.
+
+웹소켓 프레임은 HTTP 응답이 아니므로 ``KiwoomHttpBody``를 상속하지 않고 순수
+``BaseModel``로 정의한다. 응답 ``data`` List<Map> 요소 중 숫자 FID/camelCase 키를
+사용하는 필드는 의미 있는 영어 필드명 + ``alias``로 매핑하고 ``populate_by_name=True``를
+설정한다.
+
+usa20281(요청 일반)과 usa20290(요청 실시간)은 동일한 ``trnm``(GCNSRREQ) 값을 공유하며
+``search_type`` 값(0 vs 1)으로 구분된다.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
+
+# ---------------------------------------------------------------------------
+# usa20280 미국주식 조건검색 목록조회
+# ---------------------------------------------------------------------------
+
+
+class OverseasConditionSearchListRequest(BaseModel):
+    """usa20280 미국주식 조건검색 목록조회 요청."""
+
+    model_config = ConfigDict(title="미국주식 조건검색 목록조회 요청")
+
+    trnm: Literal["GCNSRLST"] = Field(description="TR명. GCNSRLST 고정값")
+
+
+class OverseasConditionSearchListItem(BaseModel):
+    """조건검색식 목록 항목."""
+
+    model_config = ConfigDict(title="조건검색식 목록 항목")
+
+    seq: str = Field(default="", description="조건검색식 일련번호")
+    name: str = Field(default="", description="조건검색식 명")
+
+
+class OverseasConditionSearchListResponse(BaseModel):
+    """usa20280 미국주식 조건검색 목록조회 응답."""
+
+    model_config = ConfigDict(title="미국주식 조건검색 목록조회 응답")
+
+    return_code: int | None = Field(default=None, description="결과코드. 정상:0")
+    return_msg: str = Field(default="", description="결과메시지. 정상인 경우는 메시지 없음")
+    trnm: str = Field(default="", description="서비스명. GCNSRLT고정값")
+    data: list[OverseasConditionSearchListItem] = Field(default_factory=list, description="조건검색식 목록")
+
+
+# ---------------------------------------------------------------------------
+# usa20281 미국주식 조건검색 요청 일반
+# ---------------------------------------------------------------------------
+
+
+class OverseasConditionSearchRequest(BaseModel):
+    """usa20281 미국주식 조건검색 요청 일반."""
+
+    model_config = ConfigDict(title="미국주식 조건검색 요청 일반")
+
+    trnm: Literal["GCNSRREQ"] = Field(description="서비스명. GCNSRREQ 고정값")
+    seq: str = Field(description="조건검색식 일련번호")
+    search_type: Literal["0"] = Field(description="조회타입. 0:조건검색")
+    cont_yn: Literal["Y", "N"] = Field(default="N", description="연속조회여부. Y:연속조회요청, N:연속조회미요청")
+    next_key: str = Field(default="", description="연속조회키")
+
+
+class OverseasConditionSearchResultItem(BaseModel):
+    """조건검색 결과 데이터 항목 (일반 조회)."""
+
+    model_config = ConfigDict(populate_by_name=True, title="조건검색 결과 데이터 항목")
+
+    stock_code: str = Field(default="", alias="9001", description="종목코드")
+    stock_name: str = Field(default="", alias="302", description="종목명")
+    current_price: str = Field(default="", alias="10", description="현재가")
+    prev_day_diff_sign: str = Field(
+        default="", alias="25", description="전일대비기호. 1:상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비")
+    fluctuation_rate: str = Field(default="", alias="12", description="등락률")
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량")
+    open_price: str = Field(default="", alias="16", description="시가")
+    high_price: str = Field(default="", alias="17", description="고가")
+    low_price: str = Field(default="", alias="18", description="저가")
+    sub_industry: str = Field(default="", alias="318", description="소업종")
+    stex_tp: str = Field(default="", description="거래소구분. NA:AMEX, ND:NASDAQ, NY:NYSE")
+
+
+class OverseasConditionSearchResponse(BaseModel):
+    """usa20281 미국주식 조건검색 요청 일반 응답."""
+
+    model_config = ConfigDict(title="미국주식 조건검색 요청 일반 응답")
+
+    return_code: int | None = Field(default=None, description="결과코드. 정상:0 나머지:에러")
+    return_msg: str = Field(default="", description="결과메시지. 정상인 경우는 메시지 없음")
+    trnm: str = Field(default="", description="서비스명. CNSRREQ")
+    seq: str = Field(default="", description="조건검색식 일련번호")
+    cont_yn: str = Field(default="", description="연속조회여부. 연속 데이터가 존재하는경우 Y, 없으면 N")
+    next_key: str = Field(default="", description="연속조회키. 연속조회여부가 Y일경우 다음 조회시 필요한 조회값")
+    data: list[OverseasConditionSearchResultItem] = Field(default_factory=list, description="검색결과데이터")
+
+
+# ---------------------------------------------------------------------------
+# usa20290 미국주식 조건검색 요청 실시간
+# ---------------------------------------------------------------------------
+
+
+class OverseasConditionSearchRealtimeRequest(BaseModel):
+    """usa20290 미국주식 조건검색 요청 실시간."""
+
+    model_config = ConfigDict(title="미국주식 조건검색 요청 실시간")
+
+    trnm: Literal["GCNSRREQ"] = Field(description="서비스명. GCNSRREQ 고정값")
+    seq: str = Field(description="조건검색식 일련번호")
+    search_type: Literal["1"] = Field(description="조회타입. 1:조건검색+실시간조건검색")
+
+
+class OverseasConditionSearchRealtimeResultItem(BaseModel):
+    """조건검색 결과 데이터 항목 (실시간 조회)."""
+
+    model_config = ConfigDict(populate_by_name=True, title="조건검색 결과 데이터 항목 (실시간)")
+
+    jmcode: str = Field(default="", description="종목코드")
+    stex_tp: str = Field(default="", alias="stexTp", description="거래소구분")
+
+
+class OverseasConditionSearchRealtimeResponse(BaseModel):
+    """usa20290 미국주식 조건검색 요청 실시간 응답."""
+
+    model_config = ConfigDict(title="미국주식 조건검색 요청 실시간 응답")
+
+    return_code: int | None = Field(default=None, description="결과코드. 정상:0 나머지:에러")
+    return_msg: str = Field(default="", description="결과메시지. 정상인 경우는 메시지 없음")
+    trnm: str = Field(default="", description="서비스명. GCNSRREQ")
+    seq: str = Field(default="", description="조건검색식 일련번호")
+    data: list[OverseasConditionSearchRealtimeResultItem] = Field(default_factory=list, description="검색결과데이터")
+
+
+# ---------------------------------------------------------------------------
+# usa20291 미국주식 조건검색 실시간 해제
+# ---------------------------------------------------------------------------
+
+
+class OverseasConditionSearchRealtimeCancelRequest(BaseModel):
+    """usa20291 미국주식 조건검색 실시간 해제 요청."""
+
+    model_config = ConfigDict(title="미국주식 조건검색 실시간 해제 요청")
+
+    trnm: Literal["GCNSRCLR"] = Field(description="서비스명. GCNSRCLR 고정값")
+    seq: str = Field(description="조건검색식 일련번호")
+
+
+class OverseasConditionSearchRealtimeCancelResponse(BaseModel):
+    """usa20291 미국주식 조건검색 실시간 해제 응답.
+
+    스펙상 네 필드 모두 Required=Y(단순 ACK 프레임)이므로 다른 TR과 달리 기본값을
+    부여하지 않는다.
+    """
+
+    model_config = ConfigDict(title="미국주식 조건검색 실시간 해제 응답")
+
+    return_code: int = Field(description="결과코드. 정상:0 나머지:에러")
+    return_msg: str = Field(description="결과메시지. 정상인 경우는 메시지 없음")
+    trnm: Literal["GCNSRCLR"] = Field(description="서비스명. GCNSRCLR 고정값")
+    seq: str = Field(description="조건검색식 일련번호")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_exchange.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_exchange.py
@@ -1,0 +1,117 @@
+from typing import Literal
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._model import (
+    KiwoomHttpHeader,
+    KiwoomHttpResponse,
+)
+from cluefin_openapi.kiwoom._overseas_exchange_types import (
+    OverseasExchangeEstimatedAmount,
+    OverseasExchangeRate,
+    OverseasExchangeRequest,
+)
+
+
+class OverseasExchange:
+    def __init__(self, client: Client):
+        self.client = client
+        self.path = "/api/us/exchange"
+
+    def get_estimated_exchange_amount(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasExchangeEstimatedAmount]:
+        """환전 예상 금액 조회 (ust31300)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasExchangeEstimatedAmount]: 환전 예상 금액 조회 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust31300",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching estimated exchange amount: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasExchangeEstimatedAmount.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_exchange_rate(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasExchangeRate]:
+        """환율 조회 (ust31301)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasExchangeRate]: 환율 조회 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust31301",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching exchange rate: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasExchangeRate.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def request_exchange(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasExchangeRequest]:
+        """환전 신청 (ust31302)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasExchangeRequest]: 환전 신청 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust31302",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error requesting exchange: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasExchangeRequest.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_exchange.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_exchange.py
@@ -19,14 +19,16 @@ class OverseasExchange:
 
     def get_estimated_exchange_amount(
         self,
-        body: dict[str, str],
+        exch_tp: Literal["1", "2"],
+        fc_exmn_amt: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasExchangeEstimatedAmount]:
         """환전 예상 금액 조회 (ust31300)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            exch_tp (Literal["1", "2"]): 환전구분. 1:원화(KRW)->달러(USD), 2:달러(USD)->원화(KRW)
+            fc_exmn_amt (str, optional): 매도통화기준 환전금액. EXCH_TP = 1 인 경우, 매도통화는 KRW 이며, 입력한 금액의 원화를 달러로 환전합니다. EXCH_TP = 2 인 경우, 매도통화: USD이며, 입력한 금액의 달러를 원화로 환전합니다. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -41,6 +43,10 @@ class OverseasExchange:
             "next-key": next_key,
             "api-id": "ust31300",
         }
+        body = {
+            "exch_tp": exch_tp,
+            "fc_exmn_amt": fc_exmn_amt,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -52,14 +58,14 @@ class OverseasExchange:
 
     def get_exchange_rate(
         self,
-        body: dict[str, str],
+        exch_tp: Literal["1", "2"],
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasExchangeRate]:
         """환율 조회 (ust31301)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            exch_tp (Literal["1", "2"]): 환전구분. 1:원화(KRW)->달러(USD), 2:달러(USD)->원화(KRW)
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -74,6 +80,9 @@ class OverseasExchange:
             "next-key": next_key,
             "api-id": "ust31301",
         }
+        body = {
+            "exch_tp": exch_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -85,14 +94,16 @@ class OverseasExchange:
 
     def request_exchange(
         self,
-        body: dict[str, str],
+        exch_tp: Literal["1", "2"],
+        fc_exmn_amt: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasExchangeRequest]:
         """환전 신청 (ust31302)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            exch_tp (Literal["1", "2"]): 환전구분. 1:원화(KRW)->달러(USD), 2:달러(USD)->원화(KRW)
+            fc_exmn_amt (str): 매도통화기준 환전금액. EXCH_TP = 1 인 경우, 매도통화는 KRW 이며, 입력한 금액의 원화를 달러로 환전합니다. EXCH_TP = 2 인 경우, 매도통화: USD이며, 입력한 금액의 달러를 원화로 환전합니다.
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -106,6 +117,10 @@ class OverseasExchange:
             "cont-yn": cont_yn,
             "next-key": next_key,
             "api-id": "ust31302",
+        }
+        body = {
+            "exch_tp": exch_tp,
+            "fc_exmn_amt": fc_exmn_amt,
         }
 
         response = self.client._post(self.path, headers, body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_exchange_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_exchange_types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 
 from cluefin_openapi.kiwoom._model import KiwoomHttpBody
@@ -7,16 +7,79 @@ from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 class OverseasExchangeEstimatedAmount(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="환전 예상 금액 조회 응답")
 
-    # TODO: 응답 필드 정의
+    sell_aplc_exrt: str = Field(default="", description="매도적용환율. 소수점 둘째 자리까지 포맷된 숫자")
+    buy_aplc_exrt: str = Field(default="", description="매수적용환율. 소수점 둘째 자리까지 포맷된 숫자")
+    aplc_exrt: str = Field(default="", description="적용환율. 소수점 여섯째 자리까지 포맷된 숫자")
+    sell_crnc_entra_nowrm: str = Field(default="", description="매도통화예수금금잔. 소수점 둘째 자리까지 포맷된 숫자")
+    sell_crnc_ch_uncla_nowrm: str = Field(
+        default="", description="매도통화현금미수금금잔. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    sell_crnc_etc_loana_nowrm: str = Field(
+        default="", description="매도통화기타대여금금잔. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    sell_crnc_exmn_alow_amt: str = Field(
+        default="", description="매도통화환전가능금액. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    buy_crnc_entra_nowrm: str = Field(default="", description="매수통화예수금금잔. 소수점 둘째 자리까지 포맷된 숫자")
+    buy_crnc_ch_uncla_nowrm: str = Field(
+        default="", description="매수통화현금미수금금잔. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    buy_crnc_etc_loana_nowrm: str = Field(
+        default="", description="매수통화기타대여금금잔. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    buy_crnc_exmn_alow_amt: str = Field(
+        default="", description="매수통화환전가능금액. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    krw_uncl_amt: str = Field(default="", description="원화미수금액. 단위: 원, 좌측 0-padding 처리된 15자리 숫자")
+    sell_expc_amt: str = Field(default="", description="매도예상금액. 소수점 둘째 자리까지 포맷된 숫자")
+    buy_expc_amt: str = Field(default="", description="매수예상금액. 소수점 둘째 자리까지 포맷된 숫자")
 
 
 class OverseasExchangeRate(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="환율 조회 응답")
 
-    # TODO: 응답 필드 정의
+    sell_aplc_exrt: str = Field(default="", description="매도적용환율. 소수점 둘째 자리까지 포맷된 숫자")
+    buy_aplc_exrt: str = Field(default="", description="매수적용환율. 소수점 둘째 자리까지 포맷된 숫자")
+    aplc_exrt: str = Field(
+        default="",
+        description="적용환율. 실제 환전에 적용되는 환율입니다. 다만, 환전시점 시 환율 변동으로 인해 조회 환율과 적용 환율이 다를 수 있으며 환전 신청 전 꼭 환율을 확인해주시기 바랍니다",
+    )
+    exrt_tp_nm: str = Field(default="", description="환율구분명")
+    spcl_bf_exrt: str = Field(
+        default="",
+        description="우대율 적용 전 환율. 환율 우대율을 적용하기 전 환율 입니다. 실제 환전은 aplc_exrt (적용환율)로 진행됩니다",
+    )
+    exrt_spcl_rt: str = Field(default="", description="환율우대율")
 
 
 class OverseasExchangeRequest(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="환전 신청 응답")
 
-    # TODO: 응답 필드 정의
+    sell_aplc_exrt: str = Field(default="", description="매도적용환율")
+    buy_aplc_exrt: str = Field(default="", description="매수적용환율")
+    aplc_exrt: str = Field(default="", description="적용환율")
+    entra_prerm: str = Field(default="", description="예수금전잔")
+    ch_uncla_prerm: str = Field(default="", description="현금미수금전잔")
+    etc_loana_prerm: str = Field(default="", description="기타대여금전잔")
+    entra_nowrm: str = Field(default="", description="예수금금잔")
+    ch_uncla_nowrm: str = Field(default="", description="현금미수금금잔")
+    etc_loana_nowrm: str = Field(default="", description="기타대여금금잔")
+    krw_exmn_alow_amt: str = Field(default="", description="원화환전가능금액")
+    ch_uncl_rpym_amt: str = Field(default="", description="현금미수변제금")
+    ch_uncl_dlfe: str = Field(default="", description="현금미수연체료")
+    etc_loan_npay_rpym_amt: str = Field(default="", description="기타대여미납변제금")
+    etc_loan_npay_dlfe: str = Field(default="", description="기타대여미납연체료")
+    fc_entra_prerm: str = Field(default="", description="외화예수금전잔")
+    fc_ch_uncla_prerm: str = Field(default="", description="외화현금미수금전잔")
+    fc_etc_loana_prerm: str = Field(default="", description="외화기타대여금전잔")
+    fc_entra_nowrm: str = Field(default="", description="외화예수금금잔")
+    fc_ch_uncla_nowrm: str = Field(default="", description="외화현금미수금금잔")
+    fc_etc_loana_nowrm: str = Field(default="", description="외화기타대여금금잔")
+    fc_exmn_alow_amt: str = Field(default="", description="외화환전가능금액")
+    fc_ch_uncl_rpym_amt: str = Field(default="", description="외화현금미수변제금")
+    fc_ch_uncl_dlfe: str = Field(default="", description="외화현금미수연체료")
+    fc_etc_loan_npay_rpym_amt: str = Field(default="", description="외화기타대여미납변제금")
+    fc_etc_loan_npay_dlfe: str = Field(default="", description="외화기타대여미납연체료")
+    krw_exmn_amt: str = Field(default="", description="원화환전금액")
+    sell_fc_amt: str = Field(default="", description="매도외화금액")
+    buy_fc_amt: str = Field(default="", description="매수외화금액")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_exchange_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_exchange_types.py
@@ -1,0 +1,22 @@
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+from cluefin_openapi.kiwoom._model import KiwoomHttpBody
+
+
+class OverseasExchangeEstimatedAmount(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="환전 예상 금액 조회 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasExchangeRate(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="환율 조회 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasExchangeRequest(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="환전 신청 응답")
+
+    # TODO: 응답 필드 정의

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_investment_info.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_investment_info.py
@@ -1,0 +1,49 @@
+from typing import Literal
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._model import (
+    KiwoomHttpHeader,
+    KiwoomHttpResponse,
+)
+from cluefin_openapi.kiwoom._overseas_investment_info_types import (
+    OverseasInvestmentInfoResearch,
+)
+
+
+class OverseasInvestmentInfo:
+    def __init__(self, client: Client):
+        self.client = client
+        self.path = "/api/us/invtinfo"
+
+    def get_research(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasInvestmentInfoResearch]:
+        """미국주식 리서치(미국주식/ETF) (usa24300)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasInvestmentInfoResearch]: 미국주식 리서치(미국주식/ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24300",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching research: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasInvestmentInfoResearch.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_investment_info.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_investment_info.py
@@ -17,14 +17,14 @@ class OverseasInvestmentInfo:
 
     def get_research(
         self,
-        body: dict[str, str],
+        qry_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasInvestmentInfoResearch]:
         """미국주식 리서치(미국주식/ETF) (usa24300)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            qry_tp (Literal["", "0", "1"], optional): 주식/ETF 구분. 0:미국주식,1:글로벌ETF. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -38,6 +38,9 @@ class OverseasInvestmentInfo:
             "cont-yn": cont_yn,
             "next-key": next_key,
             "api-id": "usa24300",
+        }
+        body = {
+            "qry_tp": qry_tp,
         }
 
         response = self.client._post(self.path, headers, body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_investment_info_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_investment_info_types.py
@@ -1,0 +1,10 @@
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+from cluefin_openapi.kiwoom._model import KiwoomHttpBody
+
+
+class OverseasInvestmentInfoResearch(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 리서치(미국주식/ETF) 응답")
+
+    # TODO: 응답 필드 정의

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_investment_info_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_investment_info_types.py
@@ -1,10 +1,22 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 
 from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 
 
+class OverseasInvestmentInfoResearchItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+
+
 class OverseasInvestmentInfoResearch(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 리서치(미국주식/ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasInvestmentInfoResearchItem] = Field(default_factory=list, description="결과리스트")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_market_condition.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_market_condition.py
@@ -21,14 +21,16 @@ class OverseasMarketCondition:
 
     def get_current_price_stock_info(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasMarketConditionCurrentPriceStockInfo]:
         """미국주식 현재가 종목정보 (usa20100)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE
+            stk_cd (str): 종목코드
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -43,6 +45,10 @@ class OverseasMarketCondition:
             "next-key": next_key,
             "api-id": "usa20100",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -54,14 +60,16 @@ class OverseasMarketCondition:
 
     def get_current_price_ten_quotes(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasMarketConditionCurrentPriceTenQuotes]:
         """미국주식 현재가 10호가 (usa20101)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE
+            stk_cd (str): 종목코드
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -76,6 +84,10 @@ class OverseasMarketCondition:
             "next-key": next_key,
             "api-id": "usa20101",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -87,14 +99,16 @@ class OverseasMarketCondition:
 
     def get_detailed_execution_history(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasMarketConditionDetailedExecutionHistory]:
         """미국주식 상세 체결내역 (usa20150)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA:AMEX,ND:NASDAQ,NY:NYSE
+            stk_cd (str): 종목코드
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -109,6 +123,10 @@ class OverseasMarketCondition:
             "next-key": next_key,
             "api-id": "usa20150",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -120,14 +138,18 @@ class OverseasMarketCondition:
 
     def get_daily_execution_history(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str,
+        base_dt: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasMarketConditionDailyExecutionHistory]:
         """미국주식 일별 체결내역 (usa20151)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA:AMEX,ND:NASDAQ,NY:NYSE
+            stk_cd (str): 종목코드
+            base_dt (str, optional): 기준일자. 기준일자 이전 내역 조회. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -142,6 +164,11 @@ class OverseasMarketCondition:
             "next-key": next_key,
             "api-id": "usa20151",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "base_dt": base_dt,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -153,14 +180,18 @@ class OverseasMarketCondition:
 
     def get_daily_stock_price(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "NA", "ND", "NY"] = "",
+        stk_cd: str = "",
+        base_dt: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasMarketConditionDailyStockPrice]:
         """미국주식 일별주가 (usa20590)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "NA", "ND", "NY"], optional): 거래소구분. NA:AMEX,ND:NASDAQ,NY:NYSE. Defaults to "".
+            stk_cd (str, optional): 종목코드. Defaults to "".
+            base_dt (str, optional): 기준일자. 기준일자 이전 내역 조회. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -174,6 +205,11 @@ class OverseasMarketCondition:
             "cont-yn": cont_yn,
             "next-key": next_key,
             "api-id": "usa20590",
+        }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "base_dt": base_dt,
         }
 
         response = self.client._post(self.path, headers, body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_market_condition.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_market_condition.py
@@ -1,0 +1,185 @@
+from typing import Literal
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._model import (
+    KiwoomHttpHeader,
+    KiwoomHttpResponse,
+)
+from cluefin_openapi.kiwoom._overseas_market_condition_types import (
+    OverseasMarketConditionCurrentPriceStockInfo,
+    OverseasMarketConditionCurrentPriceTenQuotes,
+    OverseasMarketConditionDailyExecutionHistory,
+    OverseasMarketConditionDailyStockPrice,
+    OverseasMarketConditionDetailedExecutionHistory,
+)
+
+
+class OverseasMarketCondition:
+    def __init__(self, client: Client):
+        self.client = client
+        self.path = "/api/us/mrkcond"
+
+    def get_current_price_stock_info(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasMarketConditionCurrentPriceStockInfo]:
+        """미국주식 현재가 종목정보 (usa20100)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasMarketConditionCurrentPriceStockInfo]: 미국주식 현재가 종목정보 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20100",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching current price stock info: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasMarketConditionCurrentPriceStockInfo.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_current_price_ten_quotes(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasMarketConditionCurrentPriceTenQuotes]:
+        """미국주식 현재가 10호가 (usa20101)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasMarketConditionCurrentPriceTenQuotes]: 미국주식 현재가 10호가 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20101",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching current price ten quotes: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasMarketConditionCurrentPriceTenQuotes.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_detailed_execution_history(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasMarketConditionDetailedExecutionHistory]:
+        """미국주식 상세 체결내역 (usa20150)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasMarketConditionDetailedExecutionHistory]: 미국주식 상세 체결내역 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20150",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching detailed execution history: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasMarketConditionDetailedExecutionHistory.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_daily_execution_history(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasMarketConditionDailyExecutionHistory]:
+        """미국주식 일별 체결내역 (usa20151)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasMarketConditionDailyExecutionHistory]: 미국주식 일별 체결내역 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20151",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching daily execution history: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasMarketConditionDailyExecutionHistory.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_daily_stock_price(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasMarketConditionDailyStockPrice]:
+        """미국주식 일별주가 (usa20590)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasMarketConditionDailyStockPrice]: 미국주식 일별주가 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20590",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching daily stock price: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasMarketConditionDailyStockPrice.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_market_condition_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_market_condition_types.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+from cluefin_openapi.kiwoom._model import KiwoomHttpBody
+
+
+class OverseasMarketConditionCurrentPriceStockInfo(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 현재가 종목정보 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasMarketConditionCurrentPriceTenQuotes(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 현재가 10호가 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasMarketConditionDetailedExecutionHistory(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 상세 체결내역 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasMarketConditionDailyExecutionHistory(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 일별 체결내역 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasMarketConditionDailyStockPrice(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 일별주가 응답")
+
+    # TODO: 응답 필드 정의

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_market_condition_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_market_condition_types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 
 from cluefin_openapi.kiwoom._model import KiwoomHttpBody
@@ -7,28 +7,238 @@ from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 class OverseasMarketConditionCurrentPriceStockInfo(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 현재가 종목정보 응답")
 
-    # TODO: 응답 필드 정의
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    week52_hgst_pric: str = Field(
+        default="",
+        description="52주 최고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자",
+        alias="52wk_hgst_pric",
+    )
+    week52_hgst_pric_pre_rt: str = Field(
+        default="",
+        description="52주 최고가 대비율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율",
+        alias="52wk_hgst_pric_pre_rt",
+    )
+    week52_hgst_pric_dt: str = Field(
+        default="",
+        description="52주 최고가일. YYYYMMDD",
+        alias="52wk_hgst_pric_dt",
+    )
+    week52_lwst_pric: str = Field(
+        default="",
+        description="52주 최저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자",
+        alias="52wk_lwst_pric",
+    )
+    week52_lwst_pric_pre_rt: str = Field(
+        default="",
+        description="52주 최저가 대비율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율",
+        alias="52wk_lwst_pric_pre_rt",
+    )
+    week52_lwst_pric_dt: str = Field(
+        default="",
+        description="52주 최저가일. YYYYMMDD",
+        alias="52wk_lwst_pric_dt",
+    )
+    stk_cnt: str = Field(default="", description="주식수. 단위: 1주")
+    mac: str = Field(default="", description="시가총액. 단위: 천USD")
+    setl_mm: str = Field(default="", description="결산월")
+    lg_inds_cd: str = Field(default="", description="대업종구분")
+    sm_inds_cd: str = Field(default="", description="소업종구분")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="누적거래량. 단위: 1주")
+    oyr_hgst: str = Field(default="", description="연중최고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    oyr_hgst_dt: str = Field(default="", description="연중최고가일. YYYYMMDD")
+    oyr_hgst_pre_rt: str = Field(
+        default="", description="연중최고가 대비율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    oyr_lwst: str = Field(default="", description="연중최저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    oyr_lwst_dt: str = Field(default="", description="연중최저가일. YYYYMMDD")
+    oyr_lwst_pre_rt: str = Field(
+        default="", description="연중최저가 대비율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    pre_open_pric: str = Field(default="", description="전일시가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    pre_high_pric: str = Field(default="", description="전일고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    pre_low_pric: str = Field(default="", description="전일저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    base_close_pric: str = Field(default="", description="전일종가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    upl_pric: str = Field(default="", description="상한가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    lst_pric: str = Field(default="", description="하한가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    trde_qty_unit: str = Field(default="", description="매매수량단위")
+    uncert_lv: str = Field(default="", description="불확실성")
+    comp_adv_tp: str = Field(default="", description="경쟁우위")
+    curr_unit: str = Field(default="", description="통화단위")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    trd_susp_tp: str = Field(default="", description="거래정지여부")
+    base_exrt: str = Field(default="", description="환율. 소수점 둘째 자리까지 포맷된 숫자")
 
 
 class OverseasMarketConditionCurrentPriceTenQuotes(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 현재가 10호가 응답")
 
-    # TODO: 응답 필드 정의
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    trde_prica: str = Field(default="", description="거래대금. 단위: 천USD")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    bid_tm: str = Field(default="", description="호가시간. HH:mm")
+    dt: str = Field(default="", description="일자. YYYYMMDD")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    fpr_sel_bid: str = Field(
+        default="", description="최우선매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자"
+    )
+    fpr_buy_bid: str = Field(
+        default="", description="최우선매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자"
+    )
+    pre_trde_rt: str = Field(
+        default="", description="전일거래대비. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    trde_tern_rt: str = Field(
+        default="", description="거래회전율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    sel_1bid: str = Field(default="", description="매도1호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_2bid: str = Field(default="", description="매도2호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_3bid: str = Field(default="", description="매도3호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_4bid: str = Field(default="", description="매도4호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_5bid: str = Field(default="", description="매도5호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_6bid: str = Field(default="", description="매도6호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_7bid: str = Field(default="", description="매도7호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_8bid: str = Field(default="", description="매도8호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_9bid: str = Field(default="", description="매도9호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_10bid: str = Field(default="", description="매도10호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_1bid: str = Field(default="", description="매수1호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_2bid: str = Field(default="", description="매수2호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_3bid: str = Field(default="", description="매수3호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_4bid: str = Field(default="", description="매수4호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_5bid: str = Field(default="", description="매수5호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_6bid: str = Field(default="", description="매수6호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_7bid: str = Field(default="", description="매수7호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_8bid: str = Field(default="", description="매수8호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_9bid: str = Field(default="", description="매수9호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_10bid: str = Field(default="", description="매수10호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_1bid_req: str = Field(default="", description="매도1호가잔량. 단위: 1주")
+    sel_2bid_req: str = Field(default="", description="매도2호가잔량. 단위: 1주")
+    sel_3bid_req: str = Field(default="", description="매도3호가잔량. 단위: 1주")
+    sel_4bid_req: str = Field(default="", description="매도4호가잔량. 단위: 1주")
+    sel_5bid_req: str = Field(default="", description="매도5호가잔량. 단위: 1주")
+    sel_6bid_req: str = Field(default="", description="매도6호가잔량. 단위: 1주")
+    sel_7bid_req: str = Field(default="", description="매도7호가잔량. 단위: 1주")
+    sel_8bid_req: str = Field(default="", description="매도8호가잔량. 단위: 1주")
+    sel_9bid_req: str = Field(default="", description="매도9호가잔량. 단위: 1주")
+    sel_10bid_req: str = Field(default="", description="매도10호가잔량. 단위: 1주")
+    buy_1bid_req: str = Field(default="", description="매수1호가잔량. 단위: 1주")
+    buy_2bid_req: str = Field(default="", description="매수2호가잔량. 단위: 1주")
+    buy_3bid_req: str = Field(default="", description="매수3호가잔량. 단위: 1주")
+    buy_4bid_req: str = Field(default="", description="매수4호가잔량. 단위: 1주")
+    buy_5bid_req: str = Field(default="", description="매수5호가잔량. 단위: 1주")
+    buy_6bid_req: str = Field(default="", description="매수6호가잔량. 단위: 1주")
+    buy_7bid_req: str = Field(default="", description="매수7호가잔량. 단위: 1주")
+    buy_8bid_req: str = Field(default="", description="매수8호가잔량. 단위: 1주")
+    buy_9bid_req: str = Field(default="", description="매수9호가잔량. 단위: 1주")
+    buy_10bid_req: str = Field(default="", description="매수10호가잔량. 단위: 1주")
+    sel_1bid_jub_pre: str = Field(default="", description="매도1호가직전대비")
+    sel_2bid_jub_pre: str = Field(default="", description="매도2호가직전대비")
+    sel_3bid_jub_pre: str = Field(default="", description="매도3호가직전대비")
+    sel_4bid_jub_pre: str = Field(default="", description="매도4호가직전대비")
+    sel_5bid_jub_pre: str = Field(default="", description="매도5호가직전대비")
+    sel_6bid_jub_pre: str = Field(default="", description="매도6호가직전대비")
+    sel_7bid_jub_pre: str = Field(default="", description="매도7호가직전대비")
+    sel_8bid_jub_pre: str = Field(default="", description="매도8호가직전대비")
+    sel_9bid_jub_pre: str = Field(default="", description="매도9호가직전대비")
+    sel_10bid_jub_pre: str = Field(default="", description="매도10호가직전대비")
+    buy_1th_pre_req_pre: str = Field(default="", description="매수1차선잔량대비")
+    buy_1bid_jub_pre: str = Field(default="", description="매수1호가직전대비")
+    buy_2bid_jub_pre: str = Field(default="", description="매수2호가직전대비")
+    buy_3bid_jub_pre: str = Field(default="", description="매수3호가직전대비")
+    buy_4bid_jub_pre: str = Field(default="", description="매수4호가직전대비")
+    buy_5bid_jub_pre: str = Field(default="", description="매수5호가직전대비")
+    buy_6bid_jub_pre: str = Field(default="", description="매수6호가직전대비")
+    buy_7bid_jub_pre: str = Field(default="", description="매수7호가직전대비")
+    buy_8bid_jub_pre: str = Field(default="", description="매수8호가직전대비")
+    buy_9bid_jub_pre: str = Field(default="", description="매수9호가직전대비")
+    buy_10bid_jub_pre: str = Field(default="", description="매수10호가직전대비")
+    tot_sel_req: str = Field(default="", description="총매도잔량. 단위: 1주")
+    sel_bid_tot_req_jub_pre: str = Field(default="", description="매도호가총잔량직전대비")
+    tot_buy_req: str = Field(default="", description="총매수잔량. 단위: 1주")
+    buy_bid_tot_req_jub_pre: str = Field(default="", description="매수호가총잔량직전대비")
+    netprps_req: str = Field(default="", description="순매수잔량. 단위: 1주")
+    netslmt_req: str = Field(default="", description="순매도잔량. 단위: 1주")
+    upl_pric: str = Field(default="", description="상한가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    base_pric: str = Field(default="", description="기준가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+
+
+class OverseasMarketConditionDetailedExecutionHistoryItem(BaseModel):
+    cur_prc: str = Field(default="", description="현재가, 종가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    trde_qty: str = Field(default="", description="거래량. 단위: 1주, 부호가 포함된 숫자")
+    cntr_tm: str = Field(default="", description="체결시간. HHmmss")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
 
 
 class OverseasMarketConditionDetailedExecutionHistory(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 상세 체결내역 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasMarketConditionDetailedExecutionHistoryItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasMarketConditionDailyExecutionHistoryItem(BaseModel):
+    dt: str = Field(default="", description="일자. YYYYMMDD")
+    cur_prc: str = Field(default="", description="현재가, 종가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="누적거래량. 단위: 1주")
 
 
 class OverseasMarketConditionDailyExecutionHistory(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 일별 체결내역 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasMarketConditionDailyExecutionHistoryItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasMarketConditionDailyStockPriceItem(BaseModel):
+    dt: str = Field(default="", description="일자. YYYYMMDD")
+    cur_prc: str = Field(default="", description="현재가(종가). 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="누적거래량. 단위: 1주")
+    trde_prica: str = Field(default="", description="누적금액. 단위: 천USD")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    base_pric: str = Field(default="", description="기준가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    base_open_flu_rt: str = Field(
+        default="", description="기준가대비 시가등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    base_high_flu_rt: str = Field(
+        default="", description="기준가대비 고가등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    base_low_flu_rt: str = Field(
+        default="", description="기준가대비 저가등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
 
 
 class OverseasMarketConditionDailyStockPrice(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 일별주가 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasMarketConditionDailyStockPriceItem] = Field(
+        default_factory=list, description="결과리스트"
+    )

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_order.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_order.py
@@ -21,14 +21,22 @@ class OverseasOrder:
 
     def request_buy_order(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str,
+        ord_qty: str,
+        trde_tp: Literal["00", "03", "26", "27", "30", "36", "37"],
+        ord_uv: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasOrderBuy]:
         """미국주식 매수 주문 (ust20000)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE
+            stk_cd (str): 종목코드
+            ord_qty (str): 주문수량
+            trde_tp (Literal["00", "03", "26", "27", "30", "36", "37"]): 해외매매구분. 00:지정가,03:시장가,26:VWAP지정가,27:TWAP지정가,30:LOC,36:VWAP시장가,37:TWAP시장가
+            ord_uv (str, optional): 주문단가. trde_tp가 00(지정가),30(LOC)...인 경우 필수 입력, 그 외 시장가 거래유형 설정 시 입력 값은 빈 값 처리. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -43,6 +51,13 @@ class OverseasOrder:
             "next-key": next_key,
             "api-id": "ust20000",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "ord_qty": ord_qty,
+            "ord_uv": ord_uv,
+            "trde_tp": trde_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -54,14 +69,24 @@ class OverseasOrder:
 
     def request_sell_order(
         self,
-        body: dict[str, str],
+        stk_cd: str,
+        stex_tp: Literal["NA", "ND", "NY"],
+        ord_qty: str,
+        trde_tp: Literal["00", "03", "26", "27", "30", "33", "34", "35", "36", "37"],
+        ord_uv: str = "",
+        stop_pric: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasOrderSell]:
         """미국주식 매도 주문 (ust20001)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stk_cd (str): 종목코드
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE
+            ord_qty (str): 주문수량
+            trde_tp (Literal["00", "03", "26", "27", "30", "33", "34", "35", "36", "37"]): 매매구분. 00:지정가,03:시장가,26:VWAP지정가,27:TWAP지정가,30:LOC,33:MOC,34:STOP LIMIT,35:STOP,36:VWAP시장가,37:TWAP시장가
+            ord_uv (str, optional): 주문단가. trde_tp가 00(지정가),30(LOC)...인 경우 필수 입력, 그 외 시장가 거래유형 설정 시 입력 값은 빈 값 처리. Defaults to "".
+            stop_pric (str, optional): STOP가격. trde_tp가 34(STOP LIMIT) 또는 35(STOP)인 경우 필수 입력, 그 외 거래유형(지정가,시장가 등) 설정 시 입력 값은 무시되거나 빈 값처리. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -76,6 +101,14 @@ class OverseasOrder:
             "next-key": next_key,
             "api-id": "ust20001",
         }
+        body = {
+            "stk_cd": stk_cd,
+            "stex_tp": stex_tp,
+            "ord_qty": ord_qty,
+            "ord_uv": ord_uv,
+            "stop_pric": stop_pric,
+            "trde_tp": trde_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -87,14 +120,22 @@ class OverseasOrder:
 
     def request_modify_order(
         self,
-        body: dict[str, str],
+        orig_ord_no: str,
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str,
+        mdfy_uv: str = "",
+        stop_pric: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasOrderModify]:
         """미국주식 정정 주문 (ust20002)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            orig_ord_no (str): 원주문번호. 주문 요청 응답 결과로 받은 ord_no를 설정
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE
+            stk_cd (str): 종목코드
+            mdfy_uv (str, optional): 정정단가. Defaults to "".
+            stop_pric (str, optional): STOP가격. 원주문 trde_tp가 34(STOP LIMIT) 또는 35(STOP)인 경우 필수 입력, 그 외 거래유형(지정가 등) 설정 시 입력 값은 무시되거나 빈 값처리. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -109,6 +150,13 @@ class OverseasOrder:
             "next-key": next_key,
             "api-id": "ust20002",
         }
+        body = {
+            "orig_ord_no": orig_ord_no,
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "mdfy_uv": mdfy_uv,
+            "stop_pric": stop_pric,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -120,14 +168,18 @@ class OverseasOrder:
 
     def request_cancel_order(
         self,
-        body: dict[str, str],
+        orig_ord_no: str,
+        stex_tp: Literal["NA", "ND", "NY"],
+        stk_cd: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasOrderCancel]:
         """미국주식 취소 주문 (ust20003)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            orig_ord_no (str): 원주문번호. 주문 요청 응답 결과로 받은 ord_no를 설정
+            stex_tp (Literal["NA", "ND", "NY"]): 거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE
+            stk_cd (str): 종목코드
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -142,6 +194,11 @@ class OverseasOrder:
             "next-key": next_key,
             "api-id": "ust20003",
         }
+        body = {
+            "orig_ord_no": orig_ord_no,
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -153,14 +210,18 @@ class OverseasOrder:
 
     def get_orderable_quantity(
         self,
-        body: dict[str, str],
+        stk_cd: str,
+        uv: str,
+        stex_tp: Literal["", "NA", "ND", "NY"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasOrderOrderableQuantity]:
         """미국주식 주문가능수량(종목/증거금률별) (ust31490)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stk_cd (str): 종목코드
+            uv (str): 매수가격
+            stex_tp (Literal["", "NA", "ND", "NY"], optional): 거래소구분. NA:AMEX, ND:NASDAQ, NY:NYSE. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -174,6 +235,11 @@ class OverseasOrder:
             "cont-yn": cont_yn,
             "next-key": next_key,
             "api-id": "ust31490",
+        }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "uv": uv,
         }
 
         response = self.client._post(self.path, headers, body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_order.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_order.py
@@ -1,0 +1,185 @@
+from typing import Literal
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._model import (
+    KiwoomHttpHeader,
+    KiwoomHttpResponse,
+)
+from cluefin_openapi.kiwoom._overseas_order_types import (
+    OverseasOrderBuy,
+    OverseasOrderCancel,
+    OverseasOrderModify,
+    OverseasOrderOrderableQuantity,
+    OverseasOrderSell,
+)
+
+
+class OverseasOrder:
+    def __init__(self, client: Client):
+        self.client = client
+        self.path = "/api/us/ordr"
+
+    def request_buy_order(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasOrderBuy]:
+        """미국주식 매수 주문 (ust20000)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasOrderBuy]: 미국주식 매수 주문 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust20000",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"request buy order failed: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasOrderBuy.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def request_sell_order(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasOrderSell]:
+        """미국주식 매도 주문 (ust20001)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasOrderSell]: 미국주식 매도 주문 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust20001",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"request sell order failed: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasOrderSell.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def request_modify_order(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasOrderModify]:
+        """미국주식 정정 주문 (ust20002)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasOrderModify]: 미국주식 정정 주문 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust20002",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"request modify order failed: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasOrderModify.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def request_cancel_order(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasOrderCancel]:
+        """미국주식 취소 주문 (ust20003)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasOrderCancel]: 미국주식 취소 주문 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust20003",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"request cancel order failed: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasOrderCancel.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_orderable_quantity(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasOrderOrderableQuantity]:
+        """미국주식 주문가능수량(종목/증거금률별) (ust31490)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasOrderOrderableQuantity]: 미국주식 주문가능수량(종목/증거금률별) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ust31490",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching orderable quantity: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasOrderOrderableQuantity.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_order_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_order_types.py
@@ -1,0 +1,34 @@
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+from cluefin_openapi.kiwoom._model import KiwoomHttpBody
+
+
+class OverseasOrderBuy(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 매수 주문 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasOrderSell(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 매도 주문 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasOrderModify(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 정정 주문 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasOrderCancel(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 취소 주문 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasOrderOrderableQuantity(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 주문가능수량(종목/증거금률별) 응답")
+
+    # TODO: 응답 필드 정의

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_order_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_order_types.py
@@ -1,4 +1,4 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 
 from cluefin_openapi.kiwoom._model import KiwoomHttpBody
@@ -7,28 +7,105 @@ from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 class OverseasOrderBuy(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 매수 주문 응답")
 
-    # TODO: 응답 필드 정의
+    stk_nm: str = Field(default="", description="종목명")
+    ord_no: str = Field(default="", description="주문번호. 취소 혹은 정정 주문 시 사용")
+    fc_entra: str = Field(default="", description="외화예수금")
+    tdy_rebuy_useda: str = Field(default="", description="금일재매수사용금액")
+    pred_rebuy_useda: str = Field(default="", description="전일재매수사용금액")
+    trst_prof_ch: str = Field(default="", description="사용증거금")
 
 
 class OverseasOrderSell(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 매도 주문 응답")
 
-    # TODO: 응답 필드 정의
+    stk_nm: str = Field(default="", description="종목명")
+    ord_no: str = Field(default="", description="주문번호. 취소 혹은 정정 주문 시 사용")
+    poss_qty: str = Field(default="", description="보유수량")
+    tdy_resel_usedq: str = Field(default="", description="금일재매도사용수량")
+    pred_resel_usedq: str = Field(default="", description="전일재매도사용수량")
 
 
 class OverseasOrderModify(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 정정 주문 응답")
 
-    # TODO: 응답 필드 정의
+    stk_nm: str = Field(default="", description="종목명")
+    ord_no: str = Field(default="", description="주문번호. 취소 혹은 정정 주문 시 사용")
+    fc_entra: str = Field(default="", description="외화예수금")
+    tdy_rebuy_useda: str = Field(default="", description="금일재매수사용금액")
+    pred_rebuy_useda: str = Field(default="", description="전일재매수사용금액")
+    trst_prof_ch: str = Field(default="", description="사용증거금")
+    mdfy_ord_qty: str = Field(default="", description="정정주문수량")
 
 
 class OverseasOrderCancel(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 취소 주문 응답")
 
-    # TODO: 응답 필드 정의
+    stk_nm: str = Field(default="", description="종목명")
+    ord_no: str = Field(default="", description="주문번호")
+    cncl_ord_qty: str = Field(default="", description="취소주문수량")
 
 
 class OverseasOrderOrderableQuantity(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 주문가능수량(종목/증거금률별) 응답")
 
-    # TODO: 응답 필드 정의
+    stk_profa_rt: str = Field(default="", description="종목증거금율")
+    profa_rt: str = Field(default="", description="계좌증거금율")
+    aplc_rt: str = Field(default="", description="적용증거금율")
+    krw_ord_rqst_yn: str = Field(default="", description="원화주문신청여부. Y, N")
+    krw_ord_alowa_50: str = Field(
+        default="", description="증거금50%종목 원화주문가능금액. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    krw_ord_alowq_50: str = Field(
+        default="", description="증거금50%종목 원화주문가능수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    ord_alowa_50: str = Field(default="", description="증거금50%종목 주문가능금액. 소수점 둘째 자리까지 포맷된 숫자")
+    ord_alowq_50: str = Field(
+        default="", description="증거금50%종목 주문가능수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    pred_rebuy_alowa_50: str = Field(
+        default="", description="증거금50%종목 전일재사용금액. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    tdy_rebuy_alowa_50: str = Field(
+        default="", description="증거금50%종목 금일재사용금액. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    krw_ord_alowa_100: str = Field(
+        default="", description="증거금100%종목원화주문가능금액. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    krw_ord_alowq_100: str = Field(
+        default="", description="증거금100%종목원화주문가능수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    ord_alowa_100: str = Field(default="", description="증거금100%종목 주문가능금액. 소수점 둘째 자리까지 포맷된 숫자")
+    ord_alowq_100: str = Field(
+        default="", description="증거금100%종목 주문가능수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    pred_rebuy_alowa_100: str = Field(
+        default="", description="증거금100%종목 전일재사용금액. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    tdy_rebuy_alowa_100: str = Field(
+        default="", description="증거금100%종목 금일재사용금액. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    min_krw_ord_alowa: str = Field(
+        default="", description="미수불가 원화주문가능금액. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    min_krw_ord_alowq: str = Field(
+        default="", description="미수불가 원화주문가능수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    min_ord_alowa: str = Field(default="", description="미수불가 주문가능금액. 소수점 둘째 자리까지 포맷된 숫자")
+    min_ord_alowq: str = Field(
+        default="", description="미수불가 주문가능수량. 단위: 1주, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    min_pred_rebuy_alowa: str = Field(
+        default="", description="미수불가 전일재사용금액. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    min_tdy_rebuy_alowa: str = Field(
+        default="", description="미수불가 금일재사용금액. 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    krw_entra: str = Field(default="", description="원화예수금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자")
+    fc_entra: str = Field(default="", description="외화예수금. 소수점 둘째 자리까지 포맷된 숫자")
+    fc_uncl_amt: str = Field(default="", description="외화미수금. 소수점 둘째 자리까지 포맷된 숫자")
+    ord_alowa: str = Field(default="", description="주문가능현금. 소수점 둘째 자리까지 포맷된 숫자")
+    krw_ord_set_amt: str = Field(
+        default="", description="해외원화주문설정금. 단위: 원, 좌측 0-padding 처리된 12자리 숫자"
+    )
+    krw_ord_evlt_amt: str = Field(default="", description="해외원화주문평가금. 소수점 둘째 자리까지 포맷된 숫자")
+    crnc_code: str = Field(default="", description="통화")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_rank_info.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_rank_info.py
@@ -51,14 +51,14 @@ class OverseasRankInfo:
 
     def get_realtime_symbol_query_rank(
         self,
-        body: dict[str, str],
+        svc_type: Literal["", "B286", "B281", "B282", "B283", "B284"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoRealtimeSymbolQueryRank]:
         """미국주식 실시간 종목 조회 순위 (usa01980)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            svc_type (Literal["", "B286", "B281", "B282", "B283", "B284"], optional): 서비스 유형. B286:30초,B281:1분,B282:10분,B283:1시간,B284:당일. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -73,6 +73,9 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa01980",
         }
+        body = {
+            "svc_type": svc_type,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -84,14 +87,16 @@ class OverseasRankInfo:
 
     def get_watchlist_registration_top(
         self,
-        body: dict[str, str],
+        dt_unit_tp: Literal["", "D", "W", "M"] = "",
+        stk_tp: Literal["", "A", "S", "E"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoWatchlistRegistrationTop]:
         """미국주식 관심종목 등록 상위 (usa01990)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            dt_unit_tp (Literal["", "D", "W", "M"], optional): 일,주,월단위구분. D:일,W:주,M:월. Defaults to "".
+            stk_tp (Literal["", "A", "S", "E"], optional): 시장구분. A:전체,S:주식,E:ETF. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -106,6 +111,10 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa01990",
         }
+        body = {
+            "dt_unit_tp": dt_unit_tp,
+            "stk_tp": stk_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -117,14 +126,30 @@ class OverseasRankInfo:
 
     def get_period_fluctuation_rank_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        tm: Literal["", "1", "5", "10", "30"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoPeriodFluctuationRankStock]:
         """미국주식 기간별 등락률상위(주식/업종) (usa20510)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            tm (Literal["", "1", "5", "10", "30"], optional): n일전 구분. 1:전일 5:5일 10:10일 30:30일,기본값:1. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -139,6 +164,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20510",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "stk_cnd": stk_cnd,
+            "tm": tm,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -150,14 +185,30 @@ class OverseasRankInfo:
 
     def get_period_fluctuation_rank_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        tm: Literal["", "1", "5", "10", "30"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoPeriodFluctuationRankEtf]:
         """미국주식 기간별 등락률상위(ETF) (usa20511)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            tm (Literal["", "1", "5", "10", "30"], optional): n일전 구분. 1:전일 5:5일 10:10일 30:30일,기본값:1. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -172,6 +223,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20511",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "stk_cnd": stk_cnd,
+            "tm": tm,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -183,14 +244,28 @@ class OverseasRankInfo:
 
     def get_period_fluctuation_rank_watchlist(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        stk_cd: list[dict[str, str]] | None = None,
+        tm: Literal["", "1", "5", "10", "30"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoPeriodFluctuationRankWatchlist]:
         """미국주식 기간별 등락률상위(관심종목) (usa20512)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            stk_cd (list[dict[str, str]] | None, optional): 종목코드. [{'stex_tp':'거래소구분','stk_cd':'종목코드'},...]. Defaults to None.
+            tm (Literal["", "1", "5", "10", "30"], optional): n일전 설정. 1:전일 5:5일 10:10일 30:30일,기본값:1. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -205,6 +280,15 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20512",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd if stk_cd is not None else [],
+            "tm": tm,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -216,14 +300,30 @@ class OverseasRankInfo:
 
     def get_today_trading_volume_top_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        qry_tp: Literal["", "0", "1", "2"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoTodayTradingVolumeTopStock]:
         """미국주식 당일 거래량 상위(주식/업종) (usa20530)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목 구분. 0:전체,1:주식. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            qry_tp (Literal["", "0", "1", "2"], optional): 정렬기준 구분. 0:거래량상위,1:거래대금상위,2:거래회전율상위. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목필터 구분. 0:전체,1:증100%만보기,2:증50%만보기. Defaults to "".
+            pric_cnd (Literal, optional): 검색가격대 구분. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -238,6 +338,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20530",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "trde_qty_tp": trde_qty_tp,
+            "qry_tp": qry_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -249,14 +359,30 @@ class OverseasRankInfo:
 
     def get_today_trading_volume_top_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        qry_tp: Literal["", "0", "1", "2"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoTodayTradingVolumeTopEtf]:
         """미국주식 당일 거래량 상위(ETF) (usa20531)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            qry_tp (Literal["", "0", "1", "2"], optional): 정렬기준 구분. 0:거래량상위,1:거래대금상위,2:거래회전율상위. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목필터 구분. 0:전체,1:증100%만보기,2:증50%만보기. Defaults to "".
+            pric_cnd (Literal, optional): 검색가격대 구분. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -271,6 +397,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20531",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "trde_qty_tp": trde_qty_tp,
+            "qry_tp": qry_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -282,14 +418,28 @@ class OverseasRankInfo:
 
     def get_today_trading_value_top_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoTodayTradingValueTopStock]:
         """미국주식 당일 거래대금 상위(주식/업종) (usa20540)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목 구분. 0:전체,1:주식. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목필터 구분. 0:전체,1:증100%만보기,2:증50%만보기. Defaults to "".
+            pric_cnd (Literal, optional): 검색가격대 구분. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -304,6 +454,15 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20540",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -315,14 +474,28 @@ class OverseasRankInfo:
 
     def get_today_trading_value_top_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoTodayTradingValueTopEtf]:
         """미국주식 당일 거래대금 상위(ETF) (usa20541)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목필터 구분. 0:전체,1:증100%만보기,2:증50%만보기. Defaults to "".
+            pric_cnd (Literal, optional): 검색가격대 구분. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -337,6 +510,15 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20541",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -348,14 +530,28 @@ class OverseasRankInfo:
 
     def get_market_cap_top_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoMarketCapTopStock]:
         """미국주식 시가총액상위(주식/업종) (usa20550)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목 구분. 0:전체,1:주식. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목필터 구분. 0:전체,1:증100%만보기,2:증50%만보기. Defaults to "".
+            pric_cnd (Literal, optional): 검색가격대 구분. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -370,6 +566,15 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20550",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -381,14 +586,28 @@ class OverseasRankInfo:
 
     def get_market_cap_top_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoMarketCapTopEtf]:
         """미국주식 시가총액상위(ETF) (usa20551)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목필터 구분. 0:전체,1:증100%만보기,2:증50%만보기. Defaults to "".
+            pric_cnd (Literal, optional): 검색가격대 구분. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -403,6 +622,15 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20551",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -414,14 +642,16 @@ class OverseasRankInfo:
 
     def get_kiwoom_trading_top_stock(
         self,
-        body: dict[str, str],
+        qry_tp: Literal["", "1", "2", "3", "4", "5", "6", "7"] = "",
+        dt_unit_tp: Literal["", "1", "2", "3", "4", "5", "6", "7", "8"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoKiwoomTradingTopStock]:
         """키움 거래 상위 종목(미국주식) (usa20880)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            qry_tp (Literal, optional): 조회구분. 1:매수상위,2:매도상위,3:순매수상위,4:보유잔고상위,5:보유고객상위,6:거래비중상위,7:거래대금상위. Defaults to "".
+            dt_unit_tp (Literal, optional): 일,주,월단위구분. 1:일,2:주,3:월,4:년,5:10분,6:30분,7:60분,8:5분. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -436,6 +666,10 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20880",
         }
+        body = {
+            "qry_tp": qry_tp,
+            "dt_unit_tp": dt_unit_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -447,14 +681,16 @@ class OverseasRankInfo:
 
     def get_kiwoom_trading_top_etf(
         self,
-        body: dict[str, str],
+        qry_tp: Literal["", "1", "2", "3", "4", "5", "6", "7"] = "",
+        dt_unit_tp: Literal["", "1", "2", "3", "4", "5", "6", "7", "8"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoKiwoomTradingTopEtf]:
         """키움 거래 상위 종목(미국 ETF) (usa20881)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            qry_tp (Literal, optional): 조회구분. 1:매수상위,2:매도상위,3:순매수상위,4:보유잔고상위,5:보유고객상위,6:거래비중상위,7:거래대금상위. Defaults to "".
+            dt_unit_tp (Literal, optional): 일,주,월단위구분. 1:일,2:주,3:월,4:년,5:10분,6:30분,7:60분,8:5분. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -469,6 +705,10 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20881",
         }
+        body = {
+            "qry_tp": qry_tp,
+            "dt_unit_tp": dt_unit_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -480,14 +720,32 @@ class OverseasRankInfo:
 
     def get_previous_day_fluctuation_rank_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        inds_cls_tp: Literal["", "0", "1", "2", "3"] = "",
+        sort_tp: Literal["", "1", "2", "3", "4", "5"] = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoPreviousDayFluctuationRankStock]:
         """미국주식 전일대비 등락률상위(주식/업종) (usa20910)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            inds_cls_tp (Literal["", "0", "1", "2", "3"], optional): 미국업종구분. stk_tp 0일경우, 0:전체,1:다우30,2:나스닥100,3:S&P500. Defaults to "".
+            sort_tp (Literal["", "1", "2", "3", "4", "5"], optional): 정렬기준. 1:전일대비 상승률,2:전일대비 상승폭,3:보합,4:전일대비 하락률,5:전일대비 하락폭. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -502,6 +760,17 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20910",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "inds_cls_tp": inds_cls_tp,
+            "sort_tp": sort_tp,
+            "stk_tp": stk_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "trde_qty_tp": trde_qty_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -513,14 +782,30 @@ class OverseasRankInfo:
 
     def get_previous_day_fluctuation_rank_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        sort_tp: Literal["", "1", "2", "3", "4", "5"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoPreviousDayFluctuationRankEtf]:
         """미국주식 전일대비 등락률상위(ETF) (usa20911)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            sort_tp (Literal["", "1", "2", "3", "4", "5"], optional): 정렬기준. 1:전일대비 상승률,2:전일대비 상승폭,3:보합,4:전일대비 하락률,5:전일대비 하락폭. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -535,6 +820,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20911",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "sort_tp": sort_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "trde_qty_tp": trde_qty_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -546,14 +841,30 @@ class OverseasRankInfo:
 
     def get_open_price_fluctuation_rank_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        sort_tp: Literal["", "1", "2"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoOpenPriceFluctuationRankStock]:
         """미국주식 시가대비 등락률상위(주식/업종) (usa20920)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            sort_tp (Literal["", "1", "2"], optional): 정렬기준. 1:상승률,2:하락률. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -568,6 +879,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20920",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_tp": stk_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "sort_tp": sort_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -579,14 +900,30 @@ class OverseasRankInfo:
 
     def get_open_price_fluctuation_rank_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        sort_tp: Literal["", "1", "2"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoOpenPriceFluctuationRankEtf]:
         """미국주식 시가대비 등락률상위(ETF) (usa20921)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            sort_tp (Literal["", "1", "2"], optional): 정렬기준. 1:상승률,2:하락률. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -601,6 +938,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20921",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "sort_tp": sort_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -612,14 +959,30 @@ class OverseasRankInfo:
 
     def get_open_price_fluctuation_rank_watchlist(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        stk_cd: list[dict[str, str]] | None = None,
+        sort_tp: Literal["", "1", "2"] = "",
+        stk_tp: Literal["", "0", "1", "2"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoOpenPriceFluctuationRankWatchlist]:
         """미국주식 시가대비 등락률상위(관심종목) (usa20922)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            stk_cd (list[dict[str, str]] | None, optional): 관심종목코드. [{'stex_tp':'거래소구분','stk_cd':'종목코드'},...]. Defaults to None.
+            sort_tp (Literal["", "1", "2"], optional): 정렬기준. 1:상승률,2:하락률. Defaults to "".
+            stk_tp (Literal["", "0", "1", "2"], optional): 종목구분. 0:전체,1:주식,2:ETF. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -634,6 +997,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20922",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd if stk_cd is not None else [],
+            "sort_tp": sort_tp,
+            "stk_tp": stk_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "trde_qty_tp": trde_qty_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -645,14 +1018,36 @@ class OverseasRankInfo:
 
     def get_cumulative_fluctuation_top_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        sort_tp: Literal["", "0", "1", "3", "4"] = "",
+        pric_cnd1: str = "",
+        pric_cnd2: str = "",
+        base_dt: str = "",
+        stk_cnd: Literal["", "0"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoCumulativeFluctuationTopStock]:
         """미국주식 누적 등락률 상위(주식/업종) (usa20940)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            sort_tp (Literal["", "0", "1", "3", "4"], optional): 정렬기준구분. 0:상승률,1:상승폭,3:하락률,4:하락폭. Defaults to "".
+            pric_cnd1 (str, optional): 가격1 구분. Defaults to "".
+            pric_cnd2 (str, optional): 가격2 구분. Defaults to "".
+            base_dt (str, optional): 기준일자. YYYYMMDD. Defaults to "".
+            stk_cnd (Literal["", "0"], optional): 종목조건. 0:전체. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 검색가격대 구분. 0:전체 1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -667,6 +1062,19 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20940",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "sort_tp": sort_tp,
+            "pric_cnd1": pric_cnd1,
+            "pric_cnd2": pric_cnd2,
+            "base_dt": base_dt,
+            "stk_cnd": stk_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -678,14 +1086,36 @@ class OverseasRankInfo:
 
     def get_cumulative_fluctuation_top_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        sort_tp: Literal["", "0", "1", "3", "4"] = "",
+        pric_cnd1: str = "",
+        pric_cnd2: str = "",
+        base_dt: str = "",
+        stk_cnd: Literal["", "0"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoCumulativeFluctuationTopEtf]:
         """미국주식 누적 등락률 상위(ETF) (usa20941)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            sort_tp (Literal["", "0", "1", "3", "4"], optional): 정렬기준구분. 0:상승률,1:상승폭,3:하락률,4:하락폭. Defaults to "".
+            pric_cnd1 (str, optional): 가격1 구분. Defaults to "".
+            pric_cnd2 (str, optional): 가격2 구분. Defaults to "".
+            base_dt (str, optional): 기준일자. YYYYMMDD. Defaults to "".
+            stk_cnd (Literal["", "0"], optional): 종목조건. 0:전체. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 검색가격대 구분. 0:전체 1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -700,6 +1130,19 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20941",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "sort_tp": sort_tp,
+            "pric_cnd1": pric_cnd1,
+            "pric_cnd2": pric_cnd2,
+            "base_dt": base_dt,
+            "stk_cnd": stk_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -711,14 +1154,20 @@ class OverseasRankInfo:
 
     def get_previous_day_trading_top_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        qry_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoPreviousDayTradingTopStock]:
         """미국주식 전일 거래상위(주식/업종) (usa20960)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목 구분. 0:전체,1:주식. Defaults to "".
+            qry_tp (Literal["", "0", "1"], optional): 정렬기준구분. 0:전일거래량상위,1:전일거래대금상위. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -733,6 +1182,12 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20960",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "qry_tp": qry_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -744,14 +1199,20 @@ class OverseasRankInfo:
 
     def get_previous_day_trading_top_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        qry_tp: Literal["", "0", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoPreviousDayTradingTopEtf]:
         """미국주식 전일 거래상위(ETF) (usa20961)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            qry_tp (Literal["", "0", "1"], optional): 정렬기준구분. 0:전일거래량상위,1:전일거래대금상위. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -766,6 +1227,12 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa20961",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "qry_tp": qry_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -777,14 +1244,32 @@ class OverseasRankInfo:
 
     def get_high_low_price_rise_fall_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        sort_tp: Literal["", "0", "1"] = "",
+        dt_tp: Literal["", "0", "1"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoHighLowPriceRiseFallStock]:
         """미국주식 최고최저가대비 상승하락(주식/업종) (usa24110)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목 구분. 0:전체,1:주식. Defaults to "".
+            sort_tp (Literal["", "0", "1"], optional): 정렬기준구분. 0:저가대비상승,1:고가대비하락. Defaults to "".
+            dt_tp (Literal["", "0", "1"], optional): 기간구분. 0:연중,1:52주. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체 1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -799,6 +1284,17 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24110",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "sort_tp": sort_tp,
+            "dt_tp": dt_tp,
+            "stk_cnd": stk_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -810,14 +1306,32 @@ class OverseasRankInfo:
 
     def get_high_low_price_rise_fall_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        sort_tp: Literal["", "0", "1"] = "",
+        dt_tp: Literal["", "0", "1"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoHighLowPriceRiseFallEtf]:
         """미국주식 최고최저가대비 상승하락(ETF) (usa24111)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            sort_tp (Literal["", "0", "1"], optional): 정렬기준구분. 0:저가대비상승,1:고가대비하락. Defaults to "".
+            dt_tp (Literal["", "0", "1"], optional): 기간구분. 0:연중,1:52주. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체 1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -832,6 +1346,17 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24111",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "sort_tp": sort_tp,
+            "dt_tp": dt_tp,
+            "stk_cnd": stk_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -843,14 +1368,32 @@ class OverseasRankInfo:
 
     def get_specific_date_rise_fall_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        base_dt: str = "",
+        sort_tp: Literal["", "0", "2"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoSpecificDateRiseFallStock]:
         """미국주식 특정일자 상승/하락(주식/업종) (usa24120)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            base_dt (str, optional): 기간. YYYYMMDD. Defaults to "".
+            sort_tp (Literal["", "0", "2"], optional): 정렬기준 구분. 0:상승,2:하락. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -865,6 +1408,17 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24120",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "trde_prica_cnd": trde_prica_cnd,
+            "base_dt": base_dt,
+            "sort_tp": sort_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -876,14 +1430,32 @@ class OverseasRankInfo:
 
     def get_specific_date_rise_fall_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        base_dt: str = "",
+        sort_tp: Literal["", "0", "2"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoSpecificDateRiseFallEtf]:
         """미국주식 특정일자 상승/하락(ETF) (usa24121)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            base_dt (str, optional): 기간. YYYYMMDD. Defaults to "".
+            sort_tp (Literal["", "0", "2"], optional): 정렬기준 구분. 0:상승,2:하락. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -898,6 +1470,17 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24121",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "trde_prica_cnd": trde_prica_cnd,
+            "base_dt": base_dt,
+            "sort_tp": sort_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -909,14 +1492,28 @@ class OverseasRankInfo:
 
     def get_turnover_rate_top_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoTurnoverRateTopStock]:
         """미국주식 회전율 상위(주식/업종) (usa24150)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -931,6 +1528,15 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24150",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_tp": stk_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -942,14 +1548,28 @@ class OverseasRankInfo:
 
     def get_turnover_rate_top_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoTurnoverRateTopEtf]:
         """미국주식 회전율 상위(ETF) (usa24151)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -964,6 +1584,15 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24151",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -975,14 +1604,30 @@ class OverseasRankInfo:
 
     def get_consecutive_rise_fall_rank_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        sort_tp: Literal["", "0", "1", "2", "3", "4", "5"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoConsecutiveRiseFallRankStock]:
         """미국주식 연속상승/하락 순위(주식/업종) (usa24160)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            sort_tp (Literal, optional): 정렬기준. 0:연속일수상승,1:연속일수보합,2:연속일수하락,3:기준일대비상승,4:기준일대비보합,5:기준일대비 하락. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -997,6 +1642,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24160",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "sort_tp": sort_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -1008,14 +1663,30 @@ class OverseasRankInfo:
 
     def get_consecutive_rise_fall_rank_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        sort_tp: Literal["", "0", "1", "2", "3", "4", "5"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoConsecutiveRiseFallRankEtf]:
         """미국주식 연속상승/하락 순위(ETF) (usa24161)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            sort_tp (Literal, optional): 정렬기준. 0:연속일수상승,1:연속일수보합,2:연속일수하락,3:기준일대비상승,4:기준일대비보합,5:기준일대비 하락. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1030,6 +1701,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24161",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "sort_tp": sort_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -1041,14 +1722,28 @@ class OverseasRankInfo:
 
     def get_consecutive_rise_fall_rank_watchlist(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        stk_cd: list[dict[str, str]] | None = None,
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        sort_tp: Literal["", "0", "1", "2", "3", "4", "5"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoConsecutiveRiseFallRankWatchlist]:
         """미국주식 연속상승/하락 순위(관심종목) (usa24162)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            stk_cd (list[dict[str, str]] | None, optional): 관심종목. [{'stex_tp':'거래소구분','stk_cd':'종목코드'},...]. Defaults to None.
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            sort_tp (Literal, optional): 정렬기준. 0:연속일수상승,1:연속일수보합,2:연속일수하락,3:기준일대비상승,4:기준일대비보합,5:기준일대비 하락. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1063,6 +1758,15 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24162",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd if stk_cd is not None else [],
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "sort_tp": sort_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -1074,14 +1778,30 @@ class OverseasRankInfo:
 
     def get_quote_remaining_volume_top_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        sort_tp: Literal["", "1", "2", "3", "4"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoQuoteRemainingVolumeTopStock]:
         """미국주식 호가잔량상위(주식/업종) (usa24200)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            sort_tp (Literal["", "1", "2", "3", "4"], optional): 정렬기준. 1:순매수잔량순,2:순매도잔량순,3:순매수비율순,4:순매도비율순. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1096,6 +1816,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24200",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "sort_tp": sort_tp,
+            "stk_cnd": stk_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -1107,14 +1837,30 @@ class OverseasRankInfo:
 
     def get_quote_remaining_volume_top_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        sort_tp: Literal["", "1", "2", "3", "4"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoQuoteRemainingVolumeTopEtf]:
         """미국주식 호가잔량상위(ETF) (usa24201)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            sort_tp (Literal["", "1", "2", "3", "4"], optional): 정렬기준. 1:순매수잔량순,2:순매도잔량순,3:순매수비율순,4:순매도비율순. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1129,6 +1875,16 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24201",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "sort_tp": sort_tp,
+            "stk_cnd": stk_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -1140,14 +1896,32 @@ class OverseasRankInfo:
 
     def get_daytime_trading_disparity_top_stock(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
+        inds_cls_tp: Literal["", "0", "1", "2", "3"] = "",
+        stk_tp: Literal["", "0", "1"] = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        sort_tp: Literal["", "0", "1", "2", "3", "4"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoDaytimeTradingDisparityTopStock]:
         """미국주식 주간거래 괴리율 상위(주식/업종) (usa24290)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            inds_cls_tp (Literal["", "0", "1", "2", "3"], optional): 해외주식업종분류구분. stk_tp 0일 경우, 0:전체,1:다우30,2:나스닥100,3:S&P500. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            sort_tp (Literal["", "0", "1", "2", "3", "4"], optional): 정렬기준 구분. 0:상승률,1:상승폭,2:보합,3:하락율,4:하락폭. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1162,6 +1936,17 @@ class OverseasRankInfo:
             "next-key": next_key,
             "api-id": "usa24290",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "inds_cls_tp": inds_cls_tp,
+            "stk_tp": stk_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "trde_prica_cnd": trde_prica_cnd,
+            "sort_tp": sort_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -1173,14 +1958,30 @@ class OverseasRankInfo:
 
     def get_daytime_trading_disparity_top_etf(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        stk_cnd: Literal["", "0", "1", "2"] = "",
+        pric_cnd: Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"] = "",
+        trde_qty_tp: Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"] = "",
+        trde_prica_cnd: Literal[
+            "", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"
+        ] = "",
+        sort_tp: Literal["", "0", "1", "2", "3", "4"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasRankInfoDaytimeTradingDisparityTopEtf]:
         """미국주식 주간거래 괴리율 상위(ETF) (usa24291)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            sort_tp (Literal["", "0", "1", "2", "3", "4"], optional): 정렬기준 구분. 0:상승률,1:상승폭,2:보합,3:하락율,4:하락폭. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1194,6 +1995,16 @@ class OverseasRankInfo:
             "cont-yn": cont_yn,
             "next-key": next_key,
             "api-id": "usa24291",
+        }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "trde_prica_cnd": trde_prica_cnd,
+            "sort_tp": sort_tp,
         }
 
         response = self.client._post(self.path, headers, body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_rank_info.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_rank_info.py
@@ -1,0 +1,1205 @@
+from typing import Literal
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._model import (
+    KiwoomHttpHeader,
+    KiwoomHttpResponse,
+)
+from cluefin_openapi.kiwoom._overseas_rank_info_types import (
+    OverseasRankInfoConsecutiveRiseFallRankEtf,
+    OverseasRankInfoConsecutiveRiseFallRankStock,
+    OverseasRankInfoConsecutiveRiseFallRankWatchlist,
+    OverseasRankInfoCumulativeFluctuationTopEtf,
+    OverseasRankInfoCumulativeFluctuationTopStock,
+    OverseasRankInfoDaytimeTradingDisparityTopEtf,
+    OverseasRankInfoDaytimeTradingDisparityTopStock,
+    OverseasRankInfoHighLowPriceRiseFallEtf,
+    OverseasRankInfoHighLowPriceRiseFallStock,
+    OverseasRankInfoKiwoomTradingTopEtf,
+    OverseasRankInfoKiwoomTradingTopStock,
+    OverseasRankInfoMarketCapTopEtf,
+    OverseasRankInfoMarketCapTopStock,
+    OverseasRankInfoOpenPriceFluctuationRankEtf,
+    OverseasRankInfoOpenPriceFluctuationRankStock,
+    OverseasRankInfoOpenPriceFluctuationRankWatchlist,
+    OverseasRankInfoPeriodFluctuationRankEtf,
+    OverseasRankInfoPeriodFluctuationRankStock,
+    OverseasRankInfoPeriodFluctuationRankWatchlist,
+    OverseasRankInfoPreviousDayFluctuationRankEtf,
+    OverseasRankInfoPreviousDayFluctuationRankStock,
+    OverseasRankInfoPreviousDayTradingTopEtf,
+    OverseasRankInfoPreviousDayTradingTopStock,
+    OverseasRankInfoQuoteRemainingVolumeTopEtf,
+    OverseasRankInfoQuoteRemainingVolumeTopStock,
+    OverseasRankInfoRealtimeSymbolQueryRank,
+    OverseasRankInfoSpecificDateRiseFallEtf,
+    OverseasRankInfoSpecificDateRiseFallStock,
+    OverseasRankInfoTodayTradingValueTopEtf,
+    OverseasRankInfoTodayTradingValueTopStock,
+    OverseasRankInfoTodayTradingVolumeTopEtf,
+    OverseasRankInfoTodayTradingVolumeTopStock,
+    OverseasRankInfoTurnoverRateTopEtf,
+    OverseasRankInfoTurnoverRateTopStock,
+    OverseasRankInfoWatchlistRegistrationTop,
+)
+
+
+class OverseasRankInfo:
+    def __init__(self, client: Client):
+        self.client = client
+        self.path = "/api/us/rkinfo"
+
+    def get_realtime_symbol_query_rank(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoRealtimeSymbolQueryRank]:
+        """미국주식 실시간 종목 조회 순위 (usa01980)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoRealtimeSymbolQueryRank]: 미국주식 실시간 종목 조회 순위 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa01980",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching realtime symbol query rank: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoRealtimeSymbolQueryRank.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_watchlist_registration_top(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoWatchlistRegistrationTop]:
+        """미국주식 관심종목 등록 상위 (usa01990)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoWatchlistRegistrationTop]: 미국주식 관심종목 등록 상위 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa01990",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching watchlist registration top: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoWatchlistRegistrationTop.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_period_fluctuation_rank_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoPeriodFluctuationRankStock]:
+        """미국주식 기간별 등락률상위(주식/업종) (usa20510)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoPeriodFluctuationRankStock]: 미국주식 기간별 등락률상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20510",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching period fluctuation rank stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoPeriodFluctuationRankStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_period_fluctuation_rank_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoPeriodFluctuationRankEtf]:
+        """미국주식 기간별 등락률상위(ETF) (usa20511)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoPeriodFluctuationRankEtf]: 미국주식 기간별 등락률상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20511",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching period fluctuation rank etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoPeriodFluctuationRankEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_period_fluctuation_rank_watchlist(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoPeriodFluctuationRankWatchlist]:
+        """미국주식 기간별 등락률상위(관심종목) (usa20512)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoPeriodFluctuationRankWatchlist]: 미국주식 기간별 등락률상위(관심종목) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20512",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching period fluctuation rank watchlist: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoPeriodFluctuationRankWatchlist.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_today_trading_volume_top_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoTodayTradingVolumeTopStock]:
+        """미국주식 당일 거래량 상위(주식/업종) (usa20530)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoTodayTradingVolumeTopStock]: 미국주식 당일 거래량 상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20530",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching today trading volume top stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoTodayTradingVolumeTopStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_today_trading_volume_top_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoTodayTradingVolumeTopEtf]:
+        """미국주식 당일 거래량 상위(ETF) (usa20531)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoTodayTradingVolumeTopEtf]: 미국주식 당일 거래량 상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20531",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching today trading volume top etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoTodayTradingVolumeTopEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_today_trading_value_top_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoTodayTradingValueTopStock]:
+        """미국주식 당일 거래대금 상위(주식/업종) (usa20540)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoTodayTradingValueTopStock]: 미국주식 당일 거래대금 상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20540",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching today trading value top stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoTodayTradingValueTopStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_today_trading_value_top_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoTodayTradingValueTopEtf]:
+        """미국주식 당일 거래대금 상위(ETF) (usa20541)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoTodayTradingValueTopEtf]: 미국주식 당일 거래대금 상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20541",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching today trading value top etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoTodayTradingValueTopEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_market_cap_top_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoMarketCapTopStock]:
+        """미국주식 시가총액상위(주식/업종) (usa20550)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoMarketCapTopStock]: 미국주식 시가총액상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20550",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching market cap top stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoMarketCapTopStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_market_cap_top_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoMarketCapTopEtf]:
+        """미국주식 시가총액상위(ETF) (usa20551)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoMarketCapTopEtf]: 미국주식 시가총액상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20551",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching market cap top etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoMarketCapTopEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_kiwoom_trading_top_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoKiwoomTradingTopStock]:
+        """키움 거래 상위 종목(미국주식) (usa20880)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoKiwoomTradingTopStock]: 키움 거래 상위 종목(미국주식) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20880",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching kiwoom trading top stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoKiwoomTradingTopStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_kiwoom_trading_top_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoKiwoomTradingTopEtf]:
+        """키움 거래 상위 종목(미국 ETF) (usa20881)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoKiwoomTradingTopEtf]: 키움 거래 상위 종목(미국 ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20881",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching kiwoom trading top etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoKiwoomTradingTopEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_previous_day_fluctuation_rank_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoPreviousDayFluctuationRankStock]:
+        """미국주식 전일대비 등락률상위(주식/업종) (usa20910)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoPreviousDayFluctuationRankStock]: 미국주식 전일대비 등락률상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20910",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching previous day fluctuation rank stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoPreviousDayFluctuationRankStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_previous_day_fluctuation_rank_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoPreviousDayFluctuationRankEtf]:
+        """미국주식 전일대비 등락률상위(ETF) (usa20911)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoPreviousDayFluctuationRankEtf]: 미국주식 전일대비 등락률상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20911",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching previous day fluctuation rank etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoPreviousDayFluctuationRankEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_open_price_fluctuation_rank_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoOpenPriceFluctuationRankStock]:
+        """미국주식 시가대비 등락률상위(주식/업종) (usa20920)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoOpenPriceFluctuationRankStock]: 미국주식 시가대비 등락률상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20920",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching open price fluctuation rank stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoOpenPriceFluctuationRankStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_open_price_fluctuation_rank_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoOpenPriceFluctuationRankEtf]:
+        """미국주식 시가대비 등락률상위(ETF) (usa20921)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoOpenPriceFluctuationRankEtf]: 미국주식 시가대비 등락률상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20921",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching open price fluctuation rank etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoOpenPriceFluctuationRankEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_open_price_fluctuation_rank_watchlist(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoOpenPriceFluctuationRankWatchlist]:
+        """미국주식 시가대비 등락률상위(관심종목) (usa20922)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoOpenPriceFluctuationRankWatchlist]: 미국주식 시가대비 등락률상위(관심종목) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20922",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching open price fluctuation rank watchlist: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoOpenPriceFluctuationRankWatchlist.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_cumulative_fluctuation_top_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoCumulativeFluctuationTopStock]:
+        """미국주식 누적 등락률 상위(주식/업종) (usa20940)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoCumulativeFluctuationTopStock]: 미국주식 누적 등락률 상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20940",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching cumulative fluctuation top stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoCumulativeFluctuationTopStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_cumulative_fluctuation_top_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoCumulativeFluctuationTopEtf]:
+        """미국주식 누적 등락률 상위(ETF) (usa20941)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoCumulativeFluctuationTopEtf]: 미국주식 누적 등락률 상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20941",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching cumulative fluctuation top etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoCumulativeFluctuationTopEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_previous_day_trading_top_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoPreviousDayTradingTopStock]:
+        """미국주식 전일 거래상위(주식/업종) (usa20960)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoPreviousDayTradingTopStock]: 미국주식 전일 거래상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20960",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching previous day trading top stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoPreviousDayTradingTopStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_previous_day_trading_top_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoPreviousDayTradingTopEtf]:
+        """미국주식 전일 거래상위(ETF) (usa20961)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoPreviousDayTradingTopEtf]: 미국주식 전일 거래상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20961",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching previous day trading top etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoPreviousDayTradingTopEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_high_low_price_rise_fall_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoHighLowPriceRiseFallStock]:
+        """미국주식 최고최저가대비 상승하락(주식/업종) (usa24110)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoHighLowPriceRiseFallStock]: 미국주식 최고최저가대비 상승하락(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24110",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching high low price rise fall stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoHighLowPriceRiseFallStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_high_low_price_rise_fall_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoHighLowPriceRiseFallEtf]:
+        """미국주식 최고최저가대비 상승하락(ETF) (usa24111)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoHighLowPriceRiseFallEtf]: 미국주식 최고최저가대비 상승하락(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24111",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching high low price rise fall etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoHighLowPriceRiseFallEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_specific_date_rise_fall_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoSpecificDateRiseFallStock]:
+        """미국주식 특정일자 상승/하락(주식/업종) (usa24120)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoSpecificDateRiseFallStock]: 미국주식 특정일자 상승/하락(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24120",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching specific date rise fall stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoSpecificDateRiseFallStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_specific_date_rise_fall_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoSpecificDateRiseFallEtf]:
+        """미국주식 특정일자 상승/하락(ETF) (usa24121)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoSpecificDateRiseFallEtf]: 미국주식 특정일자 상승/하락(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24121",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching specific date rise fall etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoSpecificDateRiseFallEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_turnover_rate_top_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoTurnoverRateTopStock]:
+        """미국주식 회전율 상위(주식/업종) (usa24150)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoTurnoverRateTopStock]: 미국주식 회전율 상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24150",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching turnover rate top stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoTurnoverRateTopStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_turnover_rate_top_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoTurnoverRateTopEtf]:
+        """미국주식 회전율 상위(ETF) (usa24151)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoTurnoverRateTopEtf]: 미국주식 회전율 상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24151",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching turnover rate top etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoTurnoverRateTopEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_consecutive_rise_fall_rank_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoConsecutiveRiseFallRankStock]:
+        """미국주식 연속상승/하락 순위(주식/업종) (usa24160)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoConsecutiveRiseFallRankStock]: 미국주식 연속상승/하락 순위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24160",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching consecutive rise fall rank stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoConsecutiveRiseFallRankStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_consecutive_rise_fall_rank_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoConsecutiveRiseFallRankEtf]:
+        """미국주식 연속상승/하락 순위(ETF) (usa24161)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoConsecutiveRiseFallRankEtf]: 미국주식 연속상승/하락 순위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24161",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching consecutive rise fall rank etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoConsecutiveRiseFallRankEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_consecutive_rise_fall_rank_watchlist(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoConsecutiveRiseFallRankWatchlist]:
+        """미국주식 연속상승/하락 순위(관심종목) (usa24162)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoConsecutiveRiseFallRankWatchlist]: 미국주식 연속상승/하락 순위(관심종목) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24162",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching consecutive rise fall rank watchlist: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoConsecutiveRiseFallRankWatchlist.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_quote_remaining_volume_top_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoQuoteRemainingVolumeTopStock]:
+        """미국주식 호가잔량상위(주식/업종) (usa24200)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoQuoteRemainingVolumeTopStock]: 미국주식 호가잔량상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24200",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching quote remaining volume top stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoQuoteRemainingVolumeTopStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_quote_remaining_volume_top_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoQuoteRemainingVolumeTopEtf]:
+        """미국주식 호가잔량상위(ETF) (usa24201)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoQuoteRemainingVolumeTopEtf]: 미국주식 호가잔량상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24201",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching quote remaining volume top etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoQuoteRemainingVolumeTopEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_daytime_trading_disparity_top_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoDaytimeTradingDisparityTopStock]:
+        """미국주식 주간거래 괴리율 상위(주식/업종) (usa24290)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoDaytimeTradingDisparityTopStock]: 미국주식 주간거래 괴리율 상위(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24290",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching daytime trading disparity top stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoDaytimeTradingDisparityTopStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_daytime_trading_disparity_top_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasRankInfoDaytimeTradingDisparityTopEtf]:
+        """미국주식 주간거래 괴리율 상위(ETF) (usa24291)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasRankInfoDaytimeTradingDisparityTopEtf]: 미국주식 주간거래 괴리율 상위(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24291",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching daytime trading disparity top etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasRankInfoDaytimeTradingDisparityTopEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_rank_info_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_rank_info_types.py
@@ -1,214 +1,930 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 
 from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 
 
+class OverseasRankInfoRealtimeSymbolQueryRankItem(BaseModel):
+    rank: str = Field(default="", description="종목순위")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    sign: str = Field(default="", description="등락부호. +: 상승, -:하락, '': 보합")
+    chg_val: str = Field(default="", description="직전대비 순위변화값")
+    curr_pric: str = Field(default="", description="현재가. 소수점 넷째 자리까지 포맷된 숫자")
+    sign_for_gjga: str = Field(default="", description="기준가대비 부호. +: 상승, -:하락, '': 보합")
+    diff_rate_for_gjga: str = Field(
+        default="", description="기준가대비 등락률. 단위: %, 소수점 넷째 자리까지 포맷된 백분율"
+    )
+    sign_for_prev: str = Field(default="", description="직전기준대비 부호. +: 상승, -:하락, '': 보합")
+    diff_rate_for_prev: str = Field(
+        default="", description="직전기준대비 등락률. 단위: %, 소수점 넷째 자리까지 포맷된 백분율"
+    )
+    stex_tp: str = Field(default="", description="거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX")
+
+
 class OverseasRankInfoRealtimeSymbolQueryRank(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 실시간 종목 조회 순위 응답")
 
-    # TODO: 응답 필드 정의
+    base_date: str = Field(default="", description="기준날짜. YYYYMMDD")
+    base_time: str = Field(default="", description="기준시간. HHmmss")
+    result_list: list[OverseasRankInfoRealtimeSymbolQueryRankItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoWatchlistRegistrationTopItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    rank_flu_sig: str = Field(default="", description="순위등락부호. +:상승, -:하락, 0:순위변동없음, N:신규진입")
+    rank_flu: str = Field(default="", description="순위등락폭. 부호가 포함된 숫자")
+    stex_tp: str = Field(default="", description="거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일거래량대비. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
 
 
 class OverseasRankInfoWatchlistRegistrationTop(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 관심종목 등록 상위 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoWatchlistRegistrationTopItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoPeriodFluctuationRankStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    stdt_base_pric: str = Field(
+        default="", description="시작일기준가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자"
+    )
+    endt_base_pric: str = Field(
+        default="", description="종료일기준가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자"
+    )
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    stdt_trde_qty: str = Field(default="", description="시작일거래량. 단위: 1주")
+    endt_trde_qty: str = Field(default="", description="종료일거래량. 단위: 1주")
 
 
 class OverseasRankInfoPeriodFluctuationRankStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 기간별 등락률상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoPeriodFluctuationRankStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoPeriodFluctuationRankEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    stdt_base_pric: str = Field(
+        default="", description="시작일기준가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자"
+    )
+    endt_base_pric: str = Field(
+        default="", description="종료일기준가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자"
+    )
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    stdt_trde_qty: str = Field(default="", description="시작일거래량. 단위: 1주")
+    endt_trde_qty: str = Field(default="", description="종료일거래량. 단위: 1주")
 
 
 class OverseasRankInfoPeriodFluctuationRankEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 기간별 등락률상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoPeriodFluctuationRankEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoPeriodFluctuationRankWatchlistItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    stdt_base_pric: str = Field(
+        default="", description="시작일기준가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자"
+    )
+    endt_base_pric: str = Field(
+        default="", description="종료일기준가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자"
+    )
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    stdt_trde_qty: str = Field(default="", description="시작일거래량. 단위: 1주")
+    endt_trde_qty: str = Field(default="", description="종료일거래량. 단위: 1주")
 
 
 class OverseasRankInfoPeriodFluctuationRankWatchlist(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 기간별 등락률상위(관심종목) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoPeriodFluctuationRankWatchlistItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoTodayTradingVolumeTopStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    pred_rt: str = Field(default="", description="전일비. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    trde_prica: str = Field(default="", description="거래대금. 단위: 천USD")
 
 
 class OverseasRankInfoTodayTradingVolumeTopStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 당일 거래량 상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoTodayTradingVolumeTopStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoTodayTradingVolumeTopEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    pred_rt: str = Field(default="", description="전일비. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    trde_prica: str = Field(default="", description="거래대금. 단위: 천USD")
 
 
 class OverseasRankInfoTodayTradingVolumeTopEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 당일 거래량 상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoTodayTradingVolumeTopEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoTodayTradingValueTopStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소 구분. ND:NASDAQ,NY:NYSE,NA:AMEX")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    pred_trde_qty: str = Field(default="", description="전일거래량. 단위: 1주")
+    trde_prica: str = Field(default="", description="거래대금. 단위: 천USD")
 
 
 class OverseasRankInfoTodayTradingValueTopStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 당일 거래대금 상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoTodayTradingValueTopStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoTodayTradingValueTopEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소 구분")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    pred_trde_qty: str = Field(default="", description="전일거래량. 단위: 1주")
+    trde_prica: str = Field(default="", description="거래대금. 단위: 천USD")
 
 
 class OverseasRankInfoTodayTradingValueTopEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 당일 거래대금 상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoTodayTradingValueTopEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoMarketCapTopStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    mac: str = Field(default="", description="시가총액. 단위: 천USD")
+    trde_pre_rt: str = Field(default="", description="거래대비율. 소수점 둘째 자리까지 포맷된 숫자")
+    mac_wght: str = Field(default="", description="시가총액비. 소수점 둘째 자리까지 포맷된 숫자")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
 
 
 class OverseasRankInfoMarketCapTopStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 시가총액상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoMarketCapTopStockItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasRankInfoMarketCapTopEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    mac: str = Field(default="", description="시가총액. 단위: 천USD")
+    trde_pre_rt: str = Field(default="", description="거래대비율. 소수점 둘째 자리까지 포맷된 숫자")
+    mac_wght: str = Field(default="", description="시가총액비. 소수점 둘째 자리까지 포맷된 숫자")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
 
 
 class OverseasRankInfoMarketCapTopEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 시가총액상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoMarketCapTopEtfItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasRankInfoKiwoomTradingTopStockItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    kw_high_rank: str = Field(default="", description="키움상위순위")
+    kw_high_rank_sig: str = Field(default="", description="키움상위순위등락부호. 0:신규,1:상승,2:하락,3:동일")
+    kw_high_rank_hl: str = Field(default="", description="키움상위 순위등락폭")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
 
 
 class OverseasRankInfoKiwoomTradingTopStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="키움 거래 상위 종목(미국주식) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoKiwoomTradingTopStockItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasRankInfoKiwoomTradingTopEtfItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    kw_high_rank: str = Field(default="", description="키움상위순위")
+    kw_high_rank_sig: str = Field(default="", description="키움상위순위등락부호. 0:신규,1:상승,2:하락,3:동일")
+    kw_high_rank_hl: str = Field(default="", description="키움상위 순위등락폭")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
 
 
 class OverseasRankInfoKiwoomTradingTopEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="키움 거래 상위 종목(미국 ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoKiwoomTradingTopEtfItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasRankInfoPreviousDayFluctuationRankStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    sel_req: str = Field(default="", description="매도잔량. 단위: 1주")
+    buy_req: str = Field(default="", description="매수잔량. 단위: 1주")
+    trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    cnt: str = Field(default="", description="횟수")
 
 
 class OverseasRankInfoPreviousDayFluctuationRankStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 전일대비 등락률상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoPreviousDayFluctuationRankStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoPreviousDayFluctuationRankEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    sel_req: str = Field(default="", description="매도잔량. 단위: 1주")
+    buy_req: str = Field(default="", description="매수잔량. 단위: 1주")
+    trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    cnt: str = Field(default="", description="횟수")
 
 
 class OverseasRankInfoPreviousDayFluctuationRankEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 전일대비 등락률상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoPreviousDayFluctuationRankEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoOpenPriceFluctuationRankStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    open_pric_pre: str = Field(default="", description="시가대비 등락률. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    cntr_tm: str = Field(default="", description="체결시간. HH:mm")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasRankInfoOpenPriceFluctuationRankStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 시가대비 등락률상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoOpenPriceFluctuationRankStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoOpenPriceFluctuationRankEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    open_pric_pre: str = Field(default="", description="시가대비 등락률. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    cntr_tm: str = Field(default="", description="체결시간. HH:mm")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasRankInfoOpenPriceFluctuationRankEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 시가대비 등락률상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoOpenPriceFluctuationRankEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoOpenPriceFluctuationRankWatchlistItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    open_pric_pre: str = Field(default="", description="시가대비. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    cntr_tm: str = Field(default="", description="시간. HH:mm")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasRankInfoOpenPriceFluctuationRankWatchlist(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 시가대비 등락률상위(관심종목) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoOpenPriceFluctuationRankWatchlistItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoCumulativeFluctuationTopStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    hgst_pric: str = Field(default="", description="최고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    stk_high_dt: str = Field(default="", description="종목최고일자. YYYYMMDD")
+    lwst_pric: str = Field(default="", description="최저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    stk_low_dt: str = Field(default="", description="종목최저일자. YYYYMMDD")
+    acc_flu_rt: str = Field(default="", description="누적등락률. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    acc_flu_amt: str = Field(default="", description="누적등락폭. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasRankInfoCumulativeFluctuationTopStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 누적 등락률 상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoCumulativeFluctuationTopStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoCumulativeFluctuationTopEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    hgst_pric: str = Field(default="", description="최고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    stk_high_dt: str = Field(default="", description="종목최고일자. YYYYMMDD")
+    lwst_pric: str = Field(default="", description="최저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    stk_low_dt: str = Field(default="", description="종목최저일자. YYYYMMDD")
+    acc_flu_rt: str = Field(default="", description="누적등락률. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    acc_flu_amt: str = Field(default="", description="누적등락폭. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasRankInfoCumulativeFluctuationTopEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 누적 등락률 상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoCumulativeFluctuationTopEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoPreviousDayTradingTopStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_rt: str = Field(default="", description="전일비. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="당일거래량. 단위: 1주")
 
 
 class OverseasRankInfoPreviousDayTradingTopStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 전일 거래상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoPreviousDayTradingTopStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoPreviousDayTradingTopEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_rt: str = Field(default="", description="전일비. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="당일거래량. 단위: 1주")
 
 
 class OverseasRankInfoPreviousDayTradingTopEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 전일 거래상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoPreviousDayTradingTopEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoHighLowPriceRiseFallStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    oyr_hgst: str = Field(default="", description="연중최고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    oyr_lwst: str = Field(default="", description="연중최저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    week52_hgst_pric: str = Field(
+        default="",
+        description="52주 최고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자",
+        alias="52wk_hgst_pric",
+    )
+    week52_lwst_pric: str = Field(
+        default="",
+        description="52주 최저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자",
+        alias="52wk_lwst_pric",
+    )
+    hl_pre_sig: str = Field(
+        default="", description="최저가/최고가 대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+    hl_pre: str = Field(default="", description="최저가/최고가대비")
+    pre_flu_rt: str = Field(default="", description="대비등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    base_dt: str = Field(default="", description="최고/최저일시. YYYYMMDD")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
 
 
 class OverseasRankInfoHighLowPriceRiseFallStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 최고최저가대비 상승하락(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoHighLowPriceRiseFallStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoHighLowPriceRiseFallEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    oyr_hgst: str = Field(default="", description="연중최고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    oyr_lwst: str = Field(default="", description="연중최저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    week52_hgst_pric: str = Field(
+        default="",
+        description="52주 최고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자",
+        alias="52wk_hgst_pric",
+    )
+    week52_lwst_pric: str = Field(
+        default="",
+        description="52주 최저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자",
+        alias="52wk_lwst_pric",
+    )
+    hl_pre_sig: str = Field(
+        default="", description="최저가/최고가 대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+    hl_pre: str = Field(default="", description="최저가/최고가대비")
+    pre_flu_rt: str = Field(default="", description="대비등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    base_dt: str = Field(default="", description="최고/최저일시. YYYYMMDD")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
 
 
 class OverseasRankInfoHighLowPriceRiseFallEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 최고최저가대비 상승하락(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoHighLowPriceRiseFallEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoSpecificDateRiseFallStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    base_dt: str = Field(default="", description="기준일자. YYYYMMDD")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    trde_prica: str = Field(default="", description="누적거래대금")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 소수점 다섯째 자리까지 포맷된 백분율")
 
 
 class OverseasRankInfoSpecificDateRiseFallStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 특정일자 상승/하락(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoSpecificDateRiseFallStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoSpecificDateRiseFallEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    base_dt: str = Field(default="", description="기준일자. YYYYMMDD")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    trde_prica: str = Field(default="", description="누적거래대금")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 소수점 다섯째 자리까지 포맷된 백분율")
 
 
 class OverseasRankInfoSpecificDateRiseFallEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 특정일자 상승/하락(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoSpecificDateRiseFallEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoTurnoverRateTopStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    trde_tern_rt: str = Field(
+        default="", description="거래회전율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    avg_tern_rt_2d: str = Field(
+        default="", description="2일 평균 회전율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율", alias="2d_avg_tern_rt"
+    )
+    avg_tern_rt_10d: str = Field(
+        default="", description="10일 평균 회전율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율", alias="10d_avg_tern_rt"
+    )
+    avg_tern_rt_20d: str = Field(
+        default="", description="20일 평균 회전율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율", alias="20d_avg_tern_rt"
+    )
 
 
 class OverseasRankInfoTurnoverRateTopStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 회전율 상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoTurnoverRateTopStockItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasRankInfoTurnoverRateTopEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    trde_tern_rt: str = Field(
+        default="", description="거래회전율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    avg_tern_rt_2d: str = Field(
+        default="", description="2일 평균 회전율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율", alias="2d_avg_tern_rt"
+    )
+    avg_tern_rt_10d: str = Field(
+        default="", description="10일 평균 회전율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율", alias="10d_avg_tern_rt"
+    )
+    avg_tern_rt_20d: str = Field(
+        default="", description="20일 평균 회전율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율", alias="20d_avg_tern_rt"
+    )
 
 
 class OverseasRankInfoTurnoverRateTopEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 회전율 상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoTurnoverRateTopEtfItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasRankInfoConsecutiveRiseFallRankStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+    base_close_pric: str = Field(default="", description="기준일종가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    base_pre_rt: str = Field(default="", description="기준일대비율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    conti_dt: str = Field(default="", description="연속일수")
 
 
 class OverseasRankInfoConsecutiveRiseFallRankStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 연속상승/하락 순위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoConsecutiveRiseFallRankStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoConsecutiveRiseFallRankEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+    base_close_pric: str = Field(default="", description="기준일종가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    base_pre_rt: str = Field(default="", description="기준일대비율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    conti_dt: str = Field(default="", description="연속일수")
 
 
 class OverseasRankInfoConsecutiveRiseFallRankEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 연속상승/하락 순위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoConsecutiveRiseFallRankEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoConsecutiveRiseFallRankWatchlistItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+    base_close_pric: str = Field(default="", description="기준일종가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    base_pre_rt: str = Field(default="", description="기준일대비율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    conti_dt: str = Field(default="", description="연속일수")
 
 
 class OverseasRankInfoConsecutiveRiseFallRankWatchlist(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 연속상승/하락 순위(관심종목) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoConsecutiveRiseFallRankWatchlistItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoQuoteRemainingVolumeTopStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    tot_sel_req: str = Field(default="", description="매도호가총잔량. 단위: 1주")
+    tot_buy_req: str = Field(default="", description="매수호가총잔량. 단위: 1주")
+    buy_req: str = Field(default="", description="순매수잔량. 순매수잔량/매수비율 검색일 경우")
+    buy_rt: str = Field(
+        default="", description="매수비율. 소수점 제거 된 100배 값으로 제공 예) '2658'는 26.58를 의미합니다."
+    )
+    sel_req: str = Field(default="", description="순매도잔량. 순매도잔량/매도비율 검색일 경우")
+    sel_rt: str = Field(
+        default="", description="매도비율. 소수점 제거 된 100배 값으로 제공 예) '2658'는 26.58를 의미합니다."
+    )
+    cntr_tm: str = Field(default="", description="시간. HH:mm")
 
 
 class OverseasRankInfoQuoteRemainingVolumeTopStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 호가잔량상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoQuoteRemainingVolumeTopStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoQuoteRemainingVolumeTopEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    tot_sel_req: str = Field(default="", description="매도호가총잔량. 단위: 1주")
+    tot_buy_req: str = Field(default="", description="매수호가총잔량. 단위: 1주")
+    buy_req: str = Field(default="", description="순매수잔량. 순매수잔량/매수비율 검색일 경우")
+    buy_rt: str = Field(
+        default="", description="매수비율. 소수점 제거 된 100배 값으로 제공 예) '2658'는 26.58를 의미합니다."
+    )
+    sel_req: str = Field(default="", description="순매도잔량. 순매도잔량/매도비율 검색일 경우")
+    sel_rt: str = Field(
+        default="", description="매도비율. 소수점 제거 된 100배 값으로 제공 예) '2658'는 26.58를 의미합니다."
+    )
+    cntr_tm: str = Field(default="", description="시간. HH:mm")
 
 
 class OverseasRankInfoQuoteRemainingVolumeTopEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 호가잔량상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoQuoteRemainingVolumeTopEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoDaytimeTradingDisparityTopStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    reg_close_pric: str = Field(
+        default="", description="정규장종가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자"
+    )
+    reg_pre_sig: str = Field(default="", description="정규장대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    reg_pre: str = Field(default="", description="정규장대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    dispty_rt: str = Field(default="", description="괴리율")
+    cntr_tm: str = Field(default="", description="체결시간")
+    cntr_str: str = Field(default="", description="체결강도")
+    cnt: str = Field(default="", description="횟수")
 
 
 class OverseasRankInfoDaytimeTradingDisparityTopStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 주간거래 괴리율 상위(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoDaytimeTradingDisparityTopStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasRankInfoDaytimeTradingDisparityTopEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    reg_close_pric: str = Field(
+        default="", description="정규장종가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자"
+    )
+    reg_pre_sig: str = Field(default="", description="정규장대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    reg_pre: str = Field(default="", description="정규장대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    dispty_rt: str = Field(default="", description="괴리율")
+    cntr_tm: str = Field(default="", description="체결시간")
+    cntr_str: str = Field(default="", description="체결강도")
+    cnt: str = Field(default="", description="횟수")
+    sel_req: str = Field(default="", description="매도잔량. 단위: 1주")
+    buy_req: str = Field(default="", description="매수잔량. 단위: 1주")
 
 
 class OverseasRankInfoDaytimeTradingDisparityTopEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 주간거래 괴리율 상위(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasRankInfoDaytimeTradingDisparityTopEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_rank_info_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_rank_info_types.py
@@ -1,0 +1,214 @@
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+from cluefin_openapi.kiwoom._model import KiwoomHttpBody
+
+
+class OverseasRankInfoRealtimeSymbolQueryRank(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 실시간 종목 조회 순위 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoWatchlistRegistrationTop(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 관심종목 등록 상위 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoPeriodFluctuationRankStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 기간별 등락률상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoPeriodFluctuationRankEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 기간별 등락률상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoPeriodFluctuationRankWatchlist(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 기간별 등락률상위(관심종목) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoTodayTradingVolumeTopStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 당일 거래량 상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoTodayTradingVolumeTopEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 당일 거래량 상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoTodayTradingValueTopStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 당일 거래대금 상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoTodayTradingValueTopEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 당일 거래대금 상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoMarketCapTopStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 시가총액상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoMarketCapTopEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 시가총액상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoKiwoomTradingTopStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="키움 거래 상위 종목(미국주식) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoKiwoomTradingTopEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="키움 거래 상위 종목(미국 ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoPreviousDayFluctuationRankStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 전일대비 등락률상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoPreviousDayFluctuationRankEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 전일대비 등락률상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoOpenPriceFluctuationRankStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 시가대비 등락률상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoOpenPriceFluctuationRankEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 시가대비 등락률상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoOpenPriceFluctuationRankWatchlist(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 시가대비 등락률상위(관심종목) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoCumulativeFluctuationTopStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 누적 등락률 상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoCumulativeFluctuationTopEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 누적 등락률 상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoPreviousDayTradingTopStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 전일 거래상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoPreviousDayTradingTopEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 전일 거래상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoHighLowPriceRiseFallStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 최고최저가대비 상승하락(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoHighLowPriceRiseFallEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 최고최저가대비 상승하락(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoSpecificDateRiseFallStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 특정일자 상승/하락(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoSpecificDateRiseFallEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 특정일자 상승/하락(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoTurnoverRateTopStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 회전율 상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoTurnoverRateTopEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 회전율 상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoConsecutiveRiseFallRankStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 연속상승/하락 순위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoConsecutiveRiseFallRankEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 연속상승/하락 순위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoConsecutiveRiseFallRankWatchlist(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 연속상승/하락 순위(관심종목) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoQuoteRemainingVolumeTopStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 호가잔량상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoQuoteRemainingVolumeTopEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 호가잔량상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoDaytimeTradingDisparityTopStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 주간거래 괴리율 상위(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasRankInfoDaytimeTradingDisparityTopEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 주간거래 괴리율 상위(ETF) 응답")
+
+    # TODO: 응답 필드 정의

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_realtime.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_realtime.py
@@ -1,0 +1,13 @@
+# 실시간 시세 (웹소켓)
+# 운영: wss://api.kiwoom.com:10000/api/us/websocket
+# 모의투자: wss://mockapi.kiwoom.com:10000/api/us/websocket
+
+
+class OverseasRealtime:
+    pass
+
+
+# 미국주식실시간주문확인	F4	get_order_confirmation
+# 미국주식실시간체결	F5	get_execution
+# 미국주식실시간체결가	FE	get_execution_price
+# 미국주식10호가	FT	get_ten_quotes

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_realtime.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_realtime.py
@@ -4,10 +4,16 @@
 
 
 class OverseasRealtime:
+    # 웹소켓 클라이언트 구현은 아직 없음 (stub). 요청/응답 모델만 정의됨.
+    # 모델 정의: _overseas_realtime_types.py
     pass
 
 
-# 미국주식실시간주문확인	F4	get_order_confirmation
-# 미국주식실시간체결	F5	get_execution
-# 미국주식실시간체결가	FE	get_execution_price
-# 미국주식10호가	FT	get_ten_quotes
+# 공통 요청 모델 (4개 TR 동일 등록/해지 프레임):
+#   OverseasRealtimeRequest / OverseasRealtimeRegisterData / OverseasRealtimeRegisterItem
+#
+# TR	이름	메서드(예정)	values 모델 / 응답 프레임 모델
+# F4	미국주식실시간주문확인	get_order_confirmation	OverseasRealtimeOrderConfirmationValues / OverseasRealtimeOrderConfirmation
+# F5	미국주식실시간체결	get_execution	OverseasRealtimeExecutionValues / OverseasRealtimeExecution
+# FE	미국주식실시간체결가	get_execution_price	OverseasRealtimeExecutionPriceValues / OverseasRealtimeExecutionPrice
+# FT	미국주식10호가	get_ten_quotes	OverseasRealtimeTenQuotesValues / OverseasRealtimeTenQuotes

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_realtime_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_realtime_types.py
@@ -1,0 +1,334 @@
+"""미국주식 실시간 시세 (웹소켓) 요청/응답 모델.
+
+웹소켓 프레임은 HTTP 응답이 아니므로 ``KiwoomHttpBody``를 상속하지 않고 순수
+``BaseModel``로 정의한다. 응답 ``values`` Map은 숫자 FID 키를 사용하므로 의미 있는
+영어 필드명 + ``alias``(FID)로 매핑하고 ``populate_by_name=True``를 설정한다.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
+
+# ---------------------------------------------------------------------------
+# 공통 요청 모델 (F4/F5/FE/FT 4개 TR의 등록/해지 프레임이 동일)
+# ---------------------------------------------------------------------------
+
+
+class OverseasRealtimeRegisterItem(BaseModel):
+    """실시간 등록 요소. Map 구조 {종목코드, 거래소코드}."""
+
+    model_config = ConfigDict(title="실시간 등록 요소")
+
+    jmcode: str = Field(default="", description="종목코드. ex) NVDA")
+    stex_tp: str = Field(default="", description="거래소코드. ND:NASDAQ, NY:NYSE, NA:AMEX")
+
+
+class OverseasRealtimeRegisterData(BaseModel):
+    """실시간 등록 리스트 항목."""
+
+    model_config = ConfigDict(title="실시간 등록 리스트 항목")
+
+    item: list[OverseasRealtimeRegisterItem] = Field(default_factory=list, description="실시간 등록 요소 리스트")
+    type: list[str] = Field(default_factory=list, description="실시간 항목. TR 명 리스트 (F4, F5, FE, FT 등)")
+
+
+class OverseasRealtimeRequest(BaseModel):
+    """실시간 등록/해지 요청."""
+
+    model_config = ConfigDict(title="미국주식 실시간 시세 등록/해지 요청")
+
+    trnm: Literal["REG", "REMOVE"] = Field(description="서비스명. REG:등록, REMOVE:해지")
+    grp_no: str = Field(description="그룹번호")
+    refresh: Literal["0", "1"] = Field(
+        description="기존등록유지여부. 등록(REG)시 0:기존등록 item/type 해지, 1:기존등록 유지(Default). 해지(REMOVE)시 값 불필요"
+    )
+    data: list[OverseasRealtimeRegisterData] = Field(default_factory=list, description="실시간 등록 리스트")
+
+
+# ---------------------------------------------------------------------------
+# TR별 values 모델
+# ---------------------------------------------------------------------------
+
+
+class OverseasRealtimeOrderConfirmationValues(BaseModel):
+    """F4 미국주식 실시간 주문 확인 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="미국주식 실시간 주문 확인 values")
+
+    account_no: str = Field(default="", alias="9201", description="계좌번호")
+    order_no: str = Field(default="", alias="9203", description="주문번호")
+    stock_code: str = Field(default="", alias="9001", description="종목,업종코드")
+    order_type: str = Field(default="", alias="905", description="주문구분. 10:원주문, 11:정정주문, 12:취소주문")
+    sell_buy_type: str = Field(default="", alias="907", description="매도수구분. 01:매도, 02:매수")
+    original_order_no: str = Field(default="", alias="904", description="원주문번호")
+    order_quantity: str = Field(default="", alias="900", description="주문수량")
+    order_price: str = Field(default="", alias="901", description="주문가격")
+    trade_type: str = Field(default="", alias="906", description="매매구분")
+    order_status: str = Field(default="", alias="913", description="주문상태")
+    order_execution_time: str = Field(default="", alias="908", description="주문/체결시간")
+    order_stop_price: str = Field(default="", alias="50810", description="주문STOP가격")
+    currency_code: str = Field(default="", alias="8043", description="통화코드")
+    reservation_type: str = Field(default="", alias="50841", description="예약구분")
+    country_code: str = Field(default="", alias="55190", description="(재무)국가코드 사용")
+    country_name: str = Field(default="", alias="1091", description="국가명")
+    sell_buy_type_name: str = Field(default="", alias="50072", description="매도수구분명")
+    stock_name: str = Field(default="", alias="302", description="종목명")
+    trade_type_name: str = Field(default="", alias="50073", description="매매구분명")
+
+
+class OverseasRealtimeExecutionValues(BaseModel):
+    """F5 미국주식 실시간 체결 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="미국주식 실시간 체결 values")
+
+    country_name: str = Field(default="", alias="1091", description="국가명")
+    exchange_code: str = Field(default="", alias="8046", description="거래소코드")
+    stock_code: str = Field(default="", alias="9001", description="종목코드")
+    stock_name: str = Field(default="", alias="302", description="종목명")
+    original_order_no: str = Field(default="", alias="904", description="원주문번호")
+    order_no: str = Field(default="", alias="9203", description="주문번호")
+    order_type: str = Field(default="", alias="905", description="주문구분. 10:원주문, 11:정정주문, 12:취소주문")
+    sell_buy_type: str = Field(default="", alias="907", description="매도수구분. 01:매도, 02:매수")
+    order_execution_time: str = Field(default="", alias="908", description="주문/체결시간")
+    order_status: str = Field(
+        default="", alias="913", description="주문상태. 텍스트값(주문전송, 무효주문, 부분체결, 체결완료 등)"
+    )
+    order_quantity: str = Field(default="", alias="900", description="주문수량")
+    order_price: str = Field(default="", alias="901", description="주문가격")
+    unexecuted_quantity: str = Field(default="", alias="902", description="미체결수량")
+    execution_no: str = Field(default="", alias="909", description="체결번호")
+    execution_price: str = Field(default="", alias="910", description="체결가")
+    execution_quantity: str = Field(default="", alias="911", description="체결량")
+    holding_quantity: str = Field(default="", alias="930", description="보유수량")
+    purchase_unit_price: str = Field(default="", alias="931", description="매입단가")
+    today_sell_quantity: str = Field(default="", alias="934", description="당일매도수량 사용")
+    today_buy_quantity: str = Field(default="", alias="936", description="당일매수수량 사용")
+    prev_sell_quantity: str = Field(default="", alias="8004", description="전일매도수량")
+    prev_buy_quantity: str = Field(default="", alias="8005", description="전일매수수량")
+    profit_loss_amount: str = Field(default="", alias="8018", description="손익금액")
+    profit_loss_rate: str = Field(default="", alias="8019", description="손익율")
+    currency_code: str = Field(default="", alias="8043", description="통화코드")
+    tax: str = Field(default="", alias="8075", description="세금 사용")
+    account_no: str = Field(default="", alias="9201", description="계좌번호")
+    commission: str = Field(default="", alias="13006", description="수수료 사용")
+    sell_buy_type_name: str = Field(default="", alias="50072", description="매도수구분명")
+    trade_type_name: str = Field(default="", alias="50073", description="매매구분명. 텍스트값(지정가, 시장가 등)")
+    realized_profit_loss_purchase_amount: str = Field(default="", alias="50724", description="실현손익매입금 사용")
+    exchange_realized_profit_loss_purchase_amount: str = Field(
+        default="", alias="50725", description="환전실현손익매입금액 사용"
+    )
+    order_stop_price: str = Field(default="", alias="50810", description="주문STOP가격")
+    reservation_type: str = Field(default="", alias="50841", description="예약구분")
+    exchange_realized_profit_loss_amount: str = Field(default="", alias="50844", description="환전실현손익금액 사용")
+    country_code: str = Field(default="", alias="55190", description="(재무)국가코드 사용")
+
+
+class OverseasRealtimeExecutionPriceValues(BaseModel):
+    """FE 미국주식 실시간 체결가 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="미국주식 실시간 체결가 values")
+
+    current_price: str = Field(default="", alias="10", description="현재가")
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비")
+    fluctuation_rate: str = Field(default="", alias="12", description="등락율")
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량")
+    acc_trade_value: str = Field(default="", alias="14", description="누적거래대금")
+    execution_volume: str = Field(default="", alias="15", description="체결량")
+    open_price: str = Field(default="", alias="16", description="시가")
+    high_price: str = Field(default="", alias="17", description="고가")
+    low_price: str = Field(default="", alias="18", description="저가")
+    time: str = Field(default="", alias="20", description="시간")
+    execution_date: str = Field(default="", alias="22", description="체결일자")
+    prev_day_diff_sign: str = Field(default="", alias="25", description="전일대비기호")
+    best_ask_price: str = Field(default="", alias="27", description="(최우선)매도호가")
+    best_bid_price: str = Field(default="", alias="28", description="(최우선)매수호가")
+    prev_day_volume_ratio: str = Field(default="", alias="30", description="전일거래량대비(비율)")
+    execution_strength: str = Field(default="", alias="228", description="체결강도")
+    market_type: str = Field(default="", alias="290", description="장구분")
+    local_execution_time: str = Field(default="", alias="51020", description="현지 체결시간")
+
+
+class OverseasRealtimeTenQuotesValues(BaseModel):
+    """FT 미국주식 10호가 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="미국주식 10호가 values")
+
+    time: str = Field(default="", alias="21", description="시간")
+    ask_price_1: str = Field(default="", alias="41", description="매도1호가")
+    ask_volume_1: str = Field(default="", alias="61", description="매도1호가잔량")
+    ask_prev_diff_1: str = Field(default="", alias="81", description="매도1호가직전대비")
+    bid_price_1: str = Field(default="", alias="51", description="매수1호가")
+    bid_volume_1: str = Field(default="", alias="71", description="매수1호가잔량")
+    bid_prev_diff_1: str = Field(default="", alias="91", description="매수1호가직전대비")
+    ask_price_2: str = Field(default="", alias="42", description="매도2호가")
+    ask_volume_2: str = Field(default="", alias="62", description="매도2호가잔량")
+    ask_prev_diff_2: str = Field(default="", alias="82", description="매도2호가직전대비")
+    bid_price_2: str = Field(default="", alias="52", description="매수2호가")
+    bid_volume_2: str = Field(default="", alias="72", description="매수2호가잔량")
+    bid_prev_diff_2: str = Field(default="", alias="92", description="매수2호가직전대비")
+    ask_price_3: str = Field(default="", alias="43", description="매도3호가")
+    ask_volume_3: str = Field(default="", alias="63", description="매도3호가잔량")
+    ask_prev_diff_3: str = Field(default="", alias="83", description="매도3호가직전대비")
+    bid_price_3: str = Field(default="", alias="53", description="매수3호가")
+    bid_volume_3: str = Field(default="", alias="73", description="매수3호가잔량")
+    bid_prev_diff_3: str = Field(default="", alias="93", description="매수3호가직전대비")
+    ask_price_4: str = Field(default="", alias="44", description="매도4호가")
+    ask_volume_4: str = Field(default="", alias="64", description="매도4호가잔량")
+    ask_prev_diff_4: str = Field(default="", alias="84", description="매도4호가직전대비")
+    bid_price_4: str = Field(default="", alias="54", description="매수4호가")
+    bid_volume_4: str = Field(default="", alias="74", description="매수4호가잔량")
+    bid_prev_diff_4: str = Field(default="", alias="94", description="매수4호가직전대비")
+    ask_price_5: str = Field(default="", alias="45", description="매도5호가")
+    ask_volume_5: str = Field(default="", alias="65", description="매도5호가잔량")
+    ask_prev_diff_5: str = Field(default="", alias="85", description="매도5호가직전대비")
+    bid_price_5: str = Field(default="", alias="55", description="매수5호가")
+    bid_volume_5: str = Field(default="", alias="75", description="매수5호가잔량")
+    bid_prev_diff_5: str = Field(default="", alias="95", description="매수5호가직전대비")
+    ask_price_6: str = Field(default="", alias="46", description="매도6호가")
+    ask_volume_6: str = Field(default="", alias="66", description="매도6호가잔량")
+    ask_prev_diff_6: str = Field(default="", alias="86", description="매도6호가직전대비")
+    bid_price_6: str = Field(default="", alias="56", description="매수6호가")
+    bid_volume_6: str = Field(default="", alias="76", description="매수6호가잔량")
+    bid_prev_diff_6: str = Field(default="", alias="96", description="매수6호가직전대비")
+    ask_price_7: str = Field(default="", alias="47", description="매도7호가")
+    ask_volume_7: str = Field(default="", alias="67", description="매도7호가잔량")
+    ask_prev_diff_7: str = Field(default="", alias="87", description="매도7호가직전대비")
+    bid_price_7: str = Field(default="", alias="57", description="매수7호가")
+    bid_volume_7: str = Field(default="", alias="77", description="매수7호가잔량")
+    bid_prev_diff_7: str = Field(default="", alias="97", description="매수7호가직전대비")
+    ask_price_8: str = Field(default="", alias="48", description="매도8호가")
+    ask_volume_8: str = Field(default="", alias="68", description="매도8호가잔량")
+    ask_prev_diff_8: str = Field(default="", alias="88", description="매도8호가직전대비")
+    bid_price_8: str = Field(default="", alias="58", description="매수8호가")
+    bid_volume_8: str = Field(default="", alias="78", description="매수8호가잔량")
+    bid_prev_diff_8: str = Field(default="", alias="98", description="매수8호가직전대비")
+    ask_price_9: str = Field(default="", alias="49", description="매도9호가")
+    ask_volume_9: str = Field(default="", alias="69", description="매도9호가잔량")
+    ask_prev_diff_9: str = Field(default="", alias="89", description="매도9호가직전대비")
+    bid_price_9: str = Field(default="", alias="59", description="매수9호가")
+    bid_volume_9: str = Field(default="", alias="79", description="매수9호가잔량")
+    bid_prev_diff_9: str = Field(default="", alias="99", description="매수9호가직전대비")
+    ask_price_10: str = Field(default="", alias="50", description="매도10호가")
+    ask_volume_10: str = Field(default="", alias="70", description="매도10호가잔량")
+    ask_prev_diff_10: str = Field(default="", alias="90", description="매도10호가직전대비")
+    bid_price_10: str = Field(default="", alias="60", description="매수10호가")
+    bid_volume_10: str = Field(default="", alias="80", description="매수10호가잔량")
+    bid_prev_diff_10: str = Field(default="", alias="100", description="매수10호가직전대비")
+    total_ask_volume: str = Field(default="", alias="121", description="매도호가총잔량")
+    total_ask_volume_prev_diff: str = Field(default="", alias="122", description="매도호가총잔량직전대비")
+    total_bid_volume: str = Field(default="", alias="125", description="매수호가총잔량")
+    total_bid_volume_prev_diff: str = Field(default="", alias="126", description="매수호가총잔량직전대비")
+
+
+# ---------------------------------------------------------------------------
+# TR별 응답 프레임 모델
+# ---------------------------------------------------------------------------
+
+
+class OverseasRealtimeOrderConfirmationDataItem(BaseModel):
+    """F4 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="미국주식 실시간 주문 확인 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR 명")
+    name: str = Field(default="", description="실시간 항목명")
+    stex_tp: str = Field(default="", alias="stexTp", description="거래소구분")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: OverseasRealtimeOrderConfirmationValues = Field(
+        default_factory=OverseasRealtimeOrderConfirmationValues, description="실시간 값 리스트"
+    )
+
+
+class OverseasRealtimeOrderConfirmation(BaseModel):
+    """F4 미국주식 실시간 주문 확인 응답 프레임."""
+
+    model_config = ConfigDict(title="미국주식 실시간 주문 확인 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[OverseasRealtimeOrderConfirmationDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class OverseasRealtimeExecutionDataItem(BaseModel):
+    """F5 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="미국주식 실시간 체결 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR 명")
+    name: str = Field(default="", description="실시간 항목명")
+    stex_tp: str = Field(default="", alias="stexTp", description="거래소구분")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: OverseasRealtimeExecutionValues = Field(
+        default_factory=OverseasRealtimeExecutionValues, description="실시간 값 리스트"
+    )
+
+
+class OverseasRealtimeExecution(BaseModel):
+    """F5 미국주식 실시간 체결 응답 프레임."""
+
+    model_config = ConfigDict(title="미국주식 실시간 체결 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[OverseasRealtimeExecutionDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class OverseasRealtimeExecutionPriceDataItem(BaseModel):
+    """FE 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="미국주식 실시간 체결가 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR 명")
+    name: str = Field(default="", description="실시간 항목명")
+    stex_tp: str = Field(default="", alias="stexTp", description="거래소구분")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: OverseasRealtimeExecutionPriceValues = Field(
+        default_factory=OverseasRealtimeExecutionPriceValues, description="실시간 값 리스트"
+    )
+
+
+class OverseasRealtimeExecutionPrice(BaseModel):
+    """FE 미국주식 실시간 체결가 응답 프레임."""
+
+    model_config = ConfigDict(title="미국주식 실시간 체결가 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[OverseasRealtimeExecutionPriceDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class OverseasRealtimeTenQuotesDataItem(BaseModel):
+    """FT 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="미국주식 10호가 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR 명")
+    name: str = Field(default="", description="실시간 항목명")
+    stex_tp: str = Field(default="", alias="stexTp", description="거래소구분")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: OverseasRealtimeTenQuotesValues = Field(
+        default_factory=OverseasRealtimeTenQuotesValues, description="실시간 값 리스트"
+    )
+
+
+class OverseasRealtimeTenQuotes(BaseModel):
+    """FT 미국주식 10호가 응답 프레임."""
+
+    model_config = ConfigDict(title="미국주식 10호가 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[OverseasRealtimeTenQuotesDataItem] = Field(default_factory=list, description="실시간 등록리스트")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_sector.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_sector.py
@@ -18,14 +18,16 @@ class OverseasSector:
 
     def get_industry_period_profit_rate(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        inds_cd: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasSectorIndustryPeriodProfitRate]:
         """미국주식 업종별 기간별 수익률 조회 (usa23000)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            inds_cd (str, optional): 업종 코드. 0:전체, usa10101 참고. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -40,6 +42,10 @@ class OverseasSector:
             "next-key": next_key,
             "api-id": "usa23000",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -51,14 +57,18 @@ class OverseasSector:
 
     def get_industry_fluctuation_rank(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "0", "1", "2", "3"] = "",
+        sort_tp: Literal["", "1", "2"] = "",
+        inds_cd: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasSectorIndustryFluctuationRank]:
         """미국주식 업종별 등락률 상위/하위 조회 (usa23100)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NY(NYSE),2:NA(AMEX),3:ND(NASDAQ). Defaults to "".
+            sort_tp (Literal["", "1", "2"], optional): 정렬기준구분. 1:등락율상위,2:등락율하위. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체(기본값), usa10101 참고. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -72,6 +82,11 @@ class OverseasSector:
             "cont-yn": cont_yn,
             "next-key": next_key,
             "api-id": "usa23100",
+        }
+        body = {
+            "stex_tp": stex_tp,
+            "sort_tp": sort_tp,
+            "inds_cd": inds_cd,
         }
 
         response = self.client._post(self.path, headers, body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_sector.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_sector.py
@@ -1,0 +1,83 @@
+from typing import Literal
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._model import (
+    KiwoomHttpHeader,
+    KiwoomHttpResponse,
+)
+from cluefin_openapi.kiwoom._overseas_sector_types import (
+    OverseasSectorIndustryFluctuationRank,
+    OverseasSectorIndustryPeriodProfitRate,
+)
+
+
+class OverseasSector:
+    def __init__(self, client: Client):
+        self.client = client
+        self.path = "/api/us/sect"
+
+    def get_industry_period_profit_rate(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasSectorIndustryPeriodProfitRate]:
+        """미국주식 업종별 기간별 수익률 조회 (usa23000)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasSectorIndustryPeriodProfitRate]: 미국주식 업종별 기간별 수익률 조회 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa23000",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching industry period profit rate: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasSectorIndustryPeriodProfitRate.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_industry_fluctuation_rank(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasSectorIndustryFluctuationRank]:
+        """미국주식 업종별 등락률 상위/하위 조회 (usa23100)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasSectorIndustryFluctuationRank]: 미국주식 업종별 등락률 상위/하위 조회 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa23100",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching industry fluctuation rank: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasSectorIndustryFluctuationRank.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_sector_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_sector_types.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+from cluefin_openapi.kiwoom._model import KiwoomHttpBody
+
+
+class OverseasSectorIndustryPeriodProfitRate(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 업종별 기간별 수익률 조회 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasSectorIndustryFluctuationRank(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 업종별 등락률 상위/하위 조회 응답")
+
+    # TODO: 응답 필드 정의

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_sector_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_sector_types.py
@@ -1,16 +1,48 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 
 from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 
 
+class OverseasSectorIndustryPeriodProfitRateItem(BaseModel):
+    inds_cd: str = Field(default="", description="업종코드")
+    inds_nm: str = Field(default="", description="업종명")
+    perf_1d: str = Field(default="", description="1일 수익률. 소수점 둘째 자리까지 포맷된 숫자")
+    perf_5d: str = Field(default="", description="5일 수익률. 소수점 둘째 자리까지 포맷된 숫자")
+    perf_1m: str = Field(default="", description="1개월 수익률. 소수점 둘째 자리까지 포맷된 숫자")
+    perf_3m: str = Field(default="", description="3개월 수익률. 소수점 둘째 자리까지 포맷된 숫자")
+    perf_6m: str = Field(default="", description="6개월 수익률. 소수점 둘째 자리까지 포맷된 숫자")
+    perf_ytd: str = Field(default="", description="연중 수익률. 소수점 둘째 자리까지 포맷된 숫자")
+    perf_1y: str = Field(default="", description="1년 수익률. 소수점 둘째 자리까지 포맷된 숫자")
+
+
 class OverseasSectorIndustryPeriodProfitRate(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 업종별 기간별 수익률 조회 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasSectorIndustryPeriodProfitRateItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasSectorIndustryFluctuationRankItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="한글종목명")
+    stk_enm: str = Field(default="", description="영문종목명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    cntr_tm: str = Field(default="", description="시간. HH:mm")
 
 
 class OverseasSectorIndustryFluctuationRank(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 업종별 등락률 상위/하위 조회 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasSectorIndustryFluctuationRankItem] = Field(default_factory=list, description="결과리스트")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info.py
@@ -1,0 +1,1137 @@
+from typing import Literal
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._model import (
+    KiwoomHttpHeader,
+    KiwoomHttpResponse,
+)
+from cluefin_openapi.kiwoom._overseas_stock_info_types import (
+    OverseasStockInfoEtfCategoryList,
+    OverseasStockInfoEtfEtnList,
+    OverseasStockInfoExchangeList,
+    OverseasStockInfoGapUpDownEtf,
+    OverseasStockInfoGapUpDownStock,
+    OverseasStockInfoHighLowApproachEtf,
+    OverseasStockInfoHighLowApproachStock,
+    OverseasStockInfoHighLowApproachWatchlist,
+    OverseasStockInfoIndexList,
+    OverseasStockInfoNewHighLowEtf,
+    OverseasStockInfoNewHighLowStock,
+    OverseasStockInfoPriceByRangeEtf,
+    OverseasStockInfoPriceByRangeStock,
+    OverseasStockInfoPriceSurgeEtf,
+    OverseasStockInfoPriceSurgeStock,
+    OverseasStockInfoPriceSurgeWatchlist,
+    OverseasStockInfoRemainingRatioSurgeEtf,
+    OverseasStockInfoRemainingRatioSurgeStock,
+    OverseasStockInfoSectorList,
+    OverseasStockInfoStock,
+    OverseasStockInfoStockList,
+    OverseasStockInfoVolumeConcentrationEtf,
+    OverseasStockInfoVolumeConcentrationStock,
+    OverseasStockInfoVolumeRenewalEtf,
+    OverseasStockInfoVolumeRenewalStock,
+    OverseasStockInfoVolumeRenewalWatchlist,
+    OverseasStockInfoVolumeSurgeEtf,
+    OverseasStockInfoVolumeSurgeStock,
+    OverseasStockInfoYearlyFluctuationRateByEtfCategory,
+    OverseasStockInfoYearlyFluctuationRateBySector,
+    OverseasStockInfoYearlyFluctuationRateEtf,
+    OverseasStockInfoYearlyFluctuationRateSector,
+    OverseasStockInfoYearlyFluctuationRateStock,
+)
+
+
+class OverseasStockInfo:
+    def __init__(self, client: Client):
+        self.client = client
+        self.path = "/api/us/stkinfo"
+
+    def get_exchange_list(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoExchangeList]:
+        """미국주식 거래소구분 조회 (usa10098)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoExchangeList]: 미국주식 거래소구분 조회 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa10098",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching exchange list: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoExchangeList.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_stock_list(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoStockList]:
+        """미국주식 종목리스트 (usa10099)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoStockList]: 미국주식 종목리스트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa10099",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching stock list: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoStockList.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoStock]:
+        """미국주식 종목 조회 (usa10100)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoStock]: 미국주식 종목 조회 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa10100",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_sector_list(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoSectorList]:
+        """미국주식 업종리스트 (usa10101)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoSectorList]: 미국주식 업종리스트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa10101",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching sector list: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoSectorList.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_index_list(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoIndexList]:
+        """미국지수 리스트 (usa10102)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoIndexList]: 미국지수 리스트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa10102",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching index list: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoIndexList.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_etf_etn_list(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoEtfEtnList]:
+        """미국 ETF,ETN 리스트 (usa10104)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoEtfEtnList]: 미국 ETF,ETN 리스트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa10104",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching etf etn list: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoEtfEtnList.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_etf_category_list(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoEtfCategoryList]:
+        """미국 ETF 카테고리 리스트 (usa10105)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoEtfCategoryList]: 미국 ETF 카테고리 리스트 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa10105",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching etf category list: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoEtfCategoryList.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_volume_surge_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoVolumeSurgeStock]:
+        """미국주식 거래량급등락(주식/업종) (usa20520)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoVolumeSurgeStock]: 미국주식 거래량급등락(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20520",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching volume surge stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoVolumeSurgeStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_volume_surge_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoVolumeSurgeEtf]:
+        """미국주식 거래량급등락(ETF) (usa20521)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoVolumeSurgeEtf]: 미국주식 거래량급등락(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20521",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching volume surge etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoVolumeSurgeEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_price_by_range_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoPriceByRangeStock]:
+        """미국주식 가격대별주가(주식/업종) (usa20570)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoPriceByRangeStock]: 미국주식 가격대별주가(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20570",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching price by range stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoPriceByRangeStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_price_by_range_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoPriceByRangeEtf]:
+        """미국주식 가격대별주가(ETF) (usa20571)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoPriceByRangeEtf]: 미국주식 가격대별주가(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20571",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching price by range etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoPriceByRangeEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_price_surge_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoPriceSurgeStock]:
+        """미국주식 가격급등락(주식/업종) (usa20930)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoPriceSurgeStock]: 미국주식 가격급등락(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20930",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching price surge stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoPriceSurgeStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_price_surge_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoPriceSurgeEtf]:
+        """미국주식 가격급등락(ETF) (usa20931)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoPriceSurgeEtf]: 미국주식 가격급등락(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20931",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching price surge etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoPriceSurgeEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_price_surge_watchlist(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoPriceSurgeWatchlist]:
+        """미국주식 가격급등락(관심종목) (usa20932)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoPriceSurgeWatchlist]: 미국주식 가격급등락(관심종목) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20932",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching price surge watchlist: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoPriceSurgeWatchlist.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_high_low_approach_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoHighLowApproachStock]:
+        """미국주식 고가/저가 접근(주식/업종) (usa20970)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoHighLowApproachStock]: 미국주식 고가/저가 접근(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20970",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching high low approach stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoHighLowApproachStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_high_low_approach_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoHighLowApproachEtf]:
+        """미국주식 고가/저가 접근(ETF) (usa20971)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoHighLowApproachEtf]: 미국주식 고가/저가 접근(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20971",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching high low approach etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoHighLowApproachEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_high_low_approach_watchlist(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoHighLowApproachWatchlist]:
+        """미국주식 고가/저가 접근(관심종목) (usa20972)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoHighLowApproachWatchlist]: 미국주식 고가/저가 접근(관심종목) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20972",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching high low approach watchlist: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoHighLowApproachWatchlist.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_volume_renewal_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoVolumeRenewalStock]:
+        """미국주식 거래량갱신(주식/업종) (usa23400)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoVolumeRenewalStock]: 미국주식 거래량갱신(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa23400",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching volume renewal stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoVolumeRenewalStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_volume_renewal_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoVolumeRenewalEtf]:
+        """미국주식 거래량갱신(ETF) (usa23401)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoVolumeRenewalEtf]: 미국주식 거래량갱신(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa23401",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching volume renewal etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoVolumeRenewalEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_volume_renewal_watchlist(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoVolumeRenewalWatchlist]:
+        """미국주식 거래량갱신(관심종목) (usa23402)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoVolumeRenewalWatchlist]: 미국주식 거래량갱신(관심종목) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa23402",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching volume renewal watchlist: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoVolumeRenewalWatchlist.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_new_high_low_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoNewHighLowStock]:
+        """미국주식 신고가/신저가(주식/업종) (usa24100)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoNewHighLowStock]: 미국주식 신고가/신저가(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24100",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching new high low stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoNewHighLowStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_new_high_low_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoNewHighLowEtf]:
+        """미국주식 신고가/신저가(ETF) (usa24101)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoNewHighLowEtf]: 미국주식 신고가/신저가(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24101",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching new high low etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoNewHighLowEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_gap_up_down_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoGapUpDownStock]:
+        """미국주식 갭상승/갭하락(주식/업종) (usa24140)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoGapUpDownStock]: 미국주식 갭상승/갭하락(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24140",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching gap up down stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoGapUpDownStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_gap_up_down_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoGapUpDownEtf]:
+        """미국주식 갭상승/갭하락(ETF) (usa24141)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoGapUpDownEtf]: 미국주식 갭상승/갭하락(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24141",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching gap up down etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoGapUpDownEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_remaining_ratio_surge_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoRemainingRatioSurgeStock]:
+        """미국주식 잔량률급증(주식/업종) (usa24210)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoRemainingRatioSurgeStock]: 미국주식 잔량률급증(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24210",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching remaining ratio surge stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoRemainingRatioSurgeStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_remaining_ratio_surge_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoRemainingRatioSurgeEtf]:
+        """미국주식 잔량률급증(ETF) (usa24211)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoRemainingRatioSurgeEtf]: 미국주식 잔량률급증(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24211",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching remaining ratio surge etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoRemainingRatioSurgeEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_volume_concentration_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoVolumeConcentrationStock]:
+        """미국주식 매물대집중(주식/업종) (usa24220)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoVolumeConcentrationStock]: 미국주식 매물대집중(주식/업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24220",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching volume concentration stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoVolumeConcentrationStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_volume_concentration_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoVolumeConcentrationEtf]:
+        """미국주식 매물대집중(ETF) (usa24221)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoVolumeConcentrationEtf]: 미국주식 매물대집중(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa24221",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching volume concentration etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoVolumeConcentrationEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_yearly_fluctuation_rate_stock(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateStock]:
+        """미국주식 연도별 등락률(종목) (usa26410)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateStock]: 미국주식 연도별 등락률(종목) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa26410",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching yearly fluctuation rate stock: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoYearlyFluctuationRateStock.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_yearly_fluctuation_rate_by_sector(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateBySector]:
+        """미국주식 연도별 업종별 종목등락률 (usa26411)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateBySector]: 미국주식 연도별 업종별 종목등락률 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa26411",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching yearly fluctuation rate by sector: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoYearlyFluctuationRateBySector.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_yearly_fluctuation_rate_by_etf_category(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateByEtfCategory]:
+        """미국주식 연도별 ETF 카테고리별 종목등락률 (usa26412)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateByEtfCategory]: 미국주식 연도별 ETF 카테고리별 종목등락률 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa26412",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching yearly fluctuation rate by etf category: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoYearlyFluctuationRateByEtfCategory.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_yearly_fluctuation_rate_sector(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateSector]:
+        """미국주식 연도별 등락률(업종) (usa26413)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateSector]: 미국주식 연도별 등락률(업종) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa26413",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching yearly fluctuation rate sector: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoYearlyFluctuationRateSector.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_yearly_fluctuation_rate_etf(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateEtf]:
+        """미국주식 연도별 등락률(ETF) (usa26414)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateEtf]: 미국주식 연도별 등락률(ETF) 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa26414",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching yearly fluctuation rate etf: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoYearlyFluctuationRateEtf.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info.py
@@ -41,6 +41,13 @@ from cluefin_openapi.kiwoom._overseas_stock_info_types import (
     OverseasStockInfoYearlyFluctuationRateStock,
 )
 
+_PRIC_CND = Literal["", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10"]
+_TRDE_QTY_TP = Literal["", "0", "10", "15", "20", "30", "50", "100", "300", "500"]
+_TRDE_PRICA_CND = Literal["", "0", "1", "3", "5", "10", "30", "50", "100", "300", "500", "1000", "3000", "5000"]
+_STK_CND = Literal["", "0", "1", "2"]
+_STK_TP = Literal["", "0", "1"]
+_STEX_TP = Literal["", "0", "1", "2", "3"]
+
 
 class OverseasStockInfo:
     def __init__(self, client: Client):
@@ -49,14 +56,14 @@ class OverseasStockInfo:
 
     def get_exchange_list(
         self,
-        body: dict[str, str],
+        stk_cd: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoExchangeList]:
         """미국주식 거래소구분 조회 (usa10098)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stk_cd (str): 종목코드
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -71,6 +78,9 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa10098",
         }
+        body = {
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -82,14 +92,14 @@ class OverseasStockInfo:
 
     def get_stock_list(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["%", "NA", "ND", "NY"],
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoStockList]:
         """미국주식 종목리스트 (usa10099)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["%", "NA", "ND", "NY"]): 거래소구분. %:전체,NA:AMEX,ND:NASDAQ,NY:NYSE
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -104,6 +114,9 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa10099",
         }
+        body = {
+            "stex_tp": stex_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -115,14 +128,16 @@ class OverseasStockInfo:
 
     def get_stock(
         self,
-        body: dict[str, str],
+        stk_cd: str,
+        stex_tp: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoStock]:
         """미국주식 종목 조회 (usa10100)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stk_cd (str): 종목코드
+            stex_tp (str, optional): 거래소구분. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -137,6 +152,10 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa10100",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -148,14 +167,14 @@ class OverseasStockInfo:
 
     def get_sector_list(
         self,
-        body: dict[str, str],
+        gubun: Literal["", "%", "1"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoSectorList]:
         """미국주식 업종리스트 (usa10101)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            gubun (Literal["", "%", "1"], optional): 구분. %:전체, 1:미국. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -170,6 +189,9 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa10101",
         }
+        body = {
+            "gubun": gubun,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -181,14 +203,14 @@ class OverseasStockInfo:
 
     def get_index_list(
         self,
-        body: dict[str, str],
+        index_qry_tp: Literal["", "%", "NQ", "NS", "NW"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoIndexList]:
         """미국지수 리스트 (usa10102)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            index_qry_tp (Literal["", "%", "NQ", "NS", "NW"], optional): 업종지수구분. %:전체,NQ:나스닥,NS:S&P500,NW:다우. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -203,6 +225,9 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa10102",
         }
+        body = {
+            "index_qry_tp": index_qry_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -214,14 +239,14 @@ class OverseasStockInfo:
 
     def get_etf_etn_list(
         self,
-        body: dict[str, str],
+        stex_tp: Literal["", "%", "NA", "ND", "NY"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoEtfEtnList]:
         """미국 ETF,ETN 리스트 (usa10104)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "%", "NA", "ND", "NY"], optional): 거래소구분. %:전체,NA:AMEX,ND:NASDAQ,NY:NYSE. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -236,6 +261,9 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa10104",
         }
+        body = {
+            "stex_tp": stex_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -247,14 +275,14 @@ class OverseasStockInfo:
 
     def get_etf_category_list(
         self,
-        body: dict[str, str],
+        gubun: Literal["", "%", "1", "2"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoEtfCategoryList]:
         """미국 ETF 카테고리 리스트 (usa10105)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            gubun (Literal["", "%", "1", "2"], optional): 구분. %:전체,1:카테고리1차,2:카테고리2차. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -269,6 +297,9 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa10105",
         }
+        body = {
+            "gubun": gubun,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -280,14 +311,28 @@ class OverseasStockInfo:
 
     def get_volume_surge_stock(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        inds_cd: str = "",
+        tm: str = "",
+        stk_tp: _STK_TP = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoVolumeSurgeStock]:
         """미국주식 거래량급등락(주식/업종) (usa20520)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            tm (str, optional): x일평균대비. 5일, 10일, 20일, 30일. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -302,6 +347,16 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa20520",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "tm": tm,
+            "stk_tp": stk_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "trde_qty_tp": trde_qty_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -313,14 +368,28 @@ class OverseasStockInfo:
 
     def get_volume_surge_etf(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        tm: str = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoVolumeSurgeEtf]:
         """미국주식 거래량급등락(ETF) (usa20521)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            tm (str, optional): x일평균대비. 5일, 10일, 20일, 30일. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -335,6 +404,16 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa20521",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "tm": tm,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "trde_qty_tp": trde_qty_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -346,14 +425,28 @@ class OverseasStockInfo:
 
     def get_price_by_range_stock(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        stk_tp: _STK_TP = "",
+        stk_cnd: _STK_CND = "",
+        inds_cd: str = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        pric_cnd1: str = "",
+        pric_cnd2: str = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoPriceByRangeStock]:
         """미국주식 가격대별주가(주식/업종) (usa20570)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체, 1:주식. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd1 (str, optional): 가격조건1. 최대 999999.99. Defaults to "".
+            pric_cnd2 (str, optional): 가격조건2. 최대 999999.99. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -368,6 +461,16 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa20570",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_tp": stk_tp,
+            "stk_cnd": stk_cnd,
+            "inds_cd": inds_cd,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd1": pric_cnd1,
+            "pric_cnd2": pric_cnd2,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -379,14 +482,28 @@ class OverseasStockInfo:
 
     def get_price_by_range_etf(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        stk_cnd: _STK_CND = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        pric_cnd1: str = "",
+        pric_cnd2: str = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoPriceByRangeEtf]:
         """미국주식 가격대별주가(ETF) (usa20571)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd1 (str, optional): 가격조건1. 최대 999999.99. Defaults to "".
+            pric_cnd2 (str, optional): 가격조건2. 최대 999999.99. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -401,6 +518,16 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa20571",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cnd": stk_cnd,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd1": pric_cnd1,
+            "pric_cnd2": pric_cnd2,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -412,14 +539,32 @@ class OverseasStockInfo:
 
     def get_price_surge_stock(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        stk_tp: _STK_TP = "",
+        inds_cd: str = "",
+        stk_cnd: _STK_CND = "",
+        flu_tp: Literal["", "1", "2"] = "",
+        tm_tp: Literal["", "1", "2", "3"] = "",
+        tm: str = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoPriceSurgeStock]:
         """미국주식 가격급등락(주식/업종) (usa20930)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            flu_tp (Literal["", "1", "2"], optional): 급등.급락 구분. 1:급등,2:급락. Defaults to "".
+            tm_tp (Literal["", "1", "2", "3"], optional): 분전, 전일 구분. 1:분전,2:일전,3:지정일. Defaults to "".
+            tm (str, optional): 분,일자 설정. XX분전(최대30) or XX일전(최대30) or tm_tp:3 입력 시 기간(1:1일전,2:5일전,3:1개월전,4:3개월전,5:6개월전,6:연중,7:1년전,8:3년전,9:5년전). Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -434,6 +579,18 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa20930",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_tp": stk_tp,
+            "inds_cd": inds_cd,
+            "stk_cnd": stk_cnd,
+            "flu_tp": flu_tp,
+            "tm_tp": tm_tp,
+            "tm": tm,
+            "pric_cnd": pric_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -445,14 +602,32 @@ class OverseasStockInfo:
 
     def get_price_surge_etf(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        stk_cnd: _STK_CND = "",
+        flu_tp: Literal["", "1", "2"] = "",
+        tm_tp: Literal["", "1", "2", "3"] = "",
+        tm: str = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoPriceSurgeEtf]:
         """미국주식 가격급등락(ETF) (usa20931)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            flu_tp (Literal["", "1", "2"], optional): 급등.급락 구분. 1:급등,2:급락. Defaults to "".
+            tm_tp (Literal["", "1", "2", "3"], optional): 분전, 전일 구분. 1:분전,2:일전,3:지정일. Defaults to "".
+            tm (str, optional): 분,일자 설정. XX분전(최대30) or XX일전(최대30) or tm_tp:3 입력 시 기간(1:1일전,2:5일전,3:1개월전,4:3개월전,5:6개월전,6:연중,7:1년전,8:3년전,9:5년전). Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -467,6 +642,18 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa20931",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "stk_cnd": stk_cnd,
+            "flu_tp": flu_tp,
+            "tm_tp": tm_tp,
+            "tm": tm,
+            "pric_cnd": pric_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -478,14 +665,30 @@ class OverseasStockInfo:
 
     def get_price_surge_watchlist(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        stk_cd: list[dict[str, str]] | None = None,
+        flu_tp: Literal["", "1", "2"] = "",
+        tm_tp: Literal["", "1", "2", "3"] = "",
+        tm: str = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoPriceSurgeWatchlist]:
         """미국주식 가격급등락(관심종목) (usa20932)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            stk_cd (list[dict[str, str]] | None, optional): 관심종목. [{'stex_tp':'거래소구분','stk_cd':'종목코드'},...]. Defaults to None.
+            flu_tp (Literal["", "1", "2"], optional): 정렬 구분. 1:급등(기본값),2:급락. Defaults to "".
+            tm_tp (Literal["", "1", "2", "3"], optional): 기준 구분. 1:분전(기본값),2:일전,3:지정일. Defaults to "".
+            tm (str, optional): 분전 값. XX분전(최대30) or XX일전(최대30) or tm_tp:3 입력 시 기간(1:1일전,2:5일전,3:1개월전,4:3개월전,5:6개월전,6:연중,7:1년전,8:3년전,9:5년전). Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -500,6 +703,17 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa20932",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd if stk_cd is not None else [],
+            "flu_tp": flu_tp,
+            "tm_tp": tm_tp,
+            "tm": tm,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -511,14 +725,32 @@ class OverseasStockInfo:
 
     def get_high_low_approach_stock(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        inds_cd: str = "",
+        stk_tp: _STK_TP = "",
+        high_low_tp: Literal["", "1", "2"] = "",
+        alacc_rt: Literal["", "0.5", "1.0", "1.5", "2.0", "2.5", "3.5"] = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd_st: str = "",
+        pric_cnd_ed: str = "",
+        trde_pric_cnd_st: _TRDE_PRICA_CND = "",
+        trde_qty_cnd_fr: _TRDE_QTY_TP = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoHighLowApproachStock]:
         """미국주식 고가/저가 접근(주식/업종) (usa20970)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            high_low_tp (Literal["", "1", "2"], optional): 고가,저가구분. 1:고가,2:저가. Defaults to "".
+            alacc_rt (Literal, optional): 근접률. 0.5:0.5%, 1.0:1.0%, 1.5:1.5%, 2.0:2.0%, 2.5:2.5%, 3.5:3.5%. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd_st (str, optional): 가격조건 시작. USD, 가격조건 끝으로만 조회할 경우 0. Defaults to "".
+            pric_cnd_ed (str, optional): 가격조건 끝. USD, 가격조건 시작으로만 조회할 경우 0. Defaults to "".
+            trde_pric_cnd_st (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            trde_qty_cnd_fr (Literal, optional): 거래량조건. 0:전체 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -533,6 +765,18 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa20970",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "high_low_tp": high_low_tp,
+            "alacc_rt": alacc_rt,
+            "stk_cnd": stk_cnd,
+            "pric_cnd_st": pric_cnd_st,
+            "pric_cnd_ed": pric_cnd_ed,
+            "trde_pric_cnd_st": trde_pric_cnd_st,
+            "trde_qty_cnd_fr": trde_qty_cnd_fr,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -544,14 +788,32 @@ class OverseasStockInfo:
 
     def get_high_low_approach_etf(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        high_low_tp: Literal["", "1", "2"] = "",
+        alacc_rt: Literal["", "0.5", "1.0", "1.5", "2.0", "2.5", "3.5"] = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd_st: str = "",
+        pric_cnd_ed: str = "",
+        trde_pric_cnd_st: _TRDE_PRICA_CND = "",
+        trde_qty_cnd_fr: _TRDE_QTY_TP = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoHighLowApproachEtf]:
         """미국주식 고가/저가 접근(ETF) (usa20971)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            high_low_tp (Literal["", "1", "2"], optional): 고가,저가구분. 1:고가,2:저가. Defaults to "".
+            alacc_rt (Literal, optional): 근접률. 0.5:0.5%, 1.0:1.0%, 1.5:1.5%, 2.0:2.0%, 2.5:2.5%, 3.5:3.5%. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd_st (str, optional): 가격조건 시작. USD, 가격조건 끝으로만 조회할 경우 0. Defaults to "".
+            pric_cnd_ed (str, optional): 가격조건 끝. USD, 가격조건 시작으로만 조회할 경우 0. Defaults to "".
+            trde_pric_cnd_st (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            trde_qty_cnd_fr (Literal, optional): 거래량조건. 0:전체 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -566,6 +828,18 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa20971",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "high_low_tp": high_low_tp,
+            "alacc_rt": alacc_rt,
+            "stk_cnd": stk_cnd,
+            "pric_cnd_st": pric_cnd_st,
+            "pric_cnd_ed": pric_cnd_ed,
+            "trde_pric_cnd_st": trde_pric_cnd_st,
+            "trde_qty_cnd_fr": trde_qty_cnd_fr,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -577,14 +851,30 @@ class OverseasStockInfo:
 
     def get_high_low_approach_watchlist(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        stk_cd: list[dict[str, str]] | None = None,
+        high_low_tp: Literal["", "1", "2"] = "",
+        alacc_rt: Literal["", "0.5", "1.0", "1.5", "2.0", "2.5", "3.5"] = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd_st: str = "",
+        pric_cnd_ed: str = "",
+        trde_pric_cnd_st: _TRDE_PRICA_CND = "",
+        trde_qty_cnd_fr: _TRDE_QTY_TP = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoHighLowApproachWatchlist]:
         """미국주식 고가/저가 접근(관심종목) (usa20972)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            stk_cd (list[dict[str, str]] | None, optional): 관심종목코드. [{'stex_tp':'거래소구분','stk_cd':'종목코드'},...]. Defaults to None.
+            high_low_tp (Literal["", "1", "2"], optional): 고가,저가구분. 1:고가,2:저가. Defaults to "".
+            alacc_rt (Literal, optional): 근접률. 0.5:0.5%, 1.0:1.0%, 1.5:1.5%, 2.0:2.0%, 2.5:2.5%, 3.5:3.5%. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd_st (str, optional): 가격조건 시작. USD, 가격조건 끝으로만 조회할 경우 0. Defaults to "".
+            pric_cnd_ed (str, optional): 가격조건 끝. USD, 가격조건 시작으로만 조회할 경우 0. Defaults to "".
+            trde_pric_cnd_st (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            trde_qty_cnd_fr (Literal, optional): 거래량조건. 0:전체 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -599,6 +889,17 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa20972",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd if stk_cd is not None else [],
+            "high_low_tp": high_low_tp,
+            "alacc_rt": alacc_rt,
+            "stk_cnd": stk_cnd,
+            "pric_cnd_st": pric_cnd_st,
+            "pric_cnd_ed": pric_cnd_ed,
+            "trde_pric_cnd_st": trde_pric_cnd_st,
+            "trde_qty_cnd_fr": trde_qty_cnd_fr,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -610,14 +911,28 @@ class OverseasStockInfo:
 
     def get_volume_renewal_stock(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        stk_cd: str = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        stk_tp: _STK_TP = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
+        dt_tp: Literal["", "5", "10", "20", "60", "250"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoVolumeRenewalStock]:
         """미국주식 거래량갱신(주식/업종) (usa23400)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            stk_cd (str, optional): 업종검색. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            dt_tp (Literal["", "5", "10", "20", "60", "250"], optional): 일자구분. 5:5일,10:10일,20:20일,60:60일,250:250일. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -632,6 +947,16 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa23400",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_tp": stk_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "dt_tp": dt_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -643,14 +968,28 @@ class OverseasStockInfo:
 
     def get_volume_renewal_etf(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
+        dt_tp: Literal["", "5", "10", "20", "60", "250"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoVolumeRenewalEtf]:
         """미국주식 거래량갱신(ETF) (usa23401)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            dt_tp (Literal["", "5", "10", "20", "60", "250"], optional): 일자구분. 5:5일,10:10일,20:20일,60:60일,250:250일. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -665,6 +1004,16 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa23401",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "dt_tp": dt_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -676,14 +1025,26 @@ class OverseasStockInfo:
 
     def get_volume_renewal_watchlist(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        stk_cd: list[dict[str, str]] | None = None,
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
+        dt_tp: Literal["", "5", "10", "20", "60", "250"] = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoVolumeRenewalWatchlist]:
         """미국주식 거래량갱신(관심종목) (usa23402)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            stk_cd (list[dict[str, str]] | None, optional): 관심종목. [{'stex_tp':'거래소구분','stk_cd':'종목코드'},...]. Defaults to None.
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            dt_tp (Literal["", "5", "10", "20", "60", "250"], optional): 일자구분. 5:5일,10:10일,20:20일,60:60일,250:250일. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -698,6 +1059,15 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa23402",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd if stk_cd is not None else [],
+            "trde_qty_tp": trde_qty_tp,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "dt_tp": dt_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -709,14 +1079,32 @@ class OverseasStockInfo:
 
     def get_new_high_low_stock(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        stk_tp: _STK_TP = "",
+        inds_cd: str = "",
+        stk_cnd: _STK_CND = "",
+        ntl_tp: Literal["", "1", "2"] = "",
+        high_low_tp: Literal["", "1", "2"] = "",
+        dt: str = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoNewHighLowStock]:
         """미국주식 신고가/신저가(주식/업종) (usa24100)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체, 1:주식. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            ntl_tp (Literal["", "1", "2"], optional): 신고가신저가구분. 1:신고가, 2:신저가. Defaults to "".
+            high_low_tp (Literal["", "1", "2"], optional): 고저기준. 1:고가저가기준,2:종가기준. Defaults to "".
+            dt (str, optional): 기간입력. n일 기간(최대250), 일자구분과 동시사용 안됨. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -731,6 +1119,18 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa24100",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_tp": stk_tp,
+            "inds_cd": inds_cd,
+            "stk_cnd": stk_cnd,
+            "ntl_tp": ntl_tp,
+            "high_low_tp": high_low_tp,
+            "dt": dt,
+            "pric_cnd": pric_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -742,14 +1142,32 @@ class OverseasStockInfo:
 
     def get_new_high_low_etf(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        stk_cnd: _STK_CND = "",
+        ntl_tp: Literal["", "1", "2"] = "",
+        high_low_tp: Literal["", "1", "2"] = "",
+        dt: str = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoNewHighLowEtf]:
         """미국주식 신고가/신저가(ETF) (usa24101)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%,2:증50%. Defaults to "".
+            ntl_tp (Literal["", "1", "2"], optional): 신고가신저가구분. 1:신고가, 2:신저가. Defaults to "".
+            high_low_tp (Literal["", "1", "2"], optional): 고저기준. 1:고가저가기준,2:종가기준. Defaults to "".
+            dt (str, optional): 기간입력. n일 기간(최대250), 일자구분과 동시사용 안됨. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -764,6 +1182,18 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa24101",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "stk_cnd": stk_cnd,
+            "ntl_tp": ntl_tp,
+            "high_low_tp": high_low_tp,
+            "dt": dt,
+            "pric_cnd": pric_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -775,14 +1205,32 @@ class OverseasStockInfo:
 
     def get_gap_up_down_stock(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        inds_cd: str = "",
+        stk_tp: _STK_TP = "",
+        sort_tp: Literal["", "1", "2"] = "",
+        updown_tp: Literal["", "1", "2"] = "",
+        alacc_rt: str = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoGapUpDownStock]:
         """미국주식 갭상승/갭하락(주식/업종) (usa24140)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            sort_tp (Literal["", "1", "2"], optional): 정렬기준. 1:갭비율, 2:전일대비. Defaults to "".
+            updown_tp (Literal["", "1", "2"], optional): 등락구분. 1:갭상승, 2:갭하락. Defaults to "".
+            alacc_rt (str, optional): 비율1(근접율). 갭비율 값(3:3%이상,5:5%이상,10:10%이상,50:50%이상,100:100%이상,150:150%이상,200:200%이상). Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증거금100%,2:증거금50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. USD 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -797,6 +1245,18 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa24140",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "sort_tp": sort_tp,
+            "updown_tp": updown_tp,
+            "alacc_rt": alacc_rt,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "trde_qty_tp": trde_qty_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -808,14 +1268,32 @@ class OverseasStockInfo:
 
     def get_gap_up_down_etf(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        sort_tp: Literal["", "1", "2"] = "",
+        updown_tp: Literal["", "1", "2"] = "",
+        alacc_rt: str = "",
+        stk_cnd: _STK_CND = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoGapUpDownEtf]:
         """미국주식 갭상승/갭하락(ETF) (usa24141)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            sort_tp (Literal["", "1", "2"], optional): 정렬기준. 1:갭비율, 2:전일대비. Defaults to "".
+            updown_tp (Literal["", "1", "2"], optional): 등락구분. 1:갭상승, 2:갭하락. Defaults to "".
+            alacc_rt (str, optional): 비율1(근접율). 갭비율 값(3:3%이상,5:5%이상,10:10%이상,50:50%이상,100:100%이상,150:150%이상,200:200%이상). Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증거금100%,2:증거금50%. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. USD 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -830,6 +1308,18 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa24141",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "sort_tp": sort_tp,
+            "updown_tp": updown_tp,
+            "alacc_rt": alacc_rt,
+            "stk_cnd": stk_cnd,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+            "trde_qty_tp": trde_qty_tp,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -841,14 +1331,30 @@ class OverseasStockInfo:
 
     def get_remaining_ratio_surge_stock(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        inds_cd: str = "",
+        rt_tp: Literal["", "0", "1"] = "",
+        stk_tp: _STK_TP = "",
+        tm: str = "",
+        stk_cnd: _STK_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoRemainingRatioSurgeStock]:
         """미국주식 잔량률급증(주식/업종) (usa24210)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            rt_tp (Literal["", "0", "1"], optional): 비율 구분. 0:매수/매도 1:매도/매수. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목 구분. 0:전체,1:주식. Defaults to "".
+            tm (str, optional): xxx분전 설정. 0-30분전 설정, 최대 30분. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%만보기,2:증50%만보기. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. USD 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -863,6 +1369,17 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa24210",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "rt_tp": rt_tp,
+            "stk_tp": stk_tp,
+            "tm": tm,
+            "stk_cnd": stk_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -874,14 +1391,30 @@ class OverseasStockInfo:
 
     def get_remaining_ratio_surge_etf(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        rt_tp: Literal["", "0", "1"] = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        tm: str = "",
+        stk_cnd: _STK_CND = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoRemainingRatioSurgeEtf]:
         """미국주식 잔량률급증(ETF) (usa24211)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소 구분. 0:전체,1:NYSE,2:AMEX,3:NASDAQ. Defaults to "".
+            rt_tp (Literal["", "0", "1"], optional): 비율 구분. 0:매수/매도 1:매도/매수. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            tm (str, optional): xxx분전 설정. 0-30분전 설정, 최대 30분. Defaults to "".
+            stk_cnd (Literal["", "0", "1", "2"], optional): 종목조건. 0:전체,1:증100%만보기,2:증50%만보기. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. USD 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -896,6 +1429,17 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa24211",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "rt_tp": rt_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "tm": tm,
+            "stk_cnd": stk_cnd,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -907,14 +1451,32 @@ class OverseasStockInfo:
 
     def get_volume_concentration_stock(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        inds_cd: str = "",
+        stk_tp: _STK_TP = "",
+        dt: str = "",
+        prps_cnctr_rt: str = "",
+        cond: Literal["", "0", "1", "2", "3"] = "",
+        prpscnt: str = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoVolumeConcentrationStock]:
         """미국주식 매물대집중(주식/업종) (usa24220)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 API 참고, stk_tp(종목구분) 1일 경우. Defaults to "".
+            stk_tp (Literal["", "0", "1"], optional): 종목구분. 0:전체,1:주식. Defaults to "".
+            dt (str, optional): 기간. n일, 최대 300일. Defaults to "".
+            prps_cnctr_rt (str, optional): 매물대 집중비율. n%, 최대 100%. Defaults to "".
+            cond (Literal["", "0", "1", "2", "3"], optional): 조건. 0:전체,1:현재가 매물대 진입,2:현재가 매물대 위,3:현재가 매물대 아래. Defaults to "".
+            prpscnt (str, optional): 매물대수. n 매물대수, 최대 99. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -929,6 +1491,18 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa24220",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "inds_cd": inds_cd,
+            "stk_tp": stk_tp,
+            "dt": dt,
+            "prps_cnctr_rt": prps_cnctr_rt,
+            "cond": cond,
+            "prpscnt": prpscnt,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -940,14 +1514,32 @@ class OverseasStockInfo:
 
     def get_volume_concentration_etf(
         self,
-        body: dict[str, str],
+        stex_tp: _STEX_TP = "",
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        dt: str = "",
+        prps_cnctr_rt: str = "",
+        cond: Literal["", "0", "1", "2", "3"] = "",
+        prpscnt: str = "",
+        trde_qty_tp: _TRDE_QTY_TP = "",
+        pric_cnd: _PRIC_CND = "",
+        trde_prica_cnd: _TRDE_PRICA_CND = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoVolumeConcentrationEtf]:
         """미국주식 매물대집중(ETF) (usa24221)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (Literal["", "0", "1", "2", "3"], optional): 거래소구분. 0:전체,1:NYSE,2:NASDAQ,3:AMEX. Defaults to "".
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            dt (str, optional): 기간. n일, 최대 300일. Defaults to "".
+            prps_cnctr_rt (str, optional): 매물대 집중비율. n%, 최대 100%. Defaults to "".
+            cond (Literal["", "0", "1", "2", "3"], optional): 조건. 0:전체,1:현재가 매물대 진입,2:현재가 매물대 위,3:현재가 매물대 아래. Defaults to "".
+            prpscnt (str, optional): 매물대수. n 매물대수, 최대 99. Defaults to "".
+            trde_qty_tp (Literal, optional): 거래량조건. 0:전체, 10,15,20,30,50,100,300,500(1만단위) 이상. Defaults to "".
+            pric_cnd (Literal, optional): 가격조건. 0:전체,1:5미만,2:10미만,3:10이상,4:10~20,5:20~50,6:50이상,7:50~100,8:100미만,9:100이상,10:500이상. Defaults to "".
+            trde_prica_cnd (Literal, optional): 거래대금조건. 0:전체 1,3,5,10,30,50,100,300,500,1000,3000,5000(USD, 1만단위) 이상. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -962,6 +1554,18 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa24221",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "dt": dt,
+            "prps_cnctr_rt": prps_cnctr_rt,
+            "cond": cond,
+            "prpscnt": prpscnt,
+            "trde_qty_tp": trde_qty_tp,
+            "pric_cnd": pric_cnd,
+            "trde_prica_cnd": trde_prica_cnd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -973,14 +1577,16 @@ class OverseasStockInfo:
 
     def get_yearly_fluctuation_rate_stock(
         self,
-        body: dict[str, str],
+        stex_tp: str,
+        stk_cd: str,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateStock]:
         """미국주식 연도별 등락률(종목) (usa26410)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            stex_tp (str): 거래소구분
+            stk_cd (str): 종목코드
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -995,6 +1601,10 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa26410",
         }
+        body = {
+            "stex_tp": stex_tp,
+            "stk_cd": stk_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -1006,14 +1616,16 @@ class OverseasStockInfo:
 
     def get_yearly_fluctuation_rate_by_sector(
         self,
-        body: dict[str, str],
+        inds_cd: str = "",
+        srch_yr: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateBySector]:
         """미국주식 연도별 업종별 종목등락률 (usa26411)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 참고. Defaults to "".
+            srch_yr (str, optional): 조회연도. YYYY. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1028,6 +1640,10 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa26411",
         }
+        body = {
+            "inds_cd": inds_cd,
+            "srch_yr": srch_yr,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -1039,14 +1655,18 @@ class OverseasStockInfo:
 
     def get_yearly_fluctuation_rate_by_etf_category(
         self,
-        body: dict[str, str],
+        etf_cat1: str = "",
+        etf_cat2: str = "",
+        srch_yr: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateByEtfCategory]:
         """미국주식 연도별 ETF 카테고리별 종목등락률 (usa26412)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            etf_cat1 (str, optional): ETF카테고리코드1. stk_tp(종목구분) 2일 경우 ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. stk_tp(종목구분) 2일 경우 ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
+            srch_yr (str, optional): 조회연도. YYYY. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1061,6 +1681,11 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa26412",
         }
+        body = {
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
+            "srch_yr": srch_yr,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -1072,14 +1697,14 @@ class OverseasStockInfo:
 
     def get_yearly_fluctuation_rate_sector(
         self,
-        body: dict[str, str],
+        inds_cd: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateSector]:
         """미국주식 연도별 등락률(업종) (usa26413)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            inds_cd (str, optional): 업종코드. 000:전체, usa10101 참고. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1094,6 +1719,9 @@ class OverseasStockInfo:
             "next-key": next_key,
             "api-id": "usa26413",
         }
+        body = {
+            "inds_cd": inds_cd,
+        }
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -1105,14 +1733,16 @@ class OverseasStockInfo:
 
     def get_yearly_fluctuation_rate_etf(
         self,
-        body: dict[str, str],
+        etf_cat1: str = "",
+        etf_cat2: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasStockInfoYearlyFluctuationRateEtf]:
         """미국주식 연도별 등락률(ETF) (usa26414)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            etf_cat1 (str, optional): ETF카테고리코드1. ETF 대카테고리코드, usa10105 cate1 속성 참고. Defaults to "".
+            etf_cat2 (str, optional): ETF카테고리코드2. ETF 중카테고리코드, usa10105 cate2 속성 참고. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1126,6 +1756,10 @@ class OverseasStockInfo:
             "cont-yn": cont_yn,
             "next-key": next_key,
             "api-id": "usa26414",
+        }
+        body = {
+            "etf_cat1": etf_cat1,
+            "etf_cat2": etf_cat2,
         }
 
         response = self.client._post(self.path, headers, body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info_types.py
@@ -1,202 +1,755 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 
 from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 
 
-class OverseasStockInfoExchangeList(BaseModel, KiwoomHttpBody):
-    model_config = ConfigDict(title="미국주식 거래소구분 조회 응답")
+class OverseasStockInfoExchangeListItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    mkgb: str = Field(default="", description="거래소명")
+    upgb: str = Field(default="", description="업종명")
+    isEtf: str = Field(default="", description="ETF 여부")
 
-    # TODO: 응답 필드 정의
+
+class OverseasStockInfoExchangeList(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 거래소구분 조회 응답", populate_by_name=True)
+
+    result_list: list[OverseasStockInfoExchangeListItem] = Field(
+        default_factory=list, description="결과리스트", alias="list"
+    )
+
+
+class OverseasStockInfoStockListItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    mkgb: str = Field(default="", description="거래소명")
+    upgb: str = Field(default="", description="업종명")
+    isEtf: str = Field(default="", description="ETF 여부")
 
 
 class OverseasStockInfoStockList(BaseModel, KiwoomHttpBody):
-    model_config = ConfigDict(title="미국주식 종목리스트 응답")
+    model_config = ConfigDict(title="미국주식 종목리스트 응답", populate_by_name=True)
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoStockListItem] = Field(
+        default_factory=list, description="결과리스트", alias="list"
+    )
 
 
 class OverseasStockInfoStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 종목 조회 응답")
 
-    # TODO: 응답 필드 정의
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    mkgb: str = Field(default="", description="거래소명")
+    upgb: str = Field(default="", description="업종명")
+    isEtf: str = Field(default="", description="ETF 여부")
+
+
+class OverseasStockInfoSectorListItem(BaseModel):
+    inds_cd: str = Field(default="", description="업종코드")
+    inds_nm: str = Field(default="", description="업종명")
+    inds_enm: str = Field(default="", description="업종영문명")
 
 
 class OverseasStockInfoSectorList(BaseModel, KiwoomHttpBody):
-    model_config = ConfigDict(title="미국주식 업종리스트 응답")
+    model_config = ConfigDict(title="미국주식 업종리스트 응답", populate_by_name=True)
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoSectorListItem] = Field(
+        default_factory=list, description="결과리스트", alias="list"
+    )
+
+
+class OverseasStockInfoIndexListItem(BaseModel):
+    index_cd: str = Field(default="", description="지수코드")
+    index_nm: str = Field(default="", description="지수명")
+    index_enm: str = Field(default="", description="지수영문명")
 
 
 class OverseasStockInfoIndexList(BaseModel, KiwoomHttpBody):
-    model_config = ConfigDict(title="미국지수 리스트 응답")
+    model_config = ConfigDict(title="미국지수 리스트 응답", populate_by_name=True)
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoIndexListItem] = Field(
+        default_factory=list, description="결과리스트", alias="list"
+    )
+
+
+class OverseasStockInfoEtfEtnListItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분")
+    code: str = Field(default="", description="종목코드")
+    cate1: str = Field(default="", description="카테고리1")
+    cate2: str = Field(default="", description="카테고리2")
+    etn: str = Field(default="", description="ETN여부")
+    mkgb: str = Field(default="", description="거래소명")
+    upnm: str = Field(default="", description="업종명")
 
 
 class OverseasStockInfoEtfEtnList(BaseModel, KiwoomHttpBody):
-    model_config = ConfigDict(title="미국 ETF,ETN 리스트 응답")
+    model_config = ConfigDict(title="미국 ETF,ETN 리스트 응답", populate_by_name=True)
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoEtfEtnListItem] = Field(
+        default_factory=list, description="결과리스트", alias="list"
+    )
+
+
+class OverseasStockInfoEtfCategoryListItem(BaseModel):
+    gubun: str = Field(default="", description="구분")
+    cate1: str = Field(default="", description="카테고리1차")
+    cate1nam: str = Field(default="", description="카테고리1차명")
+    cate2: str = Field(default="", description="카테고리2차")
+    cate2nam: str = Field(default="", description="카테고리2차명")
 
 
 class OverseasStockInfoEtfCategoryList(BaseModel, KiwoomHttpBody):
-    model_config = ConfigDict(title="미국 ETF 카테고리 리스트 응답")
+    model_config = ConfigDict(title="미국 ETF 카테고리 리스트 응답", populate_by_name=True)
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoEtfCategoryListItem] = Field(
+        default_factory=list, description="결과리스트", alias="list"
+    )
+
+
+class OverseasStockInfoVolumeSurgeStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    sdnin_rt: str = Field(default="", description="급증률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasStockInfoVolumeSurgeStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 거래량급등락(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoVolumeSurgeStockItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoVolumeSurgeEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    sdnin_rt: str = Field(default="", description="급증률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasStockInfoVolumeSurgeEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 거래량급등락(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoVolumeSurgeEtfItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoPriceByRangeStockItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasStockInfoPriceByRangeStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 가격대별주가(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    stk_num: str = Field(default="", description="종목수")
+    rising_stk_num: str = Field(default="", description="상승")
+    flat_stk_num: str = Field(default="", description="보합")
+    fall_stk_num: str = Field(default="", description="하락")
+    result_list: list[OverseasStockInfoPriceByRangeStockItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoPriceByRangeEtfItem(BaseModel):
+    rank: str = Field(default="", description="순위")
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasStockInfoPriceByRangeEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 가격대별주가(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    stk_num: str = Field(default="", description="종목수")
+    rising_stk_num: str = Field(default="", description="상승")
+    flat_stk_num: str = Field(default="", description="보합")
+    fall_stk_num: str = Field(default="", description="하락")
+    result_list: list[OverseasStockInfoPriceByRangeEtfItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoPriceSurgeStockItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명한글")
+    stk_enm: str = Field(default="", description="영문종목명")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    base_pric: str = Field(default="", description="기준가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    base_pre: str = Field(default="", description="기준대비. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="거래량. 단위: 1주")
+    sdnin_rt: str = Field(default="", description="급증률")
 
 
 class OverseasStockInfoPriceSurgeStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 가격급등락(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoPriceSurgeStockItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoPriceSurgeEtfItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명한글")
+    stk_enm: str = Field(default="", description="영문종목명")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    base_pric: str = Field(default="", description="기준가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    base_pre: str = Field(default="", description="기준대비. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    sdnin_rt: str = Field(default="", description="급증률")
 
 
 class OverseasStockInfoPriceSurgeEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 가격급등락(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoPriceSurgeEtfItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoPriceSurgeWatchlistItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    base_pric: str = Field(default="", description="기준가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    base_pre: str = Field(default="", description="기준가 대비. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+    sdnin_rt: str = Field(default="", description="급등락율")
 
 
 class OverseasStockInfoPriceSurgeWatchlist(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 가격급등락(관심종목) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoPriceSurgeWatchlistItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoHighLowApproachStockItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="당일고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="당일저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasStockInfoHighLowApproachStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 고가/저가 접근(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoHighLowApproachStockItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoHighLowApproachEtfItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="당일고가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="당일저가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasStockInfoHighLowApproachEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 고가/저가 접근(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoHighLowApproachEtfItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoHighLowApproachWatchlistItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    acc_trde_qty: str = Field(default="", description="누적거래량")
+    tp: str = Field(default="", description="신종목구분자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    sel_bid: str = Field(
+        default="", description="(최우선)매도호가. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    buy_bid: str = Field(
+        default="", description="(최우선)매수호가. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    high_pric: str = Field(default="", description="고가. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    low_pric: str = Field(default="", description="저가. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
 
 
 class OverseasStockInfoHighLowApproachWatchlist(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 고가/저가 접근(관심종목) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoHighLowApproachWatchlistItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasStockInfoVolumeRenewalStockItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    prev_trde_qty: str = Field(default="", description="이전거래량")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasStockInfoVolumeRenewalStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 거래량갱신(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoVolumeRenewalStockItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoVolumeRenewalEtfItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    prev_trde_qty: str = Field(default="", description="이전거래량")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasStockInfoVolumeRenewalEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 거래량갱신(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoVolumeRenewalEtfItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoVolumeRenewalWatchlistItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    prev_trde_qty: str = Field(default="", description="이전거래량")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
 
 
 class OverseasStockInfoVolumeRenewalWatchlist(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 거래량갱신(관심종목) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoVolumeRenewalWatchlistItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasStockInfoNewHighLowStockItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    pre_trde_rt: str = Field(
+        default="", description="전일거래대비. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="250일고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="250일저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    pred_trde_qty: str = Field(default="", description="전일거래량")
 
 
 class OverseasStockInfoNewHighLowStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 신고가/신저가(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoNewHighLowStockItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoNewHighLowEtfItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    pre_trde_rt: str = Field(
+        default="", description="전일거래대비. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    sel_bid: str = Field(default="", description="매도호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    buy_bid: str = Field(default="", description="매수호가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    high_pric: str = Field(default="", description="250일고가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    low_pric: str = Field(default="", description="250일저가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    pred_trde_qty: str = Field(default="", description="전일거래량")
 
 
 class OverseasStockInfoNewHighLowEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 신고가/신저가(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoNewHighLowEtfItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoGapUpDownStockItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    base_close_pric: str = Field(default="", description="전일종가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    gap_rt: str = Field(default="", description="갭비율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    pre_high_pric: str = Field(default="", description="전일고가")
+    pred_trde_qty: str = Field(default="", description="전일거래량")
 
 
 class OverseasStockInfoGapUpDownStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 갭상승/갭하락(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoGapUpDownStockItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoGapUpDownEtfItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    open_pric: str = Field(default="", description="시가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    base_close_pric: str = Field(default="", description="전일종가. 단위: USD, 소수점 넷째 자리까지 포맷된 숫자")
+    gap_rt: str = Field(default="", description="갭비율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    pre_high_pric: str = Field(default="", description="전일고가")
+    pred_trde_qty: str = Field(default="", description="전일거래량")
 
 
 class OverseasStockInfoGapUpDownEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 갭상승/갭하락(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoGapUpDownEtfItem] = Field(default_factory=list, description="결과리스트")
+
+
+class OverseasStockInfoRemainingRatioSurgeStockItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    base_rt: str = Field(default="", description="기준비율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율", alias="int")
+    now_rt: str = Field(default="", description="현재비율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    sdnin_rt: str = Field(default="", description="급증률. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    tot_sel_req: str = Field(default="", description="총매도잔량")
+    tot_buy_req: str = Field(default="", description="총매수잔량")
 
 
 class OverseasStockInfoRemainingRatioSurgeStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 잔량률급증(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoRemainingRatioSurgeStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasStockInfoRemainingRatioSurgeEtfItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    base_rt: str = Field(default="", description="기준비율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율", alias="int")
+    now_rt: str = Field(default="", description="현재비율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    sdnin_rt: str = Field(default="", description="급증률. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    tot_sel_req: str = Field(default="", description="총매도잔량")
+    tot_buy_req: str = Field(default="", description="총매수잔량")
 
 
 class OverseasStockInfoRemainingRatioSurgeEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 잔량률급증(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoRemainingRatioSurgeEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasStockInfoVolumeConcentrationStockItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    pric_cnd_st: str = Field(default="", description="가격대시작")
+    pric_cnd_ed: str = Field(default="", description="가격대끝")
+    prps_qty: str = Field(default="", description="매물량")
+    prps_rt: str = Field(default="", description="매물비")
 
 
 class OverseasStockInfoVolumeConcentrationStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 매물대집중(주식/업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoVolumeConcentrationStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasStockInfoVolumeConcentrationEtfItem(BaseModel):
+    mgn_type: str = Field(default="", description="증거금률")
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    cur_prc: str = Field(default="", description="현재가. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    pred_pre_sig: str = Field(default="", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락")
+    pred_pre: str = Field(default="", description="전일대비. 단위: USD, 부호 포함 소수점 넷째 자리까지 포맷된 숫자")
+    flu_rt: str = Field(default="", description="등락률. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율")
+    acc_trde_qty: str = Field(default="", description="거래량")
+    pric_cnd_st: str = Field(default="", description="가격대시작")
+    pric_cnd_ed: str = Field(default="", description="가격대끝")
+    prps_qty: str = Field(default="", description="매물량")
+    prps_rt: str = Field(default="", description="매물비")
 
 
 class OverseasStockInfoVolumeConcentrationEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 매물대집중(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoVolumeConcentrationEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasStockInfoYearlyFluctuationRateStockItem(BaseModel):
+    dt: str = Field(default="", description="연도. 0:평균, YYYY:년도")
+    m01_prft_rt: str = Field(default="", description="1월 수익률")
+    m02_prft_rt: str = Field(default="", description="2월 수익률")
+    m03_prft_rt: str = Field(default="", description="3월 수익률")
+    m04_prft_rt: str = Field(default="", description="4월 수익률")
+    m05_prft_rt: str = Field(default="", description="5월 수익률")
+    m06_prft_rt: str = Field(default="", description="6월 수익률")
+    m07_prft_rt: str = Field(default="", description="7월 수익률")
+    m08_prft_rt: str = Field(default="", description="8월 수익률")
+    m09_prft_rt: str = Field(default="", description="9월 수익률")
+    m10_prft_rt: str = Field(default="", description="10월 수익률")
+    m11_prft_rt: str = Field(default="", description="11월 수익률")
+    m12_prft_rt: str = Field(default="", description="12월 수익률")
 
 
 class OverseasStockInfoYearlyFluctuationRateStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 연도별 등락률(종목) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoYearlyFluctuationRateStockItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasStockInfoYearlyFluctuationRateBySectorItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    m01_prft_rt: str = Field(default="", description="1월 수익률")
+    m02_prft_rt: str = Field(default="", description="2월 수익률")
+    m03_prft_rt: str = Field(default="", description="3월 수익률")
+    m04_prft_rt: str = Field(default="", description="4월 수익률")
+    m05_prft_rt: str = Field(default="", description="5월 수익률")
+    m06_prft_rt: str = Field(default="", description="6월 수익률")
+    m07_prft_rt: str = Field(default="", description="7월 수익률")
+    m08_prft_rt: str = Field(default="", description="8월 수익률")
+    m09_prft_rt: str = Field(default="", description="9월 수익률")
+    m10_prft_rt: str = Field(default="", description="10월 수익률")
+    m11_prft_rt: str = Field(default="", description="11월 수익률")
+    m12_prft_rt: str = Field(default="", description="12월 수익률")
 
 
 class OverseasStockInfoYearlyFluctuationRateBySector(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 연도별 업종별 종목등락률 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoYearlyFluctuationRateBySectorItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasStockInfoYearlyFluctuationRateByEtfCategoryItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    stk_nm: str = Field(default="", description="종목명")
+    stk_enm: str = Field(default="", description="종목영문명")
+    m01_prft_rt: str = Field(default="", description="1월 수익률")
+    m02_prft_rt: str = Field(default="", description="2월 수익률")
+    m03_prft_rt: str = Field(default="", description="3월 수익률")
+    m04_prft_rt: str = Field(default="", description="4월 수익률")
+    m05_prft_rt: str = Field(default="", description="5월 수익률")
+    m06_prft_rt: str = Field(default="", description="6월 수익률")
+    m07_prft_rt: str = Field(default="", description="7월 수익률")
+    m08_prft_rt: str = Field(default="", description="8월 수익률")
+    m09_prft_rt: str = Field(default="", description="9월 수익률")
+    m10_prft_rt: str = Field(default="", description="10월 수익률")
+    m11_prft_rt: str = Field(default="", description="11월 수익률")
+    m12_prft_rt: str = Field(default="", description="12월 수익률")
 
 
 class OverseasStockInfoYearlyFluctuationRateByEtfCategory(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 연도별 ETF 카테고리별 종목등락률 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoYearlyFluctuationRateByEtfCategoryItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasStockInfoYearlyFluctuationRateSectorItem(BaseModel):
+    dt: str = Field(default="", description="연도. 0:평균, YYYY:년도")
+    m01_prft_rt: str = Field(default="", description="1월 수익률")
+    m02_prft_rt: str = Field(default="", description="2월 수익률")
+    m03_prft_rt: str = Field(default="", description="3월 수익률")
+    m04_prft_rt: str = Field(default="", description="4월 수익률")
+    m05_prft_rt: str = Field(default="", description="5월 수익률")
+    m06_prft_rt: str = Field(default="", description="6월 수익률")
+    m07_prft_rt: str = Field(default="", description="7월 수익률")
+    m08_prft_rt: str = Field(default="", description="8월 수익률")
+    m09_prft_rt: str = Field(default="", description="9월 수익률")
+    m10_prft_rt: str = Field(default="", description="10월 수익률")
+    m11_prft_rt: str = Field(default="", description="11월 수익률")
+    m12_prft_rt: str = Field(default="", description="12월 수익률")
 
 
 class OverseasStockInfoYearlyFluctuationRateSector(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 연도별 등락률(업종) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoYearlyFluctuationRateSectorItem] = Field(
+        default_factory=list, description="결과리스트"
+    )
+
+
+class OverseasStockInfoYearlyFluctuationRateEtfItem(BaseModel):
+    dt: str = Field(default="", description="연도. 0:평균, YYYY:년도")
+    m01_prft_rt: str = Field(default="", description="1월 수익률")
+    m02_prft_rt: str = Field(default="", description="2월 수익률")
+    m03_prft_rt: str = Field(default="", description="3월 수익률")
+    m04_prft_rt: str = Field(default="", description="4월 수익률")
+    m05_prft_rt: str = Field(default="", description="5월 수익률")
+    m06_prft_rt: str = Field(default="", description="6월 수익률")
+    m07_prft_rt: str = Field(default="", description="7월 수익률")
+    m08_prft_rt: str = Field(default="", description="8월 수익률")
+    m09_prft_rt: str = Field(default="", description="9월 수익률")
+    m10_prft_rt: str = Field(default="", description="10월 수익률")
+    m11_prft_rt: str = Field(default="", description="11월 수익률")
+    m12_prft_rt: str = Field(default="", description="12월 수익률")
 
 
 class OverseasStockInfoYearlyFluctuationRateEtf(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 연도별 등락률(ETF) 응답")
 
-    # TODO: 응답 필드 정의
+    result_list: list[OverseasStockInfoYearlyFluctuationRateEtfItem] = Field(
+        default_factory=list, description="결과리스트"
+    )

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info_types.py
@@ -1,0 +1,202 @@
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+from cluefin_openapi.kiwoom._model import KiwoomHttpBody
+
+
+class OverseasStockInfoExchangeList(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 거래소구분 조회 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoStockList(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 종목리스트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 종목 조회 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoSectorList(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 업종리스트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoIndexList(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국지수 리스트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoEtfEtnList(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국 ETF,ETN 리스트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoEtfCategoryList(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국 ETF 카테고리 리스트 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoVolumeSurgeStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 거래량급등락(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoVolumeSurgeEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 거래량급등락(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoPriceByRangeStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 가격대별주가(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoPriceByRangeEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 가격대별주가(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoPriceSurgeStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 가격급등락(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoPriceSurgeEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 가격급등락(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoPriceSurgeWatchlist(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 가격급등락(관심종목) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoHighLowApproachStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 고가/저가 접근(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoHighLowApproachEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 고가/저가 접근(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoHighLowApproachWatchlist(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 고가/저가 접근(관심종목) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoVolumeRenewalStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 거래량갱신(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoVolumeRenewalEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 거래량갱신(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoVolumeRenewalWatchlist(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 거래량갱신(관심종목) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoNewHighLowStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 신고가/신저가(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoNewHighLowEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 신고가/신저가(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoGapUpDownStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 갭상승/갭하락(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoGapUpDownEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 갭상승/갭하락(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoRemainingRatioSurgeStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 잔량률급증(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoRemainingRatioSurgeEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 잔량률급증(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoVolumeConcentrationStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 매물대집중(주식/업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoVolumeConcentrationEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 매물대집중(ETF) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoYearlyFluctuationRateStock(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 연도별 등락률(종목) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoYearlyFluctuationRateBySector(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 연도별 업종별 종목등락률 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoYearlyFluctuationRateByEtfCategory(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 연도별 ETF 카테고리별 종목등락률 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoYearlyFluctuationRateSector(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 연도별 등락률(업종) 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasStockInfoYearlyFluctuationRateEtf(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 연도별 등락률(ETF) 응답")
+
+    # TODO: 응답 필드 정의

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_watchlist.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_watchlist.py
@@ -1,0 +1,83 @@
+from typing import Literal
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._model import (
+    KiwoomHttpHeader,
+    KiwoomHttpResponse,
+)
+from cluefin_openapi.kiwoom._overseas_watchlist_types import (
+    OverseasWatchlistGroupDetail,
+    OverseasWatchlistGroupList,
+)
+
+
+class OverseasWatchlist:
+    def __init__(self, client: Client):
+        self.client = client
+        self.path = "/api/us/watchlist"
+
+    def get_watchlist_group_list(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasWatchlistGroupList]:
+        """미국주식 관심종목 그룹 리스트 조회 (usa20200)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasWatchlistGroupList]: 미국주식 관심종목 그룹 리스트 조회 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20200",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching watchlist group list: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasWatchlistGroupList.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_watchlist_group_detail(
+        self,
+        body: dict[str, str],
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasWatchlistGroupDetail]:
+        """미국주식 관심종목 그룹 상세 조회 (usa20201)
+
+        Args:
+            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasWatchlistGroupDetail]: 미국주식 관심종목 그룹 상세 조회 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa20201",
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching watchlist group detail: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasWatchlistGroupDetail.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_watchlist.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_watchlist.py
@@ -18,14 +18,12 @@ class OverseasWatchlist:
 
     def get_watchlist_group_list(
         self,
-        body: dict[str, str],
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasWatchlistGroupList]:
         """미국주식 관심종목 그룹 리스트 조회 (usa20200)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -40,6 +38,7 @@ class OverseasWatchlist:
             "next-key": next_key,
             "api-id": "usa20200",
         }
+        body: dict[str, str] = {}
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -51,14 +50,14 @@ class OverseasWatchlist:
 
     def get_watchlist_group_detail(
         self,
-        body: dict[str, str],
+        arn_grp_id: str = "",
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[OverseasWatchlistGroupDetail]:
         """미국주식 관심종목 그룹 상세 조회 (usa20201)
 
         Args:
-            body (dict[str, str]): 요청 파라미터. TODO: API 문서 확정 후 개별 인자로 교체
+            arn_grp_id (str, optional): 그룹SEQ. usa20200 응답 결과의 gcod값을 입력. Defaults to "".
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -72,6 +71,9 @@ class OverseasWatchlist:
             "cont-yn": cont_yn,
             "next-key": next_key,
             "api-id": "usa20201",
+        }
+        body = {
+            "arn_grp_id": arn_grp_id,
         }
 
         response = self.client._post(self.path, headers, body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_watchlist_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_watchlist_types.py
@@ -1,16 +1,30 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 from pydantic.config import ConfigDict
 
 from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 
 
+class OverseasWatchlistGroupListItem(BaseModel):
+    gcod: str = Field(default="", description="그룹코드")
+    name: str = Field(default="", description="그룹명")
+
+
 class OverseasWatchlistGroupList(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 관심종목 그룹 리스트 조회 응답")
 
-    # TODO: 응답 필드 정의
+    rtcd: str = Field(default="", description="처리결과. S:성공 F:실패")
+    nofi: list[OverseasWatchlistGroupListItem] = Field(default_factory=list, description="그룹갯수")
+
+
+class OverseasWatchlistGroupDetailItem(BaseModel):
+    cod2: str = Field(default="", description="종목코드")
+    bgb: str = Field(default="", description="북마크 구분")
+    bgb_clr: str = Field(default="", description="북마크 컬러")
+    stex_tp: str = Field(default="", description="거래소구분. ND:NASDAQ,NY:NYSE,NA:AMEX")
 
 
 class OverseasWatchlistGroupDetail(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="미국주식 관심종목 그룹 상세 조회 응답")
 
-    # TODO: 응답 필드 정의
+    rtcd: str = Field(default="", description="처리 결과. S:성공 F:실패")
+    nofj: list[OverseasWatchlistGroupDetailItem] = Field(default_factory=list, description="종목 갯수")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_watchlist_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_watchlist_types.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel
+from pydantic.config import ConfigDict
+
+from cluefin_openapi.kiwoom._model import KiwoomHttpBody
+
+
+class OverseasWatchlistGroupList(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 관심종목 그룹 리스트 조회 응답")
+
+    # TODO: 응답 필드 정의
+
+
+class OverseasWatchlistGroupDetail(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 관심종목 그룹 상세 조회 응답")
+
+    # TODO: 응답 필드 정의

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_account_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_account_integration.py
@@ -1,0 +1,345 @@
+import pytest
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._overseas_account_types import (
+    OverseasAccountDailyOrderExecutionHistory,
+    OverseasAccountDailyProfitRate,
+    OverseasAccountDailyRealizedProfitLoss,
+    OverseasAccountDailyRealizedProfitLossByStock,
+    OverseasAccountDailyStockProfitRate,
+    OverseasAccountDeposit,
+    OverseasAccountDepositAndSecuritiesValuationByCurrency,
+    OverseasAccountDepositAndSecuritiesValuationByCurrencyByDate,
+    OverseasAccountDepositDetail,
+    OverseasAccountKrwWithdrawableAmount,
+    OverseasAccountLedgerBalance,
+    OverseasAccountLedgerUnfilledOrders,
+    OverseasAccountLedgerValuationAmount,
+    OverseasAccountMonthlyProfitRate,
+    OverseasAccountMonthlyRealizedProfitLoss,
+    OverseasAccountMonthlyStockProfitRate,
+    OverseasAccountOrderHistoryByPeriod,
+    OverseasAccountProfitRateByPeriod,
+    OverseasAccountRealizedProfitLoss,
+    OverseasAccountTodayOrderExecution,
+    OverseasAccountTodayRealizedProfitLoss,
+    OverseasAccountTodayRealizedProfitLossByStock,
+    OverseasAccountTodayTrading,
+    OverseasAccountTodayTradingSummary,
+    OverseasAccountTransactionHistory,
+    OverseasAccountValuationAmountByDate,
+    OverseasAccountYearlyProfitRate,
+    OverseasAccountYearlyStockProfitRate,
+)
+
+
+@pytest.mark.integration
+def test_get_daily_account_profit_rate(client: Client):
+    response = client.overseas_account.get_daily_account_profit_rate(from_dt="20240102", to="20240131")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountDailyProfitRate)
+
+
+@pytest.mark.integration
+def test_get_monthly_account_profit_rate(client: Client):
+    response = client.overseas_account.get_monthly_account_profit_rate(from_dt="202401", to="202406")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountMonthlyProfitRate)
+
+
+@pytest.mark.integration
+def test_get_yearly_account_profit_rate(client: Client):
+    response = client.overseas_account.get_yearly_account_profit_rate(from_dt="2023", to="2024")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountYearlyProfitRate)
+
+
+@pytest.mark.integration
+def test_get_daily_stock_profit_rate(client: Client):
+    response = client.overseas_account.get_daily_stock_profit_rate(
+        from_dt="20240102", to="20240131", stk_cd="AAPL", stex_tp="ND"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountDailyStockProfitRate)
+
+
+@pytest.mark.integration
+def test_get_monthly_stock_profit_rate(client: Client):
+    response = client.overseas_account.get_monthly_stock_profit_rate(
+        from_dt="202401", to="202406", stk_cd="AAPL", stex_tp="ND"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountMonthlyStockProfitRate)
+
+
+@pytest.mark.integration
+def test_get_yearly_stock_profit_rate(client: Client):
+    response = client.overseas_account.get_yearly_stock_profit_rate(
+        from_dt="2023", to="2024", stk_cd="AAPL", stex_tp="ND"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountYearlyStockProfitRate)
+
+
+@pytest.mark.integration
+def test_get_ledger_unfilled_orders(client: Client):
+    response = client.overseas_account.get_ledger_unfilled_orders(
+        ord_dt="20240102", slby_tp="0", stex_tp="ND", stk_cd="AAPL"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountLedgerUnfilledOrders)
+
+
+@pytest.mark.integration
+def test_get_ledger_balance(client: Client):
+    response = client.overseas_account.get_ledger_balance(stex_tp="ND", stk_cd="AAPL")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountLedgerBalance)
+
+
+@pytest.mark.integration
+def test_get_transaction_history(client: Client):
+    response = client.overseas_account.get_transaction_history(
+        strt_dt="20240102",
+        end_dt="20240131",
+        tp="0",
+        stex_tp="ND",
+        stk_cd="AAPL",
+        krw_repl_skip_yn="N",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountTransactionHistory)
+
+
+@pytest.mark.integration
+def test_get_deposit(client: Client):
+    response = client.overseas_account.get_deposit()
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountDeposit)
+
+
+@pytest.mark.integration
+def test_get_krw_withdrawable_amount(client: Client):
+    response = client.overseas_account.get_krw_withdrawable_amount()
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountKrwWithdrawableAmount)
+
+
+@pytest.mark.integration
+def test_get_deposit_and_securities_valuation_by_currency(client: Client):
+    response = client.overseas_account.get_deposit_and_securities_valuation_by_currency(cmsn_incl_tp="0", exrt_tp="0")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountDepositAndSecuritiesValuationByCurrency)
+
+
+@pytest.mark.integration
+def test_get_ledger_valuation_amount(client: Client):
+    response = client.overseas_account.get_ledger_valuation_amount(cmsn_incl_tp="0", exrt_tp="0")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountLedgerValuationAmount)
+
+
+@pytest.mark.integration
+def test_get_valuation_amount_by_date(client: Client):
+    response = client.overseas_account.get_valuation_amount_by_date(base_dt="20240102")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountValuationAmountByDate)
+
+
+@pytest.mark.integration
+def test_get_deposit_and_securities_valuation_by_currency_on_date(client: Client):
+    response = client.overseas_account.get_deposit_and_securities_valuation_by_currency_on_date(base_dt="20240102")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountDepositAndSecuritiesValuationByCurrencyByDate)
+
+
+@pytest.mark.integration
+def test_get_daily_order_execution_history(client: Client):
+    response = client.overseas_account.get_daily_order_execution_history(
+        query_tp="1",
+        slby_tp="0",
+        ord_dt="20240102",
+        stex_tp="ND",
+        stk_cd="AAPL",
+        oppo_trde_tp="0",
+        fr_ord_no="0001",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountDailyOrderExecutionHistory)
+
+
+@pytest.mark.integration
+def test_get_deposit_detail(client: Client):
+    response = client.overseas_account.get_deposit_detail()
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountDepositDetail)
+
+
+@pytest.mark.integration
+def test_get_today_realized_profit_loss_by_stock(client: Client):
+    response = client.overseas_account.get_today_realized_profit_loss_by_stock(fc_krw_tp="0")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountTodayRealizedProfitLossByStock)
+
+
+@pytest.mark.integration
+def test_get_order_history_by_period(client: Client):
+    response = client.overseas_account.get_order_history_by_period(
+        strt_dt="20240102",
+        end_dt="20240131",
+        slby_tp="0",
+        stex_tp="ND",
+        stk_cd="AAPL",
+        oppo_trde_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountOrderHistoryByPeriod)
+
+
+@pytest.mark.integration
+def test_get_today_order_execution(client: Client):
+    response = client.overseas_account.get_today_order_execution(slby_tp="0", stex_tp="ND", stk_cd="AAPL")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountTodayOrderExecution)
+
+
+@pytest.mark.integration
+def test_get_realized_profit_loss(client: Client):
+    response = client.overseas_account.get_realized_profit_loss(strt_dt="20240102", end_dt="20240131", fc_krw_tp="0")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountRealizedProfitLoss)
+
+
+@pytest.mark.integration
+def test_get_today_trading(client: Client):
+    response = client.overseas_account.get_today_trading(qry_tp="0", fc_krw_tp="0", base_dt="20240102")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountTodayTrading)
+
+
+@pytest.mark.integration
+def test_get_today_trading_summary(client: Client):
+    response = client.overseas_account.get_today_trading_summary(fc_krw_tp="0", stex_tp="ND", stk_cd="AAPL")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountTodayTradingSummary)
+
+
+@pytest.mark.integration
+def test_get_today_realized_profit_loss(client: Client):
+    response = client.overseas_account.get_today_realized_profit_loss(fc_krw_tp="0", stex_tp="ND", stk_cd="AAPL")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountTodayRealizedProfitLoss)
+
+
+@pytest.mark.integration
+def test_get_daily_realized_profit_loss_by_stock(client: Client):
+    response = client.overseas_account.get_daily_realized_profit_loss_by_stock(
+        cntr_dt="20240102", fc_krw_tp="0", stex_tp="ND", stk_cd="AAPL"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountDailyRealizedProfitLossByStock)
+
+
+@pytest.mark.integration
+def test_get_profit_rate_by_period(client: Client):
+    response = client.overseas_account.get_profit_rate_by_period(fr_dt="20240102", to_dt="20240131")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountProfitRateByPeriod)
+
+
+@pytest.mark.integration
+def test_get_daily_realized_profit_loss(client: Client):
+    response = client.overseas_account.get_daily_realized_profit_loss(strt_dt="20240102", end_dt="20240131")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountDailyRealizedProfitLoss)
+
+
+@pytest.mark.integration
+def test_get_monthly_realized_profit_loss(client: Client):
+    response = client.overseas_account.get_monthly_realized_profit_loss(strt_dt="202401", end_dt="202406")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasAccountMonthlyRealizedProfitLoss)

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_account_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_account_unit.py
@@ -1,0 +1,156 @@
+import inspect
+import re
+
+import pytest
+
+from cluefin_openapi.kiwoom import _overseas_account as overseas_account_module
+from cluefin_openapi.kiwoom._overseas_account import OverseasAccount
+
+from ._helpers import EndpointCase, run_post_case
+
+CALL_KWARGS = {
+    "get_daily_account_profit_rate": {"from_dt": "20240102", "to": "20240131"},
+    "get_monthly_account_profit_rate": {"from_dt": "202401", "to": "202406"},
+    "get_yearly_account_profit_rate": {"from_dt": "2023", "to": "2024"},
+    "get_daily_stock_profit_rate": {
+        "from_dt": "20240102",
+        "to": "20240131",
+        "stk_cd": "AAPL",
+        "stex_tp": "ND",
+    },
+    "get_monthly_stock_profit_rate": {
+        "from_dt": "202401",
+        "to": "202406",
+        "stk_cd": "AAPL",
+        "stex_tp": "ND",
+    },
+    "get_yearly_stock_profit_rate": {
+        "from_dt": "2023",
+        "to": "2024",
+        "stk_cd": "AAPL",
+        "stex_tp": "ND",
+    },
+    "get_ledger_unfilled_orders": {
+        "ord_dt": "20240102",
+        "slby_tp": "0",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+    },
+    "get_ledger_balance": {"stex_tp": "ND", "stk_cd": "AAPL"},
+    "get_transaction_history": {
+        "strt_dt": "20240102",
+        "end_dt": "20240131",
+        "tp": "0",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "krw_repl_skip_yn": "N",
+    },
+    "get_deposit": {},
+    "get_krw_withdrawable_amount": {},
+    "get_deposit_and_securities_valuation_by_currency": {"cmsn_incl_tp": "0", "exrt_tp": "0"},
+    "get_ledger_valuation_amount": {"cmsn_incl_tp": "0", "exrt_tp": "0"},
+    "get_valuation_amount_by_date": {"base_dt": "20240102"},
+    "get_deposit_and_securities_valuation_by_currency_on_date": {"base_dt": "20240102"},
+    "get_daily_order_execution_history": {
+        "query_tp": "1",
+        "slby_tp": "0",
+        "ord_dt": "20240102",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "oppo_trde_tp": "0",
+        "fr_ord_no": "0001",
+    },
+    "get_deposit_detail": {},
+    "get_today_realized_profit_loss_by_stock": {"fc_krw_tp": "0"},
+    "get_order_history_by_period": {
+        "strt_dt": "20240102",
+        "end_dt": "20240131",
+        "slby_tp": "0",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "oppo_trde_tp": "0",
+    },
+    "get_today_order_execution": {"slby_tp": "0", "stex_tp": "ND", "stk_cd": "AAPL"},
+    "get_realized_profit_loss": {"strt_dt": "20240102", "end_dt": "20240131", "fc_krw_tp": "0"},
+    "get_today_trading": {"qry_tp": "0", "fc_krw_tp": "0", "base_dt": "20240102"},
+    "get_today_trading_summary": {"fc_krw_tp": "0", "stex_tp": "ND", "stk_cd": "AAPL"},
+    "get_today_realized_profit_loss": {"fc_krw_tp": "0", "stex_tp": "ND", "stk_cd": "AAPL"},
+    "get_daily_realized_profit_loss_by_stock": {
+        "cntr_dt": "20240102",
+        "fc_krw_tp": "0",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+    },
+    "get_profit_rate_by_period": {"fr_dt": "20240102", "to_dt": "20240131"},
+    "get_daily_realized_profit_loss": {"strt_dt": "20240102", "end_dt": "20240131"},
+    "get_monthly_realized_profit_loss": {"strt_dt": "202401", "end_dt": "202406"},
+}
+
+# Methods where the request body differs from the call kwargs because the
+# ``from_dt`` argument is serialized under the body key ``"from"``.
+EXPECTED_BODY = {
+    "get_daily_account_profit_rate": {"from": "20240102", "to": "20240131"},
+    "get_monthly_account_profit_rate": {"from": "202401", "to": "202406"},
+    "get_yearly_account_profit_rate": {"from": "2023", "to": "2024"},
+    "get_daily_stock_profit_rate": {
+        "from": "20240102",
+        "to": "20240131",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+    },
+    "get_monthly_stock_profit_rate": {
+        "from": "202401",
+        "to": "202406",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+    },
+    "get_yearly_stock_profit_rate": {
+        "from": "2023",
+        "to": "2024",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+    },
+}
+
+
+def payload(name: str):
+    return {"return_code": 0, "return_msg": "OK", "endpoint": name}
+
+
+def method_metadata(method_name: str) -> tuple[str, str]:
+    method = getattr(OverseasAccount, method_name)
+    source = inspect.getsource(method)
+    api_id = re.search(r'"api-id":\s*"([^"]+)"', source).group(1)
+    model_attr = re.search(r"= (OverseasAccount\w+)\.model_validate", source).group(1)
+    return api_id, model_attr
+
+
+ACCOUNT_CASES = []
+for method_name, kwargs in CALL_KWARGS.items():
+    api_id, model_attr = method_metadata(method_name)
+    case_name = method_name.removeprefix("get_")
+    ACCOUNT_CASES.append(
+        EndpointCase(
+            name=case_name,
+            method_name=method_name,
+            response_model_attr=model_attr,
+            api_id=api_id,
+            call_kwargs=dict(kwargs),
+            expected_body=dict(EXPECTED_BODY.get(method_name, kwargs)),
+            response_payload=payload(case_name),
+        )
+    )
+
+
+@pytest.mark.parametrize("case", ACCOUNT_CASES, ids=lambda case: case.name)
+def test_overseas_account_requests(monkeypatch, case: EndpointCase):
+    run_post_case(
+        monkeypatch,
+        overseas_account_module,
+        OverseasAccount,
+        case,
+        base_headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+        },
+    )

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_chart_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_chart_integration.py
@@ -1,0 +1,101 @@
+import pytest
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._overseas_chart_types import (
+    OverseasChartDaily,
+    OverseasChartMinute,
+    OverseasChartMonthly,
+    OverseasChartQuarterly,
+    OverseasChartTick,
+    OverseasChartWeekly,
+    OverseasChartYearly,
+)
+
+
+@pytest.mark.integration
+def test_get_tick_chart(client: Client):
+    response = client.overseas_chart.get_tick_chart(
+        stex_tp="ND", stk_cd="AAPL", tic_scope="1", upd_stkpc_tp="0", exrt_appl_tp="0"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasChartTick)
+
+
+@pytest.mark.integration
+def test_get_minute_chart(client: Client):
+    response = client.overseas_chart.get_minute_chart(
+        stex_tp="ND",
+        stk_cd="AAPL",
+        strt_dt="20240102",
+        tic_scope="1",
+        upd_stkpc_tp="0",
+        exrt_appl_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasChartMinute)
+
+
+@pytest.mark.integration
+def test_get_daily_chart(client: Client):
+    response = client.overseas_chart.get_daily_chart(
+        stex_tp="ND", stk_cd="AAPL", strt_dt="20240102", upd_stkpc_tp="0", exrt_appl_tp="0"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasChartDaily)
+
+
+@pytest.mark.integration
+def test_get_weekly_chart(client: Client):
+    response = client.overseas_chart.get_weekly_chart(
+        stex_tp="ND", stk_cd="AAPL", strt_dt="20240102", upd_stkpc_tp="0", exrt_appl_tp="0"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasChartWeekly)
+
+
+@pytest.mark.integration
+def test_get_monthly_chart(client: Client):
+    response = client.overseas_chart.get_monthly_chart(
+        stex_tp="ND", stk_cd="AAPL", strt_dt="20240102", upd_stkpc_tp="0", exrt_appl_tp="0"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasChartMonthly)
+
+
+@pytest.mark.integration
+def test_get_yearly_chart(client: Client):
+    response = client.overseas_chart.get_yearly_chart(
+        stex_tp="ND", stk_cd="AAPL", strt_dt="20240102", upd_stkpc_tp="0", exrt_appl_tp="0"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasChartYearly)
+
+
+@pytest.mark.integration
+def test_get_quarterly_chart(client: Client):
+    response = client.overseas_chart.get_quarterly_chart(
+        stex_tp="ND", stk_cd="AAPL", strt_dt="20240102", upd_stkpc_tp="0", exrt_appl_tp="0"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasChartQuarterly)

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_chart_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_chart_unit.py
@@ -1,0 +1,105 @@
+import inspect
+import re
+
+import pytest
+
+from cluefin_openapi.kiwoom import _overseas_chart as overseas_chart_module
+from cluefin_openapi.kiwoom._overseas_chart import OverseasChart
+
+from ._helpers import EndpointCase, run_post_case
+
+CALL_KWARGS = {
+    "get_tick_chart": {
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "tic_scope": "1",
+        "upd_stkpc_tp": "0",
+        "exrt_appl_tp": "0",
+    },
+    "get_minute_chart": {
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "strt_dt": "20240102",
+        "tic_scope": "1",
+        "upd_stkpc_tp": "0",
+        "exrt_appl_tp": "0",
+    },
+    "get_daily_chart": {
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "strt_dt": "20240102",
+        "upd_stkpc_tp": "0",
+        "exrt_appl_tp": "0",
+    },
+    "get_weekly_chart": {
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "strt_dt": "20240102",
+        "upd_stkpc_tp": "0",
+        "exrt_appl_tp": "0",
+    },
+    "get_monthly_chart": {
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "strt_dt": "20240102",
+        "upd_stkpc_tp": "0",
+        "exrt_appl_tp": "0",
+    },
+    "get_yearly_chart": {
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "strt_dt": "20240102",
+        "upd_stkpc_tp": "0",
+        "exrt_appl_tp": "0",
+    },
+    "get_quarterly_chart": {
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "strt_dt": "20240102",
+        "upd_stkpc_tp": "0",
+        "exrt_appl_tp": "0",
+    },
+}
+
+
+def payload(name: str):
+    return {"return_code": 0, "return_msg": "OK", "endpoint": name}
+
+
+def method_metadata(method_name: str) -> tuple[str, str]:
+    method = getattr(OverseasChart, method_name)
+    source = inspect.getsource(method)
+    api_id = re.search(r'"api-id":\s*"([^"]+)"', source).group(1)
+    model_attr = re.search(r"= (OverseasChart\w+)\.model_validate", source).group(1)
+    return api_id, model_attr
+
+
+CHART_CASES = []
+for method_name, kwargs in CALL_KWARGS.items():
+    api_id, model_attr = method_metadata(method_name)
+    case_name = method_name.removeprefix("get_")
+    CHART_CASES.append(
+        EndpointCase(
+            name=case_name,
+            method_name=method_name,
+            response_model_attr=model_attr,
+            api_id=api_id,
+            call_kwargs=dict(kwargs),
+            expected_body=dict(kwargs),
+            response_payload=payload(case_name),
+        )
+    )
+
+
+@pytest.mark.parametrize("case", CHART_CASES, ids=lambda case: case.name)
+def test_overseas_chart_requests(monkeypatch, case: EndpointCase):
+    run_post_case(
+        monkeypatch,
+        overseas_chart_module,
+        OverseasChart,
+        case,
+        base_headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+        },
+    )

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_condition_search_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_condition_search_unit.py
@@ -1,0 +1,237 @@
+"""미국주식 조건검색(웹소켓) 메시지 모델 unit 테스트.
+
+usa20280/usa20281/usa20290/usa20291 4개 TR은 웹소켓 API이므로 HTTP 클라이언트
+테스트(run_post_case)를 적용할 수 없고, 클라이언트 구현도 아직 stub
+(``_overseas_condition_search.py``)이다. 따라서 요청 모델의 wire 포맷 dump와 응답
+모델의 field/alias 매핑만 검증한다.
+"""
+
+import pytest
+
+from cluefin_openapi.kiwoom._overseas_condition_search_types import (
+    OverseasConditionSearchListItem,
+    OverseasConditionSearchListRequest,
+    OverseasConditionSearchListResponse,
+    OverseasConditionSearchRealtimeCancelRequest,
+    OverseasConditionSearchRealtimeCancelResponse,
+    OverseasConditionSearchRealtimeRequest,
+    OverseasConditionSearchRealtimeResponse,
+    OverseasConditionSearchRealtimeResultItem,
+    OverseasConditionSearchRequest,
+    OverseasConditionSearchResponse,
+    OverseasConditionSearchResultItem,
+)
+
+# ---------------------------------------------------------------------------
+# usa20280 미국주식 조건검색 목록조회
+# ---------------------------------------------------------------------------
+
+
+class TestOverseasConditionSearchList:
+    def test_request_dump_matches_wire_format(self):
+        request = OverseasConditionSearchListRequest(trnm="GCNSRLST")
+        assert request.model_dump(by_alias=True) == {"trnm": "GCNSRLST"}
+
+    def test_invalid_trnm_raises(self):
+        with pytest.raises(ValueError):
+            OverseasConditionSearchListRequest(trnm="INVALID")
+
+    def test_response_validates_and_maps_fields(self):
+        payload = {
+            "return_code": 0,
+            "return_msg": "",
+            "trnm": "GCNSRLST",
+            "data": [
+                {"seq": "0", "name": "조건식1"},
+                {"seq": "1", "name": "조건식2"},
+            ],
+        }
+
+        response = OverseasConditionSearchListResponse.model_validate(payload)
+
+        assert response.return_code == 0
+        assert response.trnm == "GCNSRLST"
+        assert len(response.data) == 2
+        assert response.data[0] == OverseasConditionSearchListItem(seq="0", name="조건식1")
+        assert response.data[1].seq == "1"
+        assert response.data[1].name == "조건식2"
+
+
+# ---------------------------------------------------------------------------
+# usa20281 미국주식 조건검색 요청 일반
+# ---------------------------------------------------------------------------
+
+
+class TestOverseasConditionSearchRequest:
+    def test_request_dump_matches_wire_format(self):
+        request = OverseasConditionSearchRequest(
+            trnm="GCNSRREQ",
+            seq="0",
+            search_type="0",
+            cont_yn="N",
+            next_key="",
+        )
+
+        assert request.model_dump(by_alias=True) == {
+            "trnm": "GCNSRREQ",
+            "seq": "0",
+            "search_type": "0",
+            "cont_yn": "N",
+            "next_key": "",
+        }
+
+    def test_request_default_cont_yn_and_next_key(self):
+        request = OverseasConditionSearchRequest(trnm="GCNSRREQ", seq="0", search_type="0")
+        assert request.cont_yn == "N"
+        assert request.next_key == ""
+
+    def test_invalid_search_type_raises(self):
+        """usa20281은 search_type이 반드시 '0' (일반조회)."""
+        with pytest.raises(ValueError):
+            OverseasConditionSearchRequest(trnm="GCNSRREQ", seq="0", search_type="1")
+
+    def test_response_maps_fid_keys_by_alias(self):
+        """usa20281 결과 항목: FID 숫자키(9001→stock_code 등) 매핑, stex_tp는 alias 없음."""
+        payload = {
+            "return_code": 0,
+            "return_msg": "",
+            "trnm": "GCNSRREQ",
+            "seq": "0",
+            "cont_yn": "N",
+            "next_key": "",
+            "data": [
+                {
+                    "9001": "NVDA",
+                    "302": "엔비디아",
+                    "10": "500.00",
+                    "25": "2",
+                    "11": "10.00",
+                    "12": "2.04",
+                    "13": "1000000",
+                    "16": "495.00",
+                    "17": "505.00",
+                    "18": "490.00",
+                    "318": "반도체",
+                    "stex_tp": "ND",
+                }
+            ],
+        }
+
+        response = OverseasConditionSearchResponse.model_validate(payload)
+
+        assert response.trnm == "GCNSRREQ"
+        assert response.cont_yn == "N"
+        item = response.data[0]
+        assert item.stock_code == "NVDA"
+        assert item.stock_name == "엔비디아"
+        assert item.current_price == "500.00"
+        assert item.prev_day_diff_sign == "2"
+        assert item.prev_day_diff == "10.00"
+        assert item.fluctuation_rate == "2.04"
+        assert item.acc_trade_volume == "1000000"
+        assert item.open_price == "495.00"
+        assert item.high_price == "505.00"
+        assert item.low_price == "490.00"
+        assert item.sub_industry == "반도체"
+        assert item.stex_tp == "ND"
+
+    def test_populate_by_name_round_trip(self):
+        item = OverseasConditionSearchResultItem(stock_code="NVDA", stock_name="엔비디아", current_price="500.00")
+        dumped = item.model_dump(by_alias=True)
+        assert dumped["9001"] == "NVDA"
+        assert dumped["302"] == "엔비디아"
+        assert dumped["10"] == "500.00"
+
+    def test_response_continuation_frame(self):
+        """cont_yn=Y 인 연속조회 프레임 - next_key 채워짐."""
+        payload = {
+            "return_code": 0,
+            "return_msg": "",
+            "trnm": "GCNSRREQ",
+            "seq": "0",
+            "cont_yn": "Y",
+            "next_key": "000123",
+            "data": [],
+        }
+        response = OverseasConditionSearchResponse.model_validate(payload)
+        assert response.cont_yn == "Y"
+        assert response.next_key == "000123"
+
+
+# ---------------------------------------------------------------------------
+# usa20290 미국주식 조건검색 요청 실시간
+# ---------------------------------------------------------------------------
+
+
+class TestOverseasConditionSearchRealtimeRequest:
+    def test_request_dump_matches_wire_format(self):
+        request = OverseasConditionSearchRealtimeRequest(trnm="GCNSRREQ", seq="0", search_type="1")
+        assert request.model_dump(by_alias=True) == {
+            "trnm": "GCNSRREQ",
+            "seq": "0",
+            "search_type": "1",
+        }
+
+    def test_invalid_search_type_raises(self):
+        """usa20290은 search_type이 반드시 '1' (조건검색+실시간조건검색)."""
+        with pytest.raises(ValueError):
+            OverseasConditionSearchRealtimeRequest(trnm="GCNSRREQ", seq="0", search_type="0")
+
+    def test_response_maps_stex_tp_alias(self):
+        """usa20290 결과 항목: jmcode는 별도 alias 없이 필드명 그대로, stexTp→stex_tp."""
+        payload = {
+            "return_code": 0,
+            "return_msg": "",
+            "trnm": "GCNSRREQ",
+            "seq": "0",
+            "data": [{"jmcode": "AAPL", "stexTp": "ND"}],
+        }
+
+        response = OverseasConditionSearchRealtimeResponse.model_validate(payload)
+
+        assert response.trnm == "GCNSRREQ"
+        assert response.seq == "0"
+        item = response.data[0]
+        assert item.jmcode == "AAPL"
+        assert item.stex_tp == "ND"
+
+    def test_populate_by_name_round_trip(self):
+        item = OverseasConditionSearchRealtimeResultItem(jmcode="AAPL", stex_tp="ND")
+        dumped = item.model_dump(by_alias=True)
+        assert dumped == {"jmcode": "AAPL", "stexTp": "ND"}
+
+    def test_response_empty_data_real_push(self):
+        """실시간 편입/이탈 이벤트가 없을 때도 data는 빈 리스트로 검증 가능."""
+        payload = {"trnm": "GCNSRREQ", "seq": "0", "data": []}
+        response = OverseasConditionSearchRealtimeResponse.model_validate(payload)
+        assert response.return_code is None
+        assert response.data == []
+
+
+# ---------------------------------------------------------------------------
+# usa20291 미국주식 조건검색 실시간 해제
+# ---------------------------------------------------------------------------
+
+
+class TestOverseasConditionSearchRealtimeCancel:
+    def test_request_dump_matches_wire_format(self):
+        request = OverseasConditionSearchRealtimeCancelRequest(trnm="GCNSRCLR", seq="0")
+        assert request.model_dump(by_alias=True) == {"trnm": "GCNSRCLR", "seq": "0"}
+
+    def test_invalid_trnm_raises(self):
+        with pytest.raises(ValueError):
+            OverseasConditionSearchRealtimeCancelRequest(trnm="INVALID", seq="0")
+
+    def test_response_requires_all_fields(self):
+        """스펙상 4개 필드 모두 Required=Y (단순 ACK 프레임) - 누락시 검증 실패."""
+        response = OverseasConditionSearchRealtimeCancelResponse.model_validate(
+            {"return_code": 0, "return_msg": "", "trnm": "GCNSRCLR", "seq": "0"}
+        )
+        assert response.return_code == 0
+        assert response.trnm == "GCNSRCLR"
+        assert response.seq == "0"
+
+        with pytest.raises(ValueError):
+            OverseasConditionSearchRealtimeCancelResponse.model_validate(
+                {"return_code": 0, "return_msg": "", "trnm": "GCNSRCLR"}
+            )

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_exchange_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_exchange_integration.py
@@ -1,0 +1,41 @@
+import pytest
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._overseas_exchange_types import (
+    OverseasExchangeEstimatedAmount,
+    OverseasExchangeRate,
+    OverseasExchangeRequest,
+)
+
+
+@pytest.mark.integration
+def test_get_estimated_exchange_amount(client: Client):
+    response = client.overseas_exchange.get_estimated_exchange_amount(exch_tp="1", fc_exmn_amt="10")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasExchangeEstimatedAmount)
+
+
+@pytest.mark.integration
+def test_get_exchange_rate(client: Client):
+    response = client.overseas_exchange.get_exchange_rate(exch_tp="1")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasExchangeRate)
+
+
+@pytest.mark.integration
+def test_request_exchange(client: Client):
+    # NOTE: ust31302 actually executes a currency exchange, so this test relies on
+    # the mock-trading (dev) environment configured via the ``client`` fixture
+    # (KIWOOM_ENV=dev) and uses a small amount to minimize impact.
+    response = client.overseas_exchange.request_exchange(exch_tp="1", fc_exmn_amt="10")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasExchangeRequest)

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_exchange_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_exchange_unit.py
@@ -1,0 +1,58 @@
+import inspect
+import re
+
+import pytest
+
+from cluefin_openapi.kiwoom import _overseas_exchange as overseas_exchange_module
+from cluefin_openapi.kiwoom._overseas_exchange import OverseasExchange
+
+from ._helpers import EndpointCase, run_post_case
+
+CALL_KWARGS = {
+    "get_estimated_exchange_amount": {"exch_tp": "1", "fc_exmn_amt": "10"},
+    "get_exchange_rate": {"exch_tp": "1"},
+    "request_exchange": {"exch_tp": "1", "fc_exmn_amt": "10"},
+}
+
+
+def payload(name: str):
+    return {"return_code": 0, "return_msg": "OK", "endpoint": name}
+
+
+def method_metadata(method_name: str) -> tuple[str, str]:
+    method = getattr(OverseasExchange, method_name)
+    source = inspect.getsource(method)
+    api_id = re.search(r'"api-id":\s*"([^"]+)"', source).group(1)
+    model_attr = re.search(r"res_body = (\w+)\.model_validate", source).group(1)
+    return api_id, model_attr
+
+
+EXCHANGE_CASES = []
+for method_name, kwargs in CALL_KWARGS.items():
+    api_id, model_attr = method_metadata(method_name)
+    case_name = method_name.removeprefix("get_").removeprefix("request_")
+    EXCHANGE_CASES.append(
+        EndpointCase(
+            name=case_name,
+            method_name=method_name,
+            response_model_attr=model_attr,
+            api_id=api_id,
+            call_kwargs=dict(kwargs),
+            expected_body=dict(kwargs),
+            response_payload=payload(case_name),
+        )
+    )
+
+
+@pytest.mark.parametrize("case", EXCHANGE_CASES, ids=lambda case: case.name)
+def test_overseas_exchange_requests(monkeypatch, case: EndpointCase):
+    run_post_case(
+        monkeypatch,
+        overseas_exchange_module,
+        OverseasExchange,
+        case,
+        base_headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+        },
+    )

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_investment_info_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_investment_info_integration.py
@@ -1,0 +1,16 @@
+import pytest
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._overseas_investment_info_types import (
+    OverseasInvestmentInfoResearch,
+)
+
+
+@pytest.mark.integration
+def test_get_research(client: Client):
+    response = client.overseas_investment_info.get_research(qry_tp="0")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasInvestmentInfoResearch)

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_investment_info_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_investment_info_unit.py
@@ -1,0 +1,56 @@
+import inspect
+import re
+
+import pytest
+
+from cluefin_openapi.kiwoom import _overseas_investment_info as overseas_investment_info_module
+from cluefin_openapi.kiwoom._overseas_investment_info import OverseasInvestmentInfo
+
+from ._helpers import EndpointCase, run_post_case
+
+CALL_KWARGS = {
+    "get_research": {"qry_tp": "0"},
+}
+
+
+def payload(name: str):
+    return {"return_code": 0, "return_msg": "OK", "endpoint": name}
+
+
+def method_metadata(method_name: str) -> tuple[str, str]:
+    method = getattr(OverseasInvestmentInfo, method_name)
+    source = inspect.getsource(method)
+    api_id = re.search(r'"api-id":\s*"([^"]+)"', source).group(1)
+    model_attr = re.search(r"res_body = (\w+)\.model_validate", source).group(1)
+    return api_id, model_attr
+
+
+INVESTMENT_INFO_CASES = []
+for method_name, kwargs in CALL_KWARGS.items():
+    api_id, model_attr = method_metadata(method_name)
+    case_name = method_name.removeprefix("get_")
+    INVESTMENT_INFO_CASES.append(
+        EndpointCase(
+            name=case_name,
+            method_name=method_name,
+            response_model_attr=model_attr,
+            api_id=api_id,
+            call_kwargs=dict(kwargs),
+            expected_body=dict(kwargs),
+            response_payload=payload(case_name),
+        )
+    )
+
+
+@pytest.mark.parametrize("case", INVESTMENT_INFO_CASES, ids=lambda case: case.name)
+def test_overseas_investment_info_requests(monkeypatch, case: EndpointCase):
+    run_post_case(
+        monkeypatch,
+        overseas_investment_info_module,
+        OverseasInvestmentInfo,
+        case,
+        base_headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+        },
+    )

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_market_condition_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_market_condition_integration.py
@@ -1,0 +1,62 @@
+import pytest
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._overseas_market_condition_types import (
+    OverseasMarketConditionCurrentPriceStockInfo,
+    OverseasMarketConditionCurrentPriceTenQuotes,
+    OverseasMarketConditionDailyExecutionHistory,
+    OverseasMarketConditionDailyStockPrice,
+    OverseasMarketConditionDetailedExecutionHistory,
+)
+
+
+@pytest.mark.integration
+def test_get_current_price_stock_info(client: Client):
+    response = client.overseas_market_condition.get_current_price_stock_info(stex_tp="ND", stk_cd="AAPL")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasMarketConditionCurrentPriceStockInfo)
+
+
+@pytest.mark.integration
+def test_get_current_price_ten_quotes(client: Client):
+    response = client.overseas_market_condition.get_current_price_ten_quotes(stex_tp="ND", stk_cd="AAPL")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasMarketConditionCurrentPriceTenQuotes)
+
+
+@pytest.mark.integration
+def test_get_detailed_execution_history(client: Client):
+    response = client.overseas_market_condition.get_detailed_execution_history(stex_tp="ND", stk_cd="AAPL")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasMarketConditionDetailedExecutionHistory)
+
+
+@pytest.mark.integration
+def test_get_daily_execution_history(client: Client):
+    response = client.overseas_market_condition.get_daily_execution_history(
+        stex_tp="ND", stk_cd="AAPL", base_dt="20240102"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasMarketConditionDailyExecutionHistory)
+
+
+@pytest.mark.integration
+def test_get_daily_stock_price(client: Client):
+    response = client.overseas_market_condition.get_daily_stock_price(stex_tp="ND", stk_cd="AAPL", base_dt="20240102")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasMarketConditionDailyStockPrice)

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_market_condition_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_market_condition_unit.py
@@ -1,0 +1,60 @@
+import inspect
+import re
+
+import pytest
+
+from cluefin_openapi.kiwoom import _overseas_market_condition as overseas_market_condition_module
+from cluefin_openapi.kiwoom._overseas_market_condition import OverseasMarketCondition
+
+from ._helpers import EndpointCase, run_post_case
+
+CALL_KWARGS = {
+    "get_current_price_stock_info": {"stex_tp": "ND", "stk_cd": "AAPL"},
+    "get_current_price_ten_quotes": {"stex_tp": "ND", "stk_cd": "AAPL"},
+    "get_detailed_execution_history": {"stex_tp": "ND", "stk_cd": "AAPL"},
+    "get_daily_execution_history": {"stex_tp": "ND", "stk_cd": "AAPL", "base_dt": "20240102"},
+    "get_daily_stock_price": {"stex_tp": "ND", "stk_cd": "AAPL", "base_dt": "20240102"},
+}
+
+
+def payload(name: str):
+    return {"return_code": 0, "return_msg": "OK", "endpoint": name}
+
+
+def method_metadata(method_name: str) -> tuple[str, str]:
+    method = getattr(OverseasMarketCondition, method_name)
+    source = inspect.getsource(method)
+    api_id = re.search(r'"api-id":\s*"([^"]+)"', source).group(1)
+    model_attr = re.search(r"= (OverseasMarketCondition\w+)\.model_validate", source).group(1)
+    return api_id, model_attr
+
+
+MARKET_CONDITION_CASES = []
+for method_name, kwargs in CALL_KWARGS.items():
+    api_id, model_attr = method_metadata(method_name)
+    case_name = method_name.removeprefix("get_")
+    MARKET_CONDITION_CASES.append(
+        EndpointCase(
+            name=case_name,
+            method_name=method_name,
+            response_model_attr=model_attr,
+            api_id=api_id,
+            call_kwargs=dict(kwargs),
+            expected_body=dict(kwargs),
+            response_payload=payload(case_name),
+        )
+    )
+
+
+@pytest.mark.parametrize("case", MARKET_CONDITION_CASES, ids=lambda case: case.name)
+def test_overseas_market_condition_requests(monkeypatch, case: EndpointCase):
+    run_post_case(
+        monkeypatch,
+        overseas_market_condition_module,
+        OverseasMarketCondition,
+        case,
+        base_headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+        },
+    )

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_order_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_order_integration.py
@@ -1,0 +1,44 @@
+import pytest
+
+from cluefin_openapi.kiwoom._client import Client
+
+
+@pytest.mark.integration
+def test_request_buy_order(client: Client):
+    response = client.overseas_order.request_buy_order(
+        stex_tp="ND", stk_cd="AAPL", ord_qty="1", trde_tp="00", ord_uv="1.00"
+    )
+    assert response is not None
+    assert response.body is not None
+
+
+@pytest.mark.integration
+def test_request_sell_order(client: Client):
+    response = client.overseas_order.request_sell_order(
+        stk_cd="AAPL", stex_tp="ND", ord_qty="1", trde_tp="00", ord_uv="100000.00"
+    )
+    assert response is not None
+    assert response.body is not None
+
+
+@pytest.mark.integration
+def test_request_modify_order(client: Client):
+    response = client.overseas_order.request_modify_order(
+        orig_ord_no="0000000", stex_tp="ND", stk_cd="AAPL", mdfy_uv="1.00"
+    )
+    assert response is not None
+    assert response.body is not None
+
+
+@pytest.mark.integration
+def test_request_cancel_order(client: Client):
+    response = client.overseas_order.request_cancel_order(orig_ord_no="0000000", stex_tp="ND", stk_cd="AAPL")
+    assert response is not None
+    assert response.body is not None
+
+
+@pytest.mark.integration
+def test_get_orderable_quantity(client: Client):
+    response = client.overseas_order.get_orderable_quantity(stk_cd="AAPL", uv="1.00", stex_tp="ND")
+    assert response is not None
+    assert response.body is not None

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_order_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_order_unit.py
@@ -1,0 +1,104 @@
+import inspect
+import re
+
+import pytest
+
+from cluefin_openapi.kiwoom import _overseas_order as overseas_order_module
+from cluefin_openapi.kiwoom._overseas_order import OverseasOrder
+
+from ._helpers import EndpointCase, run_post_case
+
+CALL_KWARGS = {
+    "request_buy_order": {
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "ord_qty": "1",
+        "trde_tp": "00",
+        "ord_uv": "1.00",
+    },
+    "request_sell_order": {
+        "stk_cd": "AAPL",
+        "stex_tp": "ND",
+        "ord_qty": "1",
+        "trde_tp": "00",
+        "ord_uv": "1.00",
+    },
+    "request_modify_order": {
+        "orig_ord_no": "0000000",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "mdfy_uv": "1.00",
+    },
+    "request_cancel_order": {
+        "orig_ord_no": "0000000",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+    },
+    "get_orderable_quantity": {
+        "stk_cd": "AAPL",
+        "uv": "1.00",
+        "stex_tp": "ND",
+    },
+}
+
+# Methods where the request body differs from the call kwargs.
+EXPECTED_BODY = {
+    "request_modify_order": {
+        "orig_ord_no": "0000000",
+        "stex_tp": "ND",
+        "stk_cd": "AAPL",
+        "mdfy_uv": "1.00",
+        "stop_pric": "",
+    },
+    "request_sell_order": {
+        "stk_cd": "AAPL",
+        "stex_tp": "ND",
+        "ord_qty": "1",
+        "ord_uv": "1.00",
+        "stop_pric": "",
+        "trde_tp": "00",
+    },
+}
+
+
+def payload(name: str):
+    return {"return_code": 0, "return_msg": "OK", "endpoint": name}
+
+
+def method_metadata(method_name: str) -> tuple[str, str]:
+    method = getattr(OverseasOrder, method_name)
+    source = inspect.getsource(method)
+    api_id = re.search(r'"api-id":\s*"([^"]+)"', source).group(1)
+    model_attr = re.search(r"= (OverseasOrder\w+)\.model_validate", source).group(1)
+    return api_id, model_attr
+
+
+ORDER_CASES = []
+for method_name, kwargs in CALL_KWARGS.items():
+    api_id, model_attr = method_metadata(method_name)
+    case_name = method_name.removeprefix("request_").removeprefix("get_")
+    ORDER_CASES.append(
+        EndpointCase(
+            name=case_name,
+            method_name=method_name,
+            response_model_attr=model_attr,
+            api_id=api_id,
+            call_kwargs=dict(kwargs),
+            expected_body=dict(EXPECTED_BODY.get(method_name, kwargs)),
+            response_payload=payload(case_name),
+        )
+    )
+
+
+@pytest.mark.parametrize("case", ORDER_CASES, ids=lambda case: case.name)
+def test_overseas_order_requests(monkeypatch, case: EndpointCase):
+    run_post_case(
+        monkeypatch,
+        overseas_order_module,
+        OverseasOrder,
+        case,
+        base_headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+        },
+    )

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_rank_info_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_rank_info_integration.py
@@ -1,0 +1,665 @@
+import pytest
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._overseas_rank_info_types import (
+    OverseasRankInfoConsecutiveRiseFallRankEtf,
+    OverseasRankInfoConsecutiveRiseFallRankStock,
+    OverseasRankInfoConsecutiveRiseFallRankWatchlist,
+    OverseasRankInfoCumulativeFluctuationTopEtf,
+    OverseasRankInfoCumulativeFluctuationTopStock,
+    OverseasRankInfoDaytimeTradingDisparityTopEtf,
+    OverseasRankInfoDaytimeTradingDisparityTopStock,
+    OverseasRankInfoHighLowPriceRiseFallEtf,
+    OverseasRankInfoHighLowPriceRiseFallStock,
+    OverseasRankInfoKiwoomTradingTopEtf,
+    OverseasRankInfoKiwoomTradingTopStock,
+    OverseasRankInfoMarketCapTopEtf,
+    OverseasRankInfoMarketCapTopStock,
+    OverseasRankInfoOpenPriceFluctuationRankEtf,
+    OverseasRankInfoOpenPriceFluctuationRankStock,
+    OverseasRankInfoOpenPriceFluctuationRankWatchlist,
+    OverseasRankInfoPeriodFluctuationRankEtf,
+    OverseasRankInfoPeriodFluctuationRankStock,
+    OverseasRankInfoPeriodFluctuationRankWatchlist,
+    OverseasRankInfoPreviousDayFluctuationRankEtf,
+    OverseasRankInfoPreviousDayFluctuationRankStock,
+    OverseasRankInfoPreviousDayTradingTopEtf,
+    OverseasRankInfoPreviousDayTradingTopStock,
+    OverseasRankInfoQuoteRemainingVolumeTopEtf,
+    OverseasRankInfoQuoteRemainingVolumeTopStock,
+    OverseasRankInfoRealtimeSymbolQueryRank,
+    OverseasRankInfoSpecificDateRiseFallEtf,
+    OverseasRankInfoSpecificDateRiseFallStock,
+    OverseasRankInfoTodayTradingValueTopEtf,
+    OverseasRankInfoTodayTradingValueTopStock,
+    OverseasRankInfoTodayTradingVolumeTopEtf,
+    OverseasRankInfoTodayTradingVolumeTopStock,
+    OverseasRankInfoTurnoverRateTopEtf,
+    OverseasRankInfoTurnoverRateTopStock,
+    OverseasRankInfoWatchlistRegistrationTop,
+)
+
+
+@pytest.mark.integration
+def test_get_realtime_symbol_query_rank(client: Client):
+    response = client.overseas_rank_info.get_realtime_symbol_query_rank(svc_type="B286")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoRealtimeSymbolQueryRank)
+
+
+@pytest.mark.integration
+def test_get_watchlist_registration_top(client: Client):
+    response = client.overseas_rank_info.get_watchlist_registration_top(dt_unit_tp="D", stk_tp="A")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoWatchlistRegistrationTop)
+
+
+@pytest.mark.integration
+def test_get_period_fluctuation_rank_stock(client: Client):
+    response = client.overseas_rank_info.get_period_fluctuation_rank_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        stk_cnd="0",
+        tm="1",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoPeriodFluctuationRankStock)
+
+
+@pytest.mark.integration
+def test_get_period_fluctuation_rank_etf(client: Client):
+    response = client.overseas_rank_info.get_period_fluctuation_rank_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        stk_cnd="0",
+        tm="1",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoPeriodFluctuationRankEtf)
+
+
+@pytest.mark.integration
+def test_get_period_fluctuation_rank_watchlist(client: Client):
+    response = client.overseas_rank_info.get_period_fluctuation_rank_watchlist(
+        stex_tp="1",
+        stk_cd=[{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        tm="1",
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoPeriodFluctuationRankWatchlist)
+
+
+@pytest.mark.integration
+def test_get_today_trading_volume_top_stock(client: Client):
+    response = client.overseas_rank_info.get_today_trading_volume_top_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        trde_qty_tp="0",
+        qry_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoTodayTradingVolumeTopStock)
+
+
+@pytest.mark.integration
+def test_get_today_trading_volume_top_etf(client: Client):
+    response = client.overseas_rank_info.get_today_trading_volume_top_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        trde_qty_tp="0",
+        qry_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoTodayTradingVolumeTopEtf)
+
+
+@pytest.mark.integration
+def test_get_today_trading_value_top_stock(client: Client):
+    response = client.overseas_rank_info.get_today_trading_value_top_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoTodayTradingValueTopStock)
+
+
+@pytest.mark.integration
+def test_get_today_trading_value_top_etf(client: Client):
+    response = client.overseas_rank_info.get_today_trading_value_top_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoTodayTradingValueTopEtf)
+
+
+@pytest.mark.integration
+def test_get_market_cap_top_stock(client: Client):
+    response = client.overseas_rank_info.get_market_cap_top_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoMarketCapTopStock)
+
+
+@pytest.mark.integration
+def test_get_market_cap_top_etf(client: Client):
+    response = client.overseas_rank_info.get_market_cap_top_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoMarketCapTopEtf)
+
+
+@pytest.mark.integration
+def test_get_kiwoom_trading_top_stock(client: Client):
+    response = client.overseas_rank_info.get_kiwoom_trading_top_stock(qry_tp="1", dt_unit_tp="1")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoKiwoomTradingTopStock)
+
+
+@pytest.mark.integration
+def test_get_kiwoom_trading_top_etf(client: Client):
+    response = client.overseas_rank_info.get_kiwoom_trading_top_etf(qry_tp="1", dt_unit_tp="1")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoKiwoomTradingTopEtf)
+
+
+@pytest.mark.integration
+def test_get_previous_day_fluctuation_rank_stock(client: Client):
+    response = client.overseas_rank_info.get_previous_day_fluctuation_rank_stock(
+        stex_tp="1",
+        inds_cd="000",
+        inds_cls_tp="0",
+        sort_tp="1",
+        stk_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        trde_qty_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoPreviousDayFluctuationRankStock)
+
+
+@pytest.mark.integration
+def test_get_previous_day_fluctuation_rank_etf(client: Client):
+    response = client.overseas_rank_info.get_previous_day_fluctuation_rank_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        sort_tp="1",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        trde_qty_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoPreviousDayFluctuationRankEtf)
+
+
+@pytest.mark.integration
+def test_get_open_price_fluctuation_rank_stock(client: Client):
+    response = client.overseas_rank_info.get_open_price_fluctuation_rank_stock(
+        stex_tp="1",
+        inds_cd="000",
+        trde_qty_tp="0",
+        stk_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        sort_tp="1",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoOpenPriceFluctuationRankStock)
+
+
+@pytest.mark.integration
+def test_get_open_price_fluctuation_rank_etf(client: Client):
+    response = client.overseas_rank_info.get_open_price_fluctuation_rank_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        sort_tp="1",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoOpenPriceFluctuationRankEtf)
+
+
+@pytest.mark.integration
+def test_get_open_price_fluctuation_rank_watchlist(client: Client):
+    response = client.overseas_rank_info.get_open_price_fluctuation_rank_watchlist(
+        stex_tp="1",
+        stk_cd=[{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        sort_tp="1",
+        stk_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        trde_qty_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoOpenPriceFluctuationRankWatchlist)
+
+
+@pytest.mark.integration
+def test_get_cumulative_fluctuation_top_stock(client: Client):
+    response = client.overseas_rank_info.get_cumulative_fluctuation_top_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        sort_tp="0",
+        pric_cnd1="",
+        pric_cnd2="",
+        base_dt="20240102",
+        stk_cnd="0",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoCumulativeFluctuationTopStock)
+
+
+@pytest.mark.integration
+def test_get_cumulative_fluctuation_top_etf(client: Client):
+    response = client.overseas_rank_info.get_cumulative_fluctuation_top_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        sort_tp="0",
+        pric_cnd1="",
+        pric_cnd2="",
+        base_dt="20240102",
+        stk_cnd="0",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoCumulativeFluctuationTopEtf)
+
+
+@pytest.mark.integration
+def test_get_previous_day_trading_top_stock(client: Client):
+    response = client.overseas_rank_info.get_previous_day_trading_top_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        qry_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoPreviousDayTradingTopStock)
+
+
+@pytest.mark.integration
+def test_get_previous_day_trading_top_etf(client: Client):
+    response = client.overseas_rank_info.get_previous_day_trading_top_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        qry_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoPreviousDayTradingTopEtf)
+
+
+@pytest.mark.integration
+def test_get_high_low_price_rise_fall_stock(client: Client):
+    response = client.overseas_rank_info.get_high_low_price_rise_fall_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        sort_tp="0",
+        dt_tp="0",
+        stk_cnd="0",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoHighLowPriceRiseFallStock)
+
+
+@pytest.mark.integration
+def test_get_high_low_price_rise_fall_etf(client: Client):
+    response = client.overseas_rank_info.get_high_low_price_rise_fall_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        sort_tp="0",
+        dt_tp="0",
+        stk_cnd="0",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoHighLowPriceRiseFallEtf)
+
+
+@pytest.mark.integration
+def test_get_specific_date_rise_fall_stock(client: Client):
+    response = client.overseas_rank_info.get_specific_date_rise_fall_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_qty_tp="0",
+        trde_prica_cnd="0",
+        base_dt="20240102",
+        sort_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoSpecificDateRiseFallStock)
+
+
+@pytest.mark.integration
+def test_get_specific_date_rise_fall_etf(client: Client):
+    response = client.overseas_rank_info.get_specific_date_rise_fall_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_qty_tp="0",
+        trde_prica_cnd="0",
+        base_dt="20240102",
+        sort_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoSpecificDateRiseFallEtf)
+
+
+@pytest.mark.integration
+def test_get_turnover_rate_top_stock(client: Client):
+    response = client.overseas_rank_info.get_turnover_rate_top_stock(
+        stex_tp="1",
+        inds_cd="000",
+        trde_qty_tp="0",
+        stk_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoTurnoverRateTopStock)
+
+
+@pytest.mark.integration
+def test_get_turnover_rate_top_etf(client: Client):
+    response = client.overseas_rank_info.get_turnover_rate_top_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoTurnoverRateTopEtf)
+
+
+@pytest.mark.integration
+def test_get_consecutive_rise_fall_rank_stock(client: Client):
+    response = client.overseas_rank_info.get_consecutive_rise_fall_rank_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        sort_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoConsecutiveRiseFallRankStock)
+
+
+@pytest.mark.integration
+def test_get_consecutive_rise_fall_rank_etf(client: Client):
+    response = client.overseas_rank_info.get_consecutive_rise_fall_rank_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        sort_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoConsecutiveRiseFallRankEtf)
+
+
+@pytest.mark.integration
+def test_get_consecutive_rise_fall_rank_watchlist(client: Client):
+    response = client.overseas_rank_info.get_consecutive_rise_fall_rank_watchlist(
+        stex_tp="1",
+        stk_cd=[{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        sort_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoConsecutiveRiseFallRankWatchlist)
+
+
+@pytest.mark.integration
+def test_get_quote_remaining_volume_top_stock(client: Client):
+    response = client.overseas_rank_info.get_quote_remaining_volume_top_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        sort_tp="1",
+        stk_cnd="0",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoQuoteRemainingVolumeTopStock)
+
+
+@pytest.mark.integration
+def test_get_quote_remaining_volume_top_etf(client: Client):
+    response = client.overseas_rank_info.get_quote_remaining_volume_top_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        sort_tp="1",
+        stk_cnd="0",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoQuoteRemainingVolumeTopEtf)
+
+
+@pytest.mark.integration
+def test_get_daytime_trading_disparity_top_stock(client: Client):
+    response = client.overseas_rank_info.get_daytime_trading_disparity_top_stock(
+        stex_tp="1",
+        inds_cd="000",
+        inds_cls_tp="0",
+        stk_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_qty_tp="0",
+        trde_prica_cnd="0",
+        sort_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoDaytimeTradingDisparityTopStock)
+
+
+@pytest.mark.integration
+def test_get_daytime_trading_disparity_top_etf(client: Client):
+    response = client.overseas_rank_info.get_daytime_trading_disparity_top_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_qty_tp="0",
+        trde_prica_cnd="0",
+        sort_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasRankInfoDaytimeTradingDisparityTopEtf)

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_rank_info_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_rank_info_unit.py
@@ -1,0 +1,370 @@
+import inspect
+import re
+
+import pytest
+
+from cluefin_openapi.kiwoom import _overseas_rank_info as overseas_rank_info_module
+from cluefin_openapi.kiwoom._overseas_rank_info import OverseasRankInfo
+
+from ._helpers import EndpointCase, run_post_case
+
+CALL_KWARGS = {
+    "get_realtime_symbol_query_rank": {"svc_type": "B286"},
+    "get_watchlist_registration_top": {"dt_unit_tp": "D", "stk_tp": "A"},
+    "get_period_fluctuation_rank_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "stk_cnd": "0",
+        "tm": "1",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_period_fluctuation_rank_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "stk_cnd": "0",
+        "tm": "1",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_period_fluctuation_rank_watchlist": {
+        "stex_tp": "1",
+        "stk_cd": [{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        "tm": "1",
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_today_trading_volume_top_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "trde_qty_tp": "0",
+        "qry_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_today_trading_volume_top_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "trde_qty_tp": "0",
+        "qry_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_today_trading_value_top_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_today_trading_value_top_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_market_cap_top_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_market_cap_top_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_kiwoom_trading_top_stock": {"qry_tp": "1", "dt_unit_tp": "1"},
+    "get_kiwoom_trading_top_etf": {"qry_tp": "1", "dt_unit_tp": "1"},
+    "get_previous_day_fluctuation_rank_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "inds_cls_tp": "0",
+        "sort_tp": "1",
+        "stk_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "trde_qty_tp": "0",
+    },
+    "get_previous_day_fluctuation_rank_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "sort_tp": "1",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "trde_qty_tp": "0",
+    },
+    "get_open_price_fluctuation_rank_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "trde_qty_tp": "0",
+        "stk_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "sort_tp": "1",
+    },
+    "get_open_price_fluctuation_rank_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "sort_tp": "1",
+    },
+    "get_open_price_fluctuation_rank_watchlist": {
+        "stex_tp": "1",
+        "stk_cd": [{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        "sort_tp": "1",
+        "stk_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "trde_qty_tp": "0",
+    },
+    "get_cumulative_fluctuation_top_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "sort_tp": "0",
+        "pric_cnd1": "",
+        "pric_cnd2": "",
+        "base_dt": "20240102",
+        "stk_cnd": "0",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_cumulative_fluctuation_top_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "sort_tp": "0",
+        "pric_cnd1": "",
+        "pric_cnd2": "",
+        "base_dt": "20240102",
+        "stk_cnd": "0",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_previous_day_trading_top_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "qry_tp": "0",
+    },
+    "get_previous_day_trading_top_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "qry_tp": "0",
+    },
+    "get_high_low_price_rise_fall_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "sort_tp": "0",
+        "dt_tp": "0",
+        "stk_cnd": "0",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_high_low_price_rise_fall_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "sort_tp": "0",
+        "dt_tp": "0",
+        "stk_cnd": "0",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_specific_date_rise_fall_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_qty_tp": "0",
+        "trde_prica_cnd": "0",
+        "base_dt": "20240102",
+        "sort_tp": "0",
+    },
+    "get_specific_date_rise_fall_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_qty_tp": "0",
+        "trde_prica_cnd": "0",
+        "base_dt": "20240102",
+        "sort_tp": "0",
+    },
+    "get_turnover_rate_top_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "trde_qty_tp": "0",
+        "stk_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_turnover_rate_top_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_consecutive_rise_fall_rank_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "sort_tp": "0",
+    },
+    "get_consecutive_rise_fall_rank_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "sort_tp": "0",
+    },
+    "get_consecutive_rise_fall_rank_watchlist": {
+        "stex_tp": "1",
+        "stk_cd": [{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "sort_tp": "0",
+    },
+    "get_quote_remaining_volume_top_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "sort_tp": "1",
+        "stk_cnd": "0",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_quote_remaining_volume_top_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "sort_tp": "1",
+        "stk_cnd": "0",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_daytime_trading_disparity_top_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "inds_cls_tp": "0",
+        "stk_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_qty_tp": "0",
+        "trde_prica_cnd": "0",
+        "sort_tp": "0",
+    },
+    "get_daytime_trading_disparity_top_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_qty_tp": "0",
+        "trde_prica_cnd": "0",
+        "sort_tp": "0",
+    },
+}
+
+# All body parameters are supplied in ``CALL_KWARGS`` and the request body is a
+# 1:1 copy of those values (including the ``stk_cd`` watchlist Map list), so the
+# expected body equals the call kwargs for every endpoint.
+EXPECTED_BODY: dict[str, dict] = {}
+
+
+def payload(name: str):
+    return {"return_code": 0, "return_msg": "OK", "endpoint": name}
+
+
+def method_metadata(method_name: str) -> tuple[str, str]:
+    method = getattr(OverseasRankInfo, method_name)
+    source = inspect.getsource(method)
+    api_id = re.search(r'"api-id":\s*"([^"]+)"', source).group(1)
+    model_attr = re.search(r"= (OverseasRankInfo\w+)\.model_validate", source).group(1)
+    return api_id, model_attr
+
+
+RANK_INFO_CASES = []
+for method_name, kwargs in CALL_KWARGS.items():
+    api_id, model_attr = method_metadata(method_name)
+    case_name = method_name.removeprefix("get_")
+    RANK_INFO_CASES.append(
+        EndpointCase(
+            name=case_name,
+            method_name=method_name,
+            response_model_attr=model_attr,
+            api_id=api_id,
+            call_kwargs=dict(kwargs),
+            expected_body=dict(EXPECTED_BODY.get(method_name, kwargs)),
+            response_payload=payload(case_name),
+        )
+    )
+
+
+@pytest.mark.parametrize("case", RANK_INFO_CASES, ids=lambda case: case.name)
+def test_overseas_rank_info_requests(monkeypatch, case: EndpointCase):
+    run_post_case(
+        monkeypatch,
+        overseas_rank_info_module,
+        OverseasRankInfo,
+        case,
+        base_headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+        },
+    )

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_realtime_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_realtime_unit.py
@@ -1,0 +1,422 @@
+"""미국주식 실시간 시세(웹소켓) 메시지 모델 unit 테스트.
+
+F4/F5/FE/FT 4개 TR은 웹소켓 API이므로 HTTP 클라이언트 테스트(run_post_case)를 적용할 수
+없고, 클라이언트 구현도 아직 stub(``_overseas_realtime.py``)이다. 따라서 등록/해지 요청
+프레임과 TR별 응답(values) 프레임의 pydantic 직렬화/역직렬화만 검증한다.
+"""
+
+import pytest
+
+from cluefin_openapi.kiwoom._overseas_realtime_types import (
+    OverseasRealtimeExecution,
+    OverseasRealtimeExecutionDataItem,
+    OverseasRealtimeExecutionPrice,
+    OverseasRealtimeExecutionPriceDataItem,
+    OverseasRealtimeExecutionPriceValues,
+    OverseasRealtimeExecutionValues,
+    OverseasRealtimeOrderConfirmation,
+    OverseasRealtimeOrderConfirmationDataItem,
+    OverseasRealtimeOrderConfirmationValues,
+    OverseasRealtimeRegisterData,
+    OverseasRealtimeRegisterItem,
+    OverseasRealtimeRequest,
+    OverseasRealtimeTenQuotes,
+    OverseasRealtimeTenQuotesDataItem,
+    OverseasRealtimeTenQuotesValues,
+)
+
+# ---------------------------------------------------------------------------
+# 등록/해지 요청 프레임 (F4/F5/FE/FT 공통)
+# ---------------------------------------------------------------------------
+
+
+class TestOverseasRealtimeRequest:
+    def test_register_request_dump_matches_wire_format(self):
+        """REG 요청: trnm/grp_no/refresh/data[item[jmcode,stex_tp],type] 그대로 dump."""
+        request = OverseasRealtimeRequest(
+            trnm="REG",
+            grp_no="1",
+            refresh="1",
+            data=[
+                OverseasRealtimeRegisterData(
+                    item=[OverseasRealtimeRegisterItem(jmcode="NVDA", stex_tp="ND")],
+                    type=["F4"],
+                )
+            ],
+        )
+
+        assert request.model_dump(by_alias=True) == {
+            "trnm": "REG",
+            "grp_no": "1",
+            "refresh": "1",
+            "data": [{"item": [{"jmcode": "NVDA", "stex_tp": "ND"}], "type": ["F4"]}],
+        }
+
+    def test_remove_request_dump_matches_wire_format(self):
+        """REMOVE 요청: 해지시 refresh 값은 스펙상 불필요하지만 필수 필드이므로 그대로 전달."""
+        request = OverseasRealtimeRequest(
+            trnm="REMOVE",
+            grp_no="1",
+            refresh="0",
+            data=[
+                OverseasRealtimeRegisterData(
+                    item=[OverseasRealtimeRegisterItem(jmcode="AAPL", stex_tp="NA")],
+                    type=["FT"],
+                )
+            ],
+        )
+
+        assert request.model_dump(by_alias=True) == {
+            "trnm": "REMOVE",
+            "grp_no": "1",
+            "refresh": "0",
+            "data": [{"item": [{"jmcode": "AAPL", "stex_tp": "NA"}], "type": ["FT"]}],
+        }
+
+    def test_register_request_multiple_items_and_types(self):
+        """복수 종목/복수 TR type 등록 요청도 wire 포맷대로 dump."""
+        request = OverseasRealtimeRequest(
+            trnm="REG",
+            grp_no="1",
+            refresh="1",
+            data=[
+                OverseasRealtimeRegisterData(
+                    item=[
+                        OverseasRealtimeRegisterItem(jmcode="NVDA", stex_tp="ND"),
+                        OverseasRealtimeRegisterItem(jmcode="AAPL", stex_tp="ND"),
+                    ],
+                    type=["FE", "FT"],
+                )
+            ],
+        )
+
+        dumped = request.model_dump(by_alias=True)
+        assert dumped["data"][0]["item"] == [
+            {"jmcode": "NVDA", "stex_tp": "ND"},
+            {"jmcode": "AAPL", "stex_tp": "ND"},
+        ]
+        assert dumped["data"][0]["type"] == ["FE", "FT"]
+
+    def test_invalid_trnm_raises(self):
+        with pytest.raises(ValueError):
+            OverseasRealtimeRequest(trnm="INVALID", grp_no="1", refresh="1")
+
+    def test_invalid_refresh_raises(self):
+        with pytest.raises(ValueError):
+            OverseasRealtimeRequest(trnm="REG", grp_no="1", refresh="2")
+
+
+# ---------------------------------------------------------------------------
+# F4 미국주식 실시간 주문 확인
+# ---------------------------------------------------------------------------
+
+
+class TestOverseasRealtimeOrderConfirmation:
+    def test_register_ack_frame_validates(self):
+        """등록/해지 요청에 대한 ACK 프레임 (return_code 존재)."""
+        frame = OverseasRealtimeOrderConfirmation.model_validate(
+            {"return_code": 0, "return_msg": "", "trnm": "REG", "data": []}
+        )
+
+        assert frame.return_code == 0
+        assert frame.return_msg == ""
+        assert frame.trnm == "REG"
+        assert frame.data == []
+
+    def test_real_frame_maps_fid_values_by_alias(self):
+        """실시간 수신 프레임(REAL): FID 숫자키 values → 필드 alias 매핑."""
+        payload = {
+            "return_msg": "",
+            "trnm": "REAL",
+            "data": [
+                {
+                    "type": "F4",
+                    "name": "미국주식실시간주문확인",
+                    "stexTp": "ND",
+                    "item": "NVDA",
+                    "values": {
+                        "9201": "1234567890",
+                        "9203": "000001",
+                        "9001": "NVDA",
+                        "905": "10",
+                        "907": "02",
+                        "904": "",
+                        "900": "10",
+                        "901": "500.00",
+                        "906": "1",
+                        "913": "접수",
+                        "908": "20250102103000",
+                        "50810": "",
+                        "8043": "USD",
+                        "50841": "0",
+                        "55190": "US",
+                        "1091": "미국",
+                        "50072": "매수",
+                        "302": "엔비디아",
+                        "50073": "지정가",
+                    },
+                }
+            ],
+        }
+
+        frame = OverseasRealtimeOrderConfirmation.model_validate(payload)
+
+        assert frame.return_code is None
+        assert frame.trnm == "REAL"
+        item = frame.data[0]
+        assert item.type == "F4"
+        assert item.stex_tp == "ND"
+        assert item.item == "NVDA"
+
+        values = item.values
+        assert values.account_no == "1234567890"
+        assert values.order_no == "000001"
+        assert values.stock_code == "NVDA"
+        assert values.order_type == "10"
+        assert values.sell_buy_type == "02"
+        assert values.order_quantity == "10"
+        assert values.order_price == "500.00"
+        assert values.order_status == "접수"
+        assert values.currency_code == "USD"
+        assert values.country_code == "US"
+        assert values.country_name == "미국"
+        assert values.sell_buy_type_name == "매수"
+        assert values.stock_name == "엔비디아"
+        assert values.trade_type_name == "지정가"
+
+    def test_populate_by_name_round_trip(self):
+        """필드명으로 생성 → by_alias dump시 FID 키로 나오는지 확인."""
+        values = OverseasRealtimeOrderConfirmationValues(
+            account_no="1234567890",
+            order_no="000001",
+            stock_code="NVDA",
+        )
+
+        dumped = values.model_dump(by_alias=True)
+        assert dumped["9201"] == "1234567890"
+        assert dumped["9203"] == "000001"
+        assert dumped["9001"] == "NVDA"
+
+    def test_data_item_default_factory(self):
+        """values 미지정시 default_factory로 빈 values가 채워짐."""
+        item = OverseasRealtimeOrderConfirmationDataItem(type="F4", item="NVDA")
+        assert item.values.account_no == ""
+
+
+# ---------------------------------------------------------------------------
+# F5 미국주식 실시간 체결
+# ---------------------------------------------------------------------------
+
+
+class TestOverseasRealtimeExecution:
+    def test_real_frame_maps_fid_values_by_alias(self):
+        payload = {
+            "trnm": "REAL",
+            "data": [
+                {
+                    "type": "F5",
+                    "name": "미국주식실시간체결",
+                    "item": "AAPL",
+                    "values": {
+                        "1091": "미국",
+                        "8046": "NAS",
+                        "9001": "AAPL",
+                        "302": "애플",
+                        "904": "",
+                        "9203": "000002",
+                        "905": "10",
+                        "907": "01",
+                        "908": "20250102103000",
+                        "913": "체결완료",
+                        "900": "5",
+                        "901": "190.00",
+                        "902": "0",
+                        "909": "000010",
+                        "910": "190.00",
+                        "911": "5",
+                        "930": "100",
+                        "931": "180.00",
+                        "8018": "50.00",
+                        "8019": "2.5",
+                        "8043": "USD",
+                        "9201": "1234567890",
+                        "50072": "매도",
+                        "50073": "지정가",
+                    },
+                }
+            ],
+        }
+
+        frame = OverseasRealtimeExecution.model_validate(payload)
+        assert frame.return_code is None
+        assert frame.trnm == "REAL"
+
+        values = frame.data[0].values
+        assert values.country_name == "미국"
+        assert values.exchange_code == "NAS"
+        assert values.stock_code == "AAPL"
+        assert values.stock_name == "애플"
+        assert values.order_no == "000002"
+        assert values.order_status == "체결완료"
+        assert values.execution_no == "000010"
+        assert values.execution_price == "190.00"
+        assert values.execution_quantity == "5"
+        assert values.holding_quantity == "100"
+        assert values.purchase_unit_price == "180.00"
+        assert values.profit_loss_amount == "50.00"
+        assert values.profit_loss_rate == "2.5"
+        assert values.account_no == "1234567890"
+        assert values.sell_buy_type_name == "매도"
+        assert values.trade_type_name == "지정가"
+
+    def test_register_ack_frame_return_code_present(self):
+        frame = OverseasRealtimeExecution.model_validate(
+            {"return_code": 1, "return_msg": "오류", "trnm": "REG", "data": []}
+        )
+        assert frame.return_code == 1
+        assert frame.return_msg == "오류"
+
+    def test_data_item_default_values(self):
+        item = OverseasRealtimeExecutionDataItem(type="F5", item="AAPL")
+        assert isinstance(item.values, OverseasRealtimeExecutionValues)
+        assert item.values.stock_code == ""
+
+
+# ---------------------------------------------------------------------------
+# FE 미국주식 실시간 체결가
+# ---------------------------------------------------------------------------
+
+
+class TestOverseasRealtimeExecutionPrice:
+    def test_real_frame_maps_fid_values_by_alias(self):
+        payload = {
+            "trnm": "REAL",
+            "data": [
+                {
+                    "type": "FE",
+                    "name": "미국주식실시간체결가",
+                    "item": "TSLA",
+                    "values": {
+                        "10": "250.00",
+                        "11": "5.00",
+                        "12": "2.04",
+                        "13": "1000000",
+                        "14": "250000000",
+                        "15": "10",
+                        "16": "245.00",
+                        "17": "252.00",
+                        "18": "244.00",
+                        "20": "103000",
+                        "22": "20250102",
+                        "25": "2",
+                        "27": "250.10",
+                        "28": "249.90",
+                        "30": "1.2",
+                        "228": "120",
+                        "290": "1",
+                        "51020": "20250101223000",
+                    },
+                }
+            ],
+        }
+
+        frame = OverseasRealtimeExecutionPrice.model_validate(payload)
+        assert frame.return_code is None
+
+        values = frame.data[0].values
+        assert values.current_price == "250.00"
+        assert values.prev_day_diff == "5.00"
+        assert values.fluctuation_rate == "2.04"
+        assert values.acc_trade_volume == "1000000"
+        assert values.acc_trade_value == "250000000"
+        assert values.execution_volume == "10"
+        assert values.open_price == "245.00"
+        assert values.high_price == "252.00"
+        assert values.low_price == "244.00"
+        assert values.time == "103000"
+        assert values.execution_date == "20250102"
+        assert values.prev_day_diff_sign == "2"
+        assert values.best_ask_price == "250.10"
+        assert values.best_bid_price == "249.90"
+        assert values.prev_day_volume_ratio == "1.2"
+        assert values.execution_strength == "120"
+        assert values.market_type == "1"
+        assert values.local_execution_time == "20250101223000"
+
+    def test_populate_by_name_round_trip(self):
+        values = OverseasRealtimeExecutionPriceValues(current_price="250.00", time="103000")
+        dumped = values.model_dump(by_alias=True)
+        assert dumped["10"] == "250.00"
+        assert dumped["20"] == "103000"
+
+    def test_data_item_default_values(self):
+        item = OverseasRealtimeExecutionPriceDataItem(type="FE", item="TSLA")
+        assert item.values.current_price == ""
+
+
+# ---------------------------------------------------------------------------
+# FT 미국주식 10호가
+# ---------------------------------------------------------------------------
+
+
+class TestOverseasRealtimeTenQuotes:
+    def test_real_frame_maps_fid_values_by_alias(self):
+        payload = {
+            "trnm": "REAL",
+            "data": [
+                {
+                    "type": "FT",
+                    "name": "미국주식10호가",
+                    "item": "NVDA",
+                    "values": {
+                        "21": "103000",
+                        "41": "500.10",
+                        "61": "100",
+                        "81": "0",
+                        "51": "500.00",
+                        "71": "200",
+                        "91": "0",
+                        "50": "505.10",
+                        "70": "10",
+                        "90": "0",
+                        "60": "504.00",
+                        "80": "20",
+                        "100": "0",
+                        "121": "1000",
+                        "122": "10",
+                        "125": "1200",
+                        "126": "-5",
+                    },
+                }
+            ],
+        }
+
+        frame = OverseasRealtimeTenQuotes.model_validate(payload)
+        assert frame.return_code is None
+
+        values = frame.data[0].values
+        assert values.time == "103000"
+        assert values.ask_price_1 == "500.10"
+        assert values.ask_volume_1 == "100"
+        assert values.ask_prev_diff_1 == "0"
+        assert values.bid_price_1 == "500.00"
+        assert values.bid_volume_1 == "200"
+        assert values.bid_prev_diff_1 == "0"
+        assert values.ask_price_10 == "505.10"
+        assert values.ask_volume_10 == "10"
+        assert values.ask_prev_diff_10 == "0"
+        assert values.bid_price_10 == "504.00"
+        assert values.bid_volume_10 == "20"
+        assert values.bid_prev_diff_10 == "0"
+        assert values.total_ask_volume == "1000"
+        assert values.total_ask_volume_prev_diff == "10"
+        assert values.total_bid_volume == "1200"
+        assert values.total_bid_volume_prev_diff == "-5"
+
+    def test_data_item_default_values(self):
+        item = OverseasRealtimeTenQuotesDataItem(type="FT", item="NVDA")
+        assert item.values.time == ""
+
+    def test_all_65_fields_present(self):
+        """스펙상 65개 FID 필드(호가/잔량/직전대비 10단계×6 + 시간 1 + 총잔량류 4) 존재 확인."""
+        assert len(OverseasRealtimeTenQuotesValues.model_fields) == 65

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_sector_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_sector_integration.py
@@ -1,0 +1,27 @@
+import pytest
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._overseas_sector_types import (
+    OverseasSectorIndustryFluctuationRank,
+    OverseasSectorIndustryPeriodProfitRate,
+)
+
+
+@pytest.mark.integration
+def test_get_industry_period_profit_rate(client: Client):
+    response = client.overseas_sector.get_industry_period_profit_rate(stex_tp="3", inds_cd="000")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasSectorIndustryPeriodProfitRate)
+
+
+@pytest.mark.integration
+def test_get_industry_fluctuation_rank(client: Client):
+    response = client.overseas_sector.get_industry_fluctuation_rank(stex_tp="3", sort_tp="1", inds_cd="000")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasSectorIndustryFluctuationRank)

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_sector_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_sector_unit.py
@@ -1,0 +1,57 @@
+import inspect
+import re
+
+import pytest
+
+from cluefin_openapi.kiwoom import _overseas_sector as overseas_sector_module
+from cluefin_openapi.kiwoom._overseas_sector import OverseasSector
+
+from ._helpers import EndpointCase, run_post_case
+
+CALL_KWARGS = {
+    "get_industry_period_profit_rate": {"stex_tp": "3", "inds_cd": "000"},
+    "get_industry_fluctuation_rank": {"stex_tp": "3", "sort_tp": "1", "inds_cd": "000"},
+}
+
+
+def payload(name: str):
+    return {"return_code": 0, "return_msg": "OK", "endpoint": name}
+
+
+def method_metadata(method_name: str) -> tuple[str, str]:
+    method = getattr(OverseasSector, method_name)
+    source = inspect.getsource(method)
+    api_id = re.search(r'"api-id":\s*"([^"]+)"', source).group(1)
+    model_attr = re.search(r"res_body = (\w+)\.model_validate", source).group(1)
+    return api_id, model_attr
+
+
+SECTOR_CASES = []
+for method_name, kwargs in CALL_KWARGS.items():
+    api_id, model_attr = method_metadata(method_name)
+    case_name = method_name.removeprefix("get_")
+    SECTOR_CASES.append(
+        EndpointCase(
+            name=case_name,
+            method_name=method_name,
+            response_model_attr=model_attr,
+            api_id=api_id,
+            call_kwargs=dict(kwargs),
+            expected_body=dict(kwargs),
+            response_payload=payload(case_name),
+        )
+    )
+
+
+@pytest.mark.parametrize("case", SECTOR_CASES, ids=lambda case: case.name)
+def test_overseas_sector_requests(monkeypatch, case: EndpointCase):
+    run_post_case(
+        monkeypatch,
+        overseas_sector_module,
+        OverseasSector,
+        case,
+        base_headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+        },
+    )

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_stock_info_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_stock_info_integration.py
@@ -1,0 +1,582 @@
+import pytest
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._overseas_stock_info_types import (
+    OverseasStockInfoEtfCategoryList,
+    OverseasStockInfoEtfEtnList,
+    OverseasStockInfoExchangeList,
+    OverseasStockInfoGapUpDownEtf,
+    OverseasStockInfoGapUpDownStock,
+    OverseasStockInfoHighLowApproachEtf,
+    OverseasStockInfoHighLowApproachStock,
+    OverseasStockInfoHighLowApproachWatchlist,
+    OverseasStockInfoIndexList,
+    OverseasStockInfoNewHighLowEtf,
+    OverseasStockInfoNewHighLowStock,
+    OverseasStockInfoPriceByRangeEtf,
+    OverseasStockInfoPriceByRangeStock,
+    OverseasStockInfoPriceSurgeEtf,
+    OverseasStockInfoPriceSurgeStock,
+    OverseasStockInfoPriceSurgeWatchlist,
+    OverseasStockInfoRemainingRatioSurgeEtf,
+    OverseasStockInfoRemainingRatioSurgeStock,
+    OverseasStockInfoSectorList,
+    OverseasStockInfoStock,
+    OverseasStockInfoStockList,
+    OverseasStockInfoVolumeConcentrationEtf,
+    OverseasStockInfoVolumeConcentrationStock,
+    OverseasStockInfoVolumeRenewalEtf,
+    OverseasStockInfoVolumeRenewalStock,
+    OverseasStockInfoVolumeRenewalWatchlist,
+    OverseasStockInfoVolumeSurgeEtf,
+    OverseasStockInfoVolumeSurgeStock,
+    OverseasStockInfoYearlyFluctuationRateByEtfCategory,
+    OverseasStockInfoYearlyFluctuationRateBySector,
+    OverseasStockInfoYearlyFluctuationRateEtf,
+    OverseasStockInfoYearlyFluctuationRateSector,
+    OverseasStockInfoYearlyFluctuationRateStock,
+)
+
+
+@pytest.mark.integration
+def test_get_exchange_list(client: Client):
+    response = client.overseas_stock_info.get_exchange_list(stk_cd="AAPL")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoExchangeList)
+
+
+@pytest.mark.integration
+def test_get_stock_list(client: Client):
+    response = client.overseas_stock_info.get_stock_list(stex_tp="ND")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoStockList)
+
+
+@pytest.mark.integration
+def test_get_stock(client: Client):
+    response = client.overseas_stock_info.get_stock(stk_cd="AAPL", stex_tp="ND")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoStock)
+
+
+@pytest.mark.integration
+def test_get_sector_list(client: Client):
+    response = client.overseas_stock_info.get_sector_list(gubun="%")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoSectorList)
+
+
+@pytest.mark.integration
+def test_get_index_list(client: Client):
+    response = client.overseas_stock_info.get_index_list(index_qry_tp="NQ")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoIndexList)
+
+
+@pytest.mark.integration
+def test_get_etf_etn_list(client: Client):
+    response = client.overseas_stock_info.get_etf_etn_list(stex_tp="ND")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoEtfEtnList)
+
+
+@pytest.mark.integration
+def test_get_etf_category_list(client: Client):
+    response = client.overseas_stock_info.get_etf_category_list(gubun="1")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoEtfCategoryList)
+
+
+@pytest.mark.integration
+def test_get_volume_surge_stock(client: Client):
+    response = client.overseas_stock_info.get_volume_surge_stock(
+        stex_tp="1",
+        inds_cd="000",
+        tm="5",
+        stk_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        trde_qty_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoVolumeSurgeStock)
+
+
+@pytest.mark.integration
+def test_get_volume_surge_etf(client: Client):
+    response = client.overseas_stock_info.get_volume_surge_etf(
+        stex_tp="1",
+        tm="5",
+        etf_cat1="",
+        etf_cat2="",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        trde_qty_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoVolumeSurgeEtf)
+
+
+@pytest.mark.integration
+def test_get_price_by_range_stock(client: Client):
+    response = client.overseas_stock_info.get_price_by_range_stock(
+        stex_tp="1",
+        stk_tp="0",
+        stk_cnd="0",
+        inds_cd="000",
+        trde_qty_tp="0",
+        pric_cnd1="",
+        pric_cnd2="",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoPriceByRangeStock)
+
+
+@pytest.mark.integration
+def test_get_price_by_range_etf(client: Client):
+    response = client.overseas_stock_info.get_price_by_range_etf(
+        stex_tp="1",
+        stk_cnd="0",
+        etf_cat1="",
+        etf_cat2="",
+        trde_qty_tp="0",
+        pric_cnd1="",
+        pric_cnd2="",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoPriceByRangeEtf)
+
+
+@pytest.mark.integration
+def test_get_price_surge_stock(client: Client):
+    response = client.overseas_stock_info.get_price_surge_stock(
+        stex_tp="1",
+        stk_tp="0",
+        inds_cd="000",
+        stk_cnd="0",
+        flu_tp="1",
+        tm_tp="1",
+        tm="5",
+        pric_cnd="0",
+        trde_qty_tp="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoPriceSurgeStock)
+
+
+@pytest.mark.integration
+def test_get_price_surge_etf(client: Client):
+    response = client.overseas_stock_info.get_price_surge_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        stk_cnd="0",
+        flu_tp="1",
+        tm_tp="1",
+        tm="5",
+        pric_cnd="0",
+        trde_qty_tp="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoPriceSurgeEtf)
+
+
+@pytest.mark.integration
+def test_get_price_surge_watchlist(client: Client):
+    response = client.overseas_stock_info.get_price_surge_watchlist(
+        stex_tp="1",
+        stk_cd=[{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        flu_tp="1",
+        tm_tp="1",
+        tm="5",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_qty_tp="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoPriceSurgeWatchlist)
+
+
+@pytest.mark.integration
+def test_get_high_low_approach_stock(client: Client):
+    response = client.overseas_stock_info.get_high_low_approach_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        high_low_tp="1",
+        alacc_rt="0.5",
+        stk_cnd="0",
+        pric_cnd_st="0",
+        pric_cnd_ed="0",
+        trde_pric_cnd_st="0",
+        trde_qty_cnd_fr="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoHighLowApproachStock)
+
+
+@pytest.mark.integration
+def test_get_high_low_approach_etf(client: Client):
+    response = client.overseas_stock_info.get_high_low_approach_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        high_low_tp="1",
+        alacc_rt="0.5",
+        stk_cnd="0",
+        pric_cnd_st="0",
+        pric_cnd_ed="0",
+        trde_pric_cnd_st="0",
+        trde_qty_cnd_fr="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoHighLowApproachEtf)
+
+
+@pytest.mark.integration
+def test_get_high_low_approach_watchlist(client: Client):
+    response = client.overseas_stock_info.get_high_low_approach_watchlist(
+        stex_tp="1",
+        stk_cd=[{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        high_low_tp="1",
+        alacc_rt="0.5",
+        stk_cnd="0",
+        pric_cnd_st="0",
+        pric_cnd_ed="0",
+        trde_pric_cnd_st="0",
+        trde_qty_cnd_fr="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoHighLowApproachWatchlist)
+
+
+@pytest.mark.integration
+def test_get_volume_renewal_stock(client: Client):
+    response = client.overseas_stock_info.get_volume_renewal_stock(
+        stex_tp="1",
+        stk_cd="000",
+        trde_qty_tp="0",
+        stk_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        dt_tp="5",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoVolumeRenewalStock)
+
+
+@pytest.mark.integration
+def test_get_volume_renewal_etf(client: Client):
+    response = client.overseas_stock_info.get_volume_renewal_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        dt_tp="5",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoVolumeRenewalEtf)
+
+
+@pytest.mark.integration
+def test_get_volume_renewal_watchlist(client: Client):
+    response = client.overseas_stock_info.get_volume_renewal_watchlist(
+        stex_tp="1",
+        stk_cd=[{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        trde_qty_tp="0",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        dt_tp="5",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoVolumeRenewalWatchlist)
+
+
+@pytest.mark.integration
+def test_get_new_high_low_stock(client: Client):
+    response = client.overseas_stock_info.get_new_high_low_stock(
+        stex_tp="1",
+        stk_tp="0",
+        inds_cd="000",
+        stk_cnd="0",
+        ntl_tp="1",
+        high_low_tp="1",
+        dt="20",
+        pric_cnd="0",
+        trde_qty_tp="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoNewHighLowStock)
+
+
+@pytest.mark.integration
+def test_get_new_high_low_etf(client: Client):
+    response = client.overseas_stock_info.get_new_high_low_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        stk_cnd="0",
+        ntl_tp="1",
+        high_low_tp="1",
+        dt="20",
+        pric_cnd="0",
+        trde_qty_tp="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoNewHighLowEtf)
+
+
+@pytest.mark.integration
+def test_get_gap_up_down_stock(client: Client):
+    response = client.overseas_stock_info.get_gap_up_down_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        sort_tp="1",
+        updown_tp="1",
+        alacc_rt="3",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        trde_qty_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoGapUpDownStock)
+
+
+@pytest.mark.integration
+def test_get_gap_up_down_etf(client: Client):
+    response = client.overseas_stock_info.get_gap_up_down_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        sort_tp="1",
+        updown_tp="1",
+        alacc_rt="3",
+        stk_cnd="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+        trde_qty_tp="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoGapUpDownEtf)
+
+
+@pytest.mark.integration
+def test_get_remaining_ratio_surge_stock(client: Client):
+    response = client.overseas_stock_info.get_remaining_ratio_surge_stock(
+        stex_tp="1",
+        inds_cd="000",
+        rt_tp="0",
+        stk_tp="0",
+        tm="5",
+        stk_cnd="0",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoRemainingRatioSurgeStock)
+
+
+@pytest.mark.integration
+def test_get_remaining_ratio_surge_etf(client: Client):
+    response = client.overseas_stock_info.get_remaining_ratio_surge_etf(
+        stex_tp="1",
+        rt_tp="0",
+        etf_cat1="",
+        etf_cat2="",
+        tm="5",
+        stk_cnd="0",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoRemainingRatioSurgeEtf)
+
+
+@pytest.mark.integration
+def test_get_volume_concentration_stock(client: Client):
+    response = client.overseas_stock_info.get_volume_concentration_stock(
+        stex_tp="1",
+        inds_cd="000",
+        stk_tp="0",
+        dt="20",
+        prps_cnctr_rt="50",
+        cond="0",
+        prpscnt="10",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoVolumeConcentrationStock)
+
+
+@pytest.mark.integration
+def test_get_volume_concentration_etf(client: Client):
+    response = client.overseas_stock_info.get_volume_concentration_etf(
+        stex_tp="1",
+        etf_cat1="",
+        etf_cat2="",
+        dt="20",
+        prps_cnctr_rt="50",
+        cond="0",
+        prpscnt="10",
+        trde_qty_tp="0",
+        pric_cnd="0",
+        trde_prica_cnd="0",
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoVolumeConcentrationEtf)
+
+
+@pytest.mark.integration
+def test_get_yearly_fluctuation_rate_stock(client: Client):
+    response = client.overseas_stock_info.get_yearly_fluctuation_rate_stock(stex_tp="ND", stk_cd="AAPL")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoYearlyFluctuationRateStock)
+
+
+@pytest.mark.integration
+def test_get_yearly_fluctuation_rate_by_sector(client: Client):
+    response = client.overseas_stock_info.get_yearly_fluctuation_rate_by_sector(inds_cd="000", srch_yr="2024")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoYearlyFluctuationRateBySector)
+
+
+@pytest.mark.integration
+def test_get_yearly_fluctuation_rate_by_etf_category(client: Client):
+    response = client.overseas_stock_info.get_yearly_fluctuation_rate_by_etf_category(
+        etf_cat1="", etf_cat2="", srch_yr="2024"
+    )
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoYearlyFluctuationRateByEtfCategory)
+
+
+@pytest.mark.integration
+def test_get_yearly_fluctuation_rate_sector(client: Client):
+    response = client.overseas_stock_info.get_yearly_fluctuation_rate_sector(inds_cd="000")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoYearlyFluctuationRateSector)
+
+
+@pytest.mark.integration
+def test_get_yearly_fluctuation_rate_etf(client: Client):
+    response = client.overseas_stock_info.get_yearly_fluctuation_rate_etf(etf_cat1="", etf_cat2="")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoYearlyFluctuationRateEtf)

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_stock_info_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_stock_info_unit.py
@@ -1,0 +1,310 @@
+import inspect
+import re
+
+import pytest
+
+from cluefin_openapi.kiwoom import _overseas_stock_info as overseas_stock_info_module
+from cluefin_openapi.kiwoom._overseas_stock_info import OverseasStockInfo
+
+from ._helpers import EndpointCase, run_post_case
+
+CALL_KWARGS = {
+    "get_exchange_list": {"stk_cd": "AAPL"},
+    "get_stock_list": {"stex_tp": "ND"},
+    "get_stock": {"stk_cd": "AAPL", "stex_tp": "ND"},
+    "get_sector_list": {"gubun": "%"},
+    "get_index_list": {"index_qry_tp": "NQ"},
+    "get_etf_etn_list": {"stex_tp": "ND"},
+    "get_etf_category_list": {"gubun": "1"},
+    "get_volume_surge_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "tm": "5",
+        "stk_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "trde_qty_tp": "0",
+    },
+    "get_volume_surge_etf": {
+        "stex_tp": "1",
+        "tm": "5",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "trde_qty_tp": "0",
+    },
+    "get_price_by_range_stock": {
+        "stex_tp": "1",
+        "stk_tp": "0",
+        "stk_cnd": "0",
+        "inds_cd": "000",
+        "trde_qty_tp": "0",
+        "pric_cnd1": "",
+        "pric_cnd2": "",
+        "trde_prica_cnd": "0",
+    },
+    "get_price_by_range_etf": {
+        "stex_tp": "1",
+        "stk_cnd": "0",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "trde_qty_tp": "0",
+        "pric_cnd1": "",
+        "pric_cnd2": "",
+        "trde_prica_cnd": "0",
+    },
+    "get_price_surge_stock": {
+        "stex_tp": "1",
+        "stk_tp": "0",
+        "inds_cd": "000",
+        "stk_cnd": "0",
+        "flu_tp": "1",
+        "tm_tp": "1",
+        "tm": "5",
+        "pric_cnd": "0",
+        "trde_qty_tp": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_price_surge_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "stk_cnd": "0",
+        "flu_tp": "1",
+        "tm_tp": "1",
+        "tm": "5",
+        "pric_cnd": "0",
+        "trde_qty_tp": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_price_surge_watchlist": {
+        "stex_tp": "1",
+        "stk_cd": [{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        "flu_tp": "1",
+        "tm_tp": "1",
+        "tm": "5",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_qty_tp": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_high_low_approach_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "high_low_tp": "1",
+        "alacc_rt": "0.5",
+        "stk_cnd": "0",
+        "pric_cnd_st": "0",
+        "pric_cnd_ed": "0",
+        "trde_pric_cnd_st": "0",
+        "trde_qty_cnd_fr": "0",
+    },
+    "get_high_low_approach_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "high_low_tp": "1",
+        "alacc_rt": "0.5",
+        "stk_cnd": "0",
+        "pric_cnd_st": "0",
+        "pric_cnd_ed": "0",
+        "trde_pric_cnd_st": "0",
+        "trde_qty_cnd_fr": "0",
+    },
+    "get_high_low_approach_watchlist": {
+        "stex_tp": "1",
+        "stk_cd": [{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        "high_low_tp": "1",
+        "alacc_rt": "0.5",
+        "stk_cnd": "0",
+        "pric_cnd_st": "0",
+        "pric_cnd_ed": "0",
+        "trde_pric_cnd_st": "0",
+        "trde_qty_cnd_fr": "0",
+    },
+    "get_volume_renewal_stock": {
+        "stex_tp": "1",
+        "stk_cd": "000",
+        "trde_qty_tp": "0",
+        "stk_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "dt_tp": "5",
+    },
+    "get_volume_renewal_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "dt_tp": "5",
+    },
+    "get_volume_renewal_watchlist": {
+        "stex_tp": "1",
+        "stk_cd": [{"stex_tp": "ND", "stk_cd": "AAPL"}],
+        "trde_qty_tp": "0",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "dt_tp": "5",
+    },
+    "get_new_high_low_stock": {
+        "stex_tp": "1",
+        "stk_tp": "0",
+        "inds_cd": "000",
+        "stk_cnd": "0",
+        "ntl_tp": "1",
+        "high_low_tp": "1",
+        "dt": "20",
+        "pric_cnd": "0",
+        "trde_qty_tp": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_new_high_low_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "stk_cnd": "0",
+        "ntl_tp": "1",
+        "high_low_tp": "1",
+        "dt": "20",
+        "pric_cnd": "0",
+        "trde_qty_tp": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_gap_up_down_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "sort_tp": "1",
+        "updown_tp": "1",
+        "alacc_rt": "3",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "trde_qty_tp": "0",
+    },
+    "get_gap_up_down_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "sort_tp": "1",
+        "updown_tp": "1",
+        "alacc_rt": "3",
+        "stk_cnd": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+        "trde_qty_tp": "0",
+    },
+    "get_remaining_ratio_surge_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "rt_tp": "0",
+        "stk_tp": "0",
+        "tm": "5",
+        "stk_cnd": "0",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_remaining_ratio_surge_etf": {
+        "stex_tp": "1",
+        "rt_tp": "0",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "tm": "5",
+        "stk_cnd": "0",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_volume_concentration_stock": {
+        "stex_tp": "1",
+        "inds_cd": "000",
+        "stk_tp": "0",
+        "dt": "20",
+        "prps_cnctr_rt": "50",
+        "cond": "0",
+        "prpscnt": "10",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_volume_concentration_etf": {
+        "stex_tp": "1",
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "dt": "20",
+        "prps_cnctr_rt": "50",
+        "cond": "0",
+        "prpscnt": "10",
+        "trde_qty_tp": "0",
+        "pric_cnd": "0",
+        "trde_prica_cnd": "0",
+    },
+    "get_yearly_fluctuation_rate_stock": {"stex_tp": "ND", "stk_cd": "AAPL"},
+    "get_yearly_fluctuation_rate_by_sector": {"inds_cd": "000", "srch_yr": "2024"},
+    "get_yearly_fluctuation_rate_by_etf_category": {
+        "etf_cat1": "",
+        "etf_cat2": "",
+        "srch_yr": "2024",
+    },
+    "get_yearly_fluctuation_rate_sector": {"inds_cd": "000"},
+    "get_yearly_fluctuation_rate_etf": {"etf_cat1": "", "etf_cat2": ""},
+}
+
+# All body parameters are supplied in ``CALL_KWARGS`` and the request body is a
+# 1:1 copy of those values (including the ``stk_cd`` watchlist Map list, which is
+# emitted verbatim when not ``None``), so the expected body equals the call kwargs
+# for every endpoint.
+EXPECTED_BODY: dict[str, dict] = {}
+
+
+def payload(name: str):
+    return {"return_code": 0, "return_msg": "OK", "endpoint": name}
+
+
+def method_metadata(method_name: str) -> tuple[str, str]:
+    method = getattr(OverseasStockInfo, method_name)
+    source = inspect.getsource(method)
+    api_id = re.search(r'"api-id":\s*"([^"]+)"', source).group(1)
+    model_attr = re.search(r"= (OverseasStockInfo\w+)\.model_validate", source).group(1)
+    return api_id, model_attr
+
+
+STOCK_INFO_CASES = []
+for method_name, kwargs in CALL_KWARGS.items():
+    api_id, model_attr = method_metadata(method_name)
+    case_name = method_name.removeprefix("get_")
+    STOCK_INFO_CASES.append(
+        EndpointCase(
+            name=case_name,
+            method_name=method_name,
+            response_model_attr=model_attr,
+            api_id=api_id,
+            call_kwargs=dict(kwargs),
+            expected_body=dict(EXPECTED_BODY.get(method_name, kwargs)),
+            response_payload=payload(case_name),
+        )
+    )
+
+
+@pytest.mark.parametrize("case", STOCK_INFO_CASES, ids=lambda case: case.name)
+def test_overseas_stock_info_requests(monkeypatch, case: EndpointCase):
+    run_post_case(
+        monkeypatch,
+        overseas_stock_info_module,
+        OverseasStockInfo,
+        case,
+        base_headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+        },
+    )

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_watchlist_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_watchlist_integration.py
@@ -1,0 +1,27 @@
+import pytest
+
+from cluefin_openapi.kiwoom._client import Client
+from cluefin_openapi.kiwoom._overseas_watchlist_types import (
+    OverseasWatchlistGroupDetail,
+    OverseasWatchlistGroupList,
+)
+
+
+@pytest.mark.integration
+def test_get_watchlist_group_list(client: Client):
+    response = client.overseas_watchlist.get_watchlist_group_list()
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasWatchlistGroupList)
+
+
+@pytest.mark.integration
+def test_get_watchlist_group_detail(client: Client):
+    response = client.overseas_watchlist.get_watchlist_group_detail(arn_grp_id="10")
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasWatchlistGroupDetail)

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_watchlist_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_watchlist_unit.py
@@ -1,0 +1,58 @@
+import inspect
+import re
+
+import pytest
+
+from cluefin_openapi.kiwoom import _overseas_watchlist as overseas_watchlist_module
+from cluefin_openapi.kiwoom._overseas_watchlist import OverseasWatchlist
+
+from ._helpers import EndpointCase, run_post_case
+
+# usa20200 has no request body; usa20201 takes an optional ``arn_grp_id``.
+CALL_KWARGS = {
+    "get_watchlist_group_list": {},
+    "get_watchlist_group_detail": {"arn_grp_id": "10"},
+}
+
+
+def payload(name: str):
+    return {"return_code": 0, "return_msg": "OK", "endpoint": name}
+
+
+def method_metadata(method_name: str) -> tuple[str, str]:
+    method = getattr(OverseasWatchlist, method_name)
+    source = inspect.getsource(method)
+    api_id = re.search(r'"api-id":\s*"([^"]+)"', source).group(1)
+    model_attr = re.search(r"res_body = (\w+)\.model_validate", source).group(1)
+    return api_id, model_attr
+
+
+WATCHLIST_CASES = []
+for method_name, kwargs in CALL_KWARGS.items():
+    api_id, model_attr = method_metadata(method_name)
+    case_name = method_name.removeprefix("get_")
+    WATCHLIST_CASES.append(
+        EndpointCase(
+            name=case_name,
+            method_name=method_name,
+            response_model_attr=model_attr,
+            api_id=api_id,
+            call_kwargs=dict(kwargs),
+            expected_body=dict(kwargs),
+            response_payload=payload(case_name),
+        )
+    )
+
+
+@pytest.mark.parametrize("case", WATCHLIST_CASES, ids=lambda case: case.name)
+def test_overseas_watchlist_requests(monkeypatch, case: EndpointCase):
+    run_post_case(
+        monkeypatch,
+        overseas_watchlist_module,
+        OverseasWatchlist,
+        case,
+        base_headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+        },
+    )


### PR DESCRIPTION
## Summary

Kiwoom OpenAPI 클라이언트(`packages/cluefin-openapi`)에 미국주식(해외주식) API 지원을 추가합니다. 국내주식과 동일한 모듈/타입 패턴으로 12개 메뉴를 구현했습니다.

## Changes

- **HTTP API 10개 메뉴, 메서드 121개**: 계좌(28) · 순위정보(35) · 종목정보(33) · 차트(7) · 시세(5) · 주문(5) · 환전(3) · 관심종목(2) · 업종(2) · 투자정보(1)
  - `Client`에 `overseas_account` ~ `overseas_watchlist` property 10개 추가
  - 공식 가이드 스펙 기반으로 요청 파라미터(Required/Literal 타입 반영)와 응답 pydantic 모델 정의 (모델 총 254개)
- **웹소켓 2개 메뉴**: 실시간시세(F4/F5/FE/FT) · 조건검색(usa20280~20291)은 메시지 모델(`*_types.py`)만 제공 — 웹소켓 클라이언트 구현 전까지 모듈은 stub 유지
- **문서**: AGENTS.md를 에이전트용 프로젝트 가이드 단일 출처로 정리

## Testing

- unit 156개: HTTP 메서드별 요청 헤더/바디/모델 라우팅 검증 121개 + 웹소켓 메시지 모델 직렬화/alias 검증 35개
- integration 121개: HTTP 메서드 1:1, 모의투자(dev) 환경 실호출로 전부 통과 확인 (주문·환전 포함)
- 전체 단위 테스트 1,096개 통과 (기존 회귀 없음), `ruff check` 클린
