### PR TITLE
feat(kiwoom): 미국주식 조건검색·실시간 시세 웹소켓 구현

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,11 @@ The active US-stock work (branch `feat/kiwoom-overseas`) is **Python-only** — 
   raw Kiwoom field codes). Mirrors the existing `_domestic_*` set.
 - **Client wiring** (`_client.py`): no separate client — lazy `@property` accessors on the
   single `Client`, with `overseas_`-prefixed names (`overseas_account`, `overseas_order`, …).
-  `_overseas_condition_search` and `_overseas_realtime` exist but are **not yet wired**
-  (WebSocket/streaming, in progress) and are unit-test-only.
+- **WebSocket** (`_overseas_condition_search`, `_overseas_realtime`): async, not on the HTTP
+  `Client`. `_socket_client.py`'s `KiwoomWebSocketClient` is a shared raw-asyncio (no extra
+  dep) client for `wss://…:10000/api/us/websocket` that handles LOGIN/PING; the two domain
+  classes take it in their ctor and send JSON frames (REG/REMOVE, GCNSRLST/GCNSRREQ/GCNSRCLR)
+  + parse responses. Mirrors the `kis/_socket_client.py` pattern.
 - **Tests** (`packages/cluefin-openapi/tests/kiwoom/`): `test_overseas_<category>_unit.py`
   (table-driven via `_helpers.py` `EndpointCase` / `run_post_case`, no marker) plus
   `test_overseas_<category>_integration.py` (`@pytest.mark.integration`, using the `client`

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/__init__.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/__init__.py
@@ -13,6 +13,9 @@ from ._exceptions import (
     KiwoomTimeoutError,
     KiwoomValidationError,
 )
+from ._overseas_condition_search import OverseasConditionSearch
+from ._overseas_realtime import OverseasRealtime
+from ._socket_client import KiwoomWebSocketClient, KiwoomWebSocketMessage
 
 __all__ = [
     "KIWOOM_ERROR_CODES",
@@ -26,6 +29,10 @@ __all__ = [
     "KiwoomServerError",
     "KiwoomTimeoutError",
     "KiwoomValidationError",
+    "KiwoomWebSocketClient",
+    "KiwoomWebSocketMessage",
+    "OverseasConditionSearch",
+    "OverseasRealtime",
     "error_type_for_code",
     "resolve_kiwoom_error",
 ]

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_condition_search.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_condition_search.py
@@ -1,20 +1,124 @@
-# 조건검색 (웹소켓)
-# 운영: wss://api.kiwoom.com:10000/api/us/websocket
-# 모의투자: wss://mockapi.kiwoom.com:10000/api/us/websocket
-#
-# 웹소켓 클라이언트 구현은 아직 없음. request/response 모델은
-# _overseas_condition_search_types.py 참고.
+"""미국주식 조건검색 (웹소켓).
+
+운영: wss://api.kiwoom.com:10000/api/us/websocket
+모의투자: wss://mockapi.kiwoom.com:10000/api/us/websocket
+
+``KiwoomWebSocketClient``(LOGIN/PING 처리)를 감싸 조건검색 요청 프레임을 송신하고 응답을
+파싱한다. 목록조회/요청 일반/해제는 요청-응답형이고, 요청 실시간(search_type=1)은 이후
+편입/이탈 이벤트가 실시간 푸시로 도착한다.
+
+TR:
+- usa20280 조건검색 목록조회   GCNSRLST → OverseasConditionSearchListResponse
+- usa20281 조건검색 요청 일반   GCNSRREQ(search_type=0) → OverseasConditionSearchResponse
+- usa20290 조건검색 요청 실시간 GCNSRREQ(search_type=1) → OverseasConditionSearchRealtimeResponse
+- usa20291 조건검색 실시간 해제 GCNSRCLR → OverseasConditionSearchRealtimeCancelResponse
+"""
+
+from typing import Literal
+
+from ._overseas_condition_search_types import (
+    OverseasConditionSearchListRequest,
+    OverseasConditionSearchListResponse,
+    OverseasConditionSearchRealtimeCancelRequest,
+    OverseasConditionSearchRealtimeCancelResponse,
+    OverseasConditionSearchRealtimeRequest,
+    OverseasConditionSearchRealtimeResponse,
+    OverseasConditionSearchRequest,
+    OverseasConditionSearchResponse,
+)
+from ._socket_client import KiwoomWebSocketClient, KiwoomWebSocketMessage
 
 
 class OverseasConditionSearch:
-    pass
+    """미국주식 조건검색 WebSocket API.
 
+    Example:
+        ```python
+        async with KiwoomWebSocketClient(token="...", env="prod") as ws:
+            condition = OverseasConditionSearch(ws)
+            search_list = await condition.get_condition_search_list()
+            result = await condition.request_condition_search(seq="0")
+            print(result.data)
+        ```
+    """
 
-# 미국주식 조건검색 목록조회	usa20280	get_condition_search_list
-#   OverseasConditionSearchListRequest / OverseasConditionSearchListResponse
-# 미국주식 조건검색 요청 일반	usa20281	request_condition_search
-#   OverseasConditionSearchRequest / OverseasConditionSearchResponse
-# 미국주식 조건검색 요청 실시간	usa20290	request_realtime_condition_search
-#   OverseasConditionSearchRealtimeRequest / OverseasConditionSearchRealtimeResponse
-# 미국주식 조건검색 실시간 해제	usa20291	cancel_realtime_condition_search
-#   OverseasConditionSearchRealtimeCancelRequest / OverseasConditionSearchRealtimeCancelResponse
+    def __init__(self, socket_client: KiwoomWebSocketClient):
+        self.socket_client = socket_client
+
+    async def get_condition_search_list(self) -> OverseasConditionSearchListResponse:
+        """미국주식 조건검색 목록조회 (usa20280, GCNSRLST).
+
+        Returns:
+            OverseasConditionSearchListResponse: 조건검색식 목록.
+        """
+        await self.socket_client.send(OverseasConditionSearchListRequest(trnm="GCNSRLST"))
+        message = await self._recv_until("GCNSRLST")
+        return OverseasConditionSearchListResponse.model_validate(message.body)
+
+    async def request_condition_search(
+        self,
+        seq: str,
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> OverseasConditionSearchResponse:
+        """미국주식 조건검색 요청 일반 (usa20281, GCNSRREQ search_type=0).
+
+        Args:
+            seq: 조건검색식 일련번호.
+            cont_yn: 연속조회여부. "Y":연속조회요청, "N":연속조회미요청.
+            next_key: 연속조회키.
+
+        Returns:
+            OverseasConditionSearchResponse: 조건검색 결과.
+        """
+        await self.socket_client.send(
+            OverseasConditionSearchRequest(
+                trnm="GCNSRREQ",
+                seq=seq,
+                search_type="0",
+                cont_yn=cont_yn,
+                next_key=next_key,
+            )
+        )
+        message = await self._recv_until("GCNSRREQ")
+        return OverseasConditionSearchResponse.model_validate(message.body)
+
+    async def request_realtime_condition_search(self, seq: str) -> OverseasConditionSearchRealtimeResponse:
+        """미국주식 조건검색 요청 실시간 (usa20290, GCNSRREQ search_type=1).
+
+        요청 직후 현재 편입 종목이 응답으로 반환되며, 이후 편입/이탈 이벤트는 실시간 푸시로
+        도착한다 (``socket_client.events()``로 수신).
+
+        Args:
+            seq: 조건검색식 일련번호.
+
+        Returns:
+            OverseasConditionSearchRealtimeResponse: 실시간 조건검색 초기 결과.
+        """
+        await self.socket_client.send(OverseasConditionSearchRealtimeRequest(trnm="GCNSRREQ", seq=seq, search_type="1"))
+        message = await self._recv_until("GCNSRREQ")
+        return OverseasConditionSearchRealtimeResponse.model_validate(message.body)
+
+    async def cancel_realtime_condition_search(self, seq: str) -> OverseasConditionSearchRealtimeCancelResponse:
+        """미국주식 조건검색 실시간 해제 (usa20291, GCNSRCLR).
+
+        Args:
+            seq: 조건검색식 일련번호.
+
+        Returns:
+            OverseasConditionSearchRealtimeCancelResponse: 해제 ACK.
+        """
+        await self.socket_client.send(OverseasConditionSearchRealtimeCancelRequest(trnm="GCNSRCLR", seq=seq))
+        message = await self._recv_until("GCNSRCLR")
+        return OverseasConditionSearchRealtimeCancelResponse.model_validate(message.body)
+
+    async def _recv_until(self, trnm: str) -> KiwoomWebSocketMessage:
+        """지정한 ``trnm`` 응답 프레임이 올 때까지 수신한다.
+
+        실시간 조건검색이 함께 켜져 있으면 REAL 푸시 프레임이 섞여 들어올 수 있으므로
+        요청에 대응하는 응답 프레임만 골라 반환한다.
+        """
+        while True:
+            message = await self.socket_client.recv()
+            if message.trnm == trnm:
+                return message

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_realtime.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_realtime.py
@@ -1,19 +1,144 @@
-# 실시간 시세 (웹소켓)
-# 운영: wss://api.kiwoom.com:10000/api/us/websocket
-# 모의투자: wss://mockapi.kiwoom.com:10000/api/us/websocket
+"""미국주식 실시간 시세 (웹소켓).
+
+운영: wss://api.kiwoom.com:10000/api/us/websocket
+모의투자: wss://mockapi.kiwoom.com:10000/api/us/websocket
+
+``KiwoomWebSocketClient``(LOGIN/PING 처리)를 감싸 실시간 시세 등록/해지(REG/REMOVE)
+프레임을 송신하고, 수신한 REAL 프레임을 TR별 응답 모델로 파싱한다.
+
+TR:
+- F4 미국주식실시간주문확인 → OverseasRealtimeOrderConfirmation
+- F5 미국주식실시간체결     → OverseasRealtimeExecution
+- FE 미국주식실시간체결가   → OverseasRealtimeExecutionPrice
+- FT 미국주식10호가         → OverseasRealtimeTenQuotes
+"""
+
+from typing import Iterable, Union
+
+from ._overseas_realtime_types import (
+    OverseasRealtimeExecution,
+    OverseasRealtimeExecutionPrice,
+    OverseasRealtimeOrderConfirmation,
+    OverseasRealtimeRegisterData,
+    OverseasRealtimeRegisterItem,
+    OverseasRealtimeRequest,
+    OverseasRealtimeTenQuotes,
+)
+from ._socket_client import KiwoomWebSocketClient, KiwoomWebSocketMessage
+
+# 수신한 REAL 프레임의 ``data[].type`` → 응답 모델 매핑
+_FRAME_MODELS = {
+    "F4": OverseasRealtimeOrderConfirmation,
+    "F5": OverseasRealtimeExecution,
+    "FE": OverseasRealtimeExecutionPrice,
+    "FT": OverseasRealtimeTenQuotes,
+}
 
 
 class OverseasRealtime:
-    # 웹소켓 클라이언트 구현은 아직 없음 (stub). 요청/응답 모델만 정의됨.
-    # 모델 정의: _overseas_realtime_types.py
-    pass
+    """미국주식 실시간 시세 WebSocket API.
 
+    Example:
+        ```python
+        async with KiwoomWebSocketClient(token="...", env="prod") as ws:
+            realtime = OverseasRealtime(ws)
+            await realtime.register(["F5", "FT"], [("NVDA", "ND"), ("AAPL", "ND")])
+            async for message in ws.events():
+                parsed = realtime.parse(message)
+                if parsed is not None:
+                    print(parsed)
+        ```
+    """
 
-# 공통 요청 모델 (4개 TR 동일 등록/해지 프레임):
-#   OverseasRealtimeRequest / OverseasRealtimeRegisterData / OverseasRealtimeRegisterItem
-#
-# TR	이름	메서드(예정)	values 모델 / 응답 프레임 모델
-# F4	미국주식실시간주문확인	get_order_confirmation	OverseasRealtimeOrderConfirmationValues / OverseasRealtimeOrderConfirmation
-# F5	미국주식실시간체결	get_execution	OverseasRealtimeExecutionValues / OverseasRealtimeExecution
-# FE	미국주식실시간체결가	get_execution_price	OverseasRealtimeExecutionPriceValues / OverseasRealtimeExecutionPrice
-# FT	미국주식10호가	get_ten_quotes	OverseasRealtimeTenQuotesValues / OverseasRealtimeTenQuotes
+    # 실시간 TR (type)
+    TR_ORDER_CONFIRMATION = "F4"  # 미국주식실시간주문확인
+    TR_EXECUTION = "F5"  # 미국주식실시간체결
+    TR_EXECUTION_PRICE = "FE"  # 미국주식실시간체결가
+    TR_TEN_QUOTES = "FT"  # 미국주식10호가
+
+    def __init__(self, socket_client: KiwoomWebSocketClient):
+        self.socket_client = socket_client
+
+    async def register(
+        self,
+        types: Iterable[str],
+        items: Iterable[Union[OverseasRealtimeRegisterItem, tuple[str, str]]],
+        grp_no: str = "1",
+        refresh: str = "1",
+    ) -> None:
+        """실시간 시세를 등록(REG)한다.
+
+        Args:
+            types: 등록할 TR type 리스트 (예: ["F5", "FT"]).
+            items: 등록할 종목 리스트. ``OverseasRealtimeRegisterItem`` 또는
+                ``(jmcode, stex_tp)`` 튜플 (예: ("NVDA", "ND")).
+            grp_no: 그룹번호. Defaults to "1".
+            refresh: 기존등록유지여부. "1":기존유지(Default), "0":기존등록 item/type 해지.
+        """
+        await self._send("REG", types, items, grp_no, refresh)
+
+    async def remove(
+        self,
+        types: Iterable[str],
+        items: Iterable[Union[OverseasRealtimeRegisterItem, tuple[str, str]]],
+        grp_no: str = "1",
+    ) -> None:
+        """실시간 시세를 해지(REMOVE)한다.
+
+        Args:
+            types: 해지할 TR type 리스트.
+            items: 해지할 종목 리스트.
+            grp_no: 그룹번호. Defaults to "1".
+        """
+        # 해지시 refresh 값은 스펙상 불필요하지만 필수 필드이므로 "0"을 전달한다.
+        await self._send("REMOVE", types, items, grp_no, "0")
+
+    async def _send(
+        self,
+        trnm: str,
+        types: Iterable[str],
+        items: Iterable[Union[OverseasRealtimeRegisterItem, tuple[str, str]]],
+        grp_no: str,
+        refresh: str,
+    ) -> None:
+        register_items = [
+            item
+            if isinstance(item, OverseasRealtimeRegisterItem)
+            else OverseasRealtimeRegisterItem(jmcode=item[0], stex_tp=item[1])
+            for item in items
+        ]
+        request = OverseasRealtimeRequest(
+            trnm=trnm,
+            grp_no=grp_no,
+            refresh=refresh,
+            data=[OverseasRealtimeRegisterData(item=register_items, type=list(types))],
+        )
+        await self.socket_client.send(request)
+
+    @staticmethod
+    def parse(
+        message: KiwoomWebSocketMessage,
+    ) -> Union[
+        OverseasRealtimeOrderConfirmation,
+        OverseasRealtimeExecution,
+        OverseasRealtimeExecutionPrice,
+        OverseasRealtimeTenQuotes,
+        None,
+    ]:
+        """수신 프레임을 TR type에 맞는 응답 모델로 파싱한다.
+
+        ``data[].type``으로 TR을 판별하며, 실시간 대상이 아닌 프레임(빈 data, LOGIN/PING
+        등)은 ``None``을 반환한다.
+
+        Args:
+            message: 수신한 WebSocket 메시지.
+
+        Returns:
+            파싱된 응답 모델. 대상 TR이 아니면 None.
+        """
+        data = message.body.get("data") or []
+        tr_type = data[0].get("type") if data and isinstance(data[0], dict) else None
+        model = _FRAME_MODELS.get(tr_type)
+        if model is None:
+            return None
+        return model.model_validate(message.body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_socket_client.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_socket_client.py
@@ -1,0 +1,388 @@
+"""미국주식 실시간 WebSocket 클라이언트.
+
+실시간 시세(``_overseas_realtime``)와 조건검색(``_overseas_condition_search``)이 공유하는
+저수준 WebSocket 클라이언트다. Python 표준 라이브러리(asyncio)만 사용하며 외부 의존성을
+추가하지 않는다 (KIS ``_socket_client``와 동일한 방식).
+
+WebSocket URL:
+- 운영: wss://api.kiwoom.com:10000/api/us/websocket
+- 모의투자: wss://mockapi.kiwoom.com:10000/api/us/websocket
+
+프로토콜 (JSON 텍스트 프레임):
+- 접속 후 ``{"trnm": "LOGIN", "token": <access_token>}`` 전송 → LOGIN 응답(return_code) 수신
+- 서버가 주기적으로 ``{"trnm": "PING", ...}`` 전송 → 받은 프레임을 그대로 회신
+- REG/REMOVE(실시간 등록/해지), GCNSRLST/GCNSRREQ/GCNSRCLR(조건검색) 프레임 송신
+- ``{"trnm": "REAL", ...}`` 실시간 푸시 및 각 요청에 대한 응답 프레임 수신
+"""
+
+import asyncio
+import base64
+import hashlib
+import json
+import os
+import ssl
+import struct
+from dataclasses import dataclass, field
+from typing import Any, Dict, Literal, Optional, Union
+from urllib.parse import urlparse
+
+from loguru import logger
+from pydantic import BaseModel
+
+from cluefin_openapi._rate_limiter import TokenBucket
+
+from ._exceptions import KiwoomAPIError, KiwoomNetworkError
+
+
+@dataclass
+class KiwoomWebSocketMessage:
+    """수신한 WebSocket 프레임 (파싱된 JSON)."""
+
+    trnm: str
+    body: Dict[str, Any] = field(default_factory=dict)
+    raw: str = ""
+
+
+class KiwoomWebSocketClient:
+    """미국주식 실시간 WebSocket 클라이언트.
+
+    LOGIN 인증과 PING/PONG 유지는 이 클라이언트가 처리하고, 그 외 프레임은 이벤트 큐로
+    전달한다. ``OverseasRealtime``/``OverseasConditionSearch``가 이 클라이언트를 감싸
+    도메인별 요청 프레임을 송신하고 응답을 파싱한다.
+
+    Example:
+        ```python
+        async with KiwoomWebSocketClient(token="...", env="prod") as ws:
+            await ws.send({"trnm": "GCNSRLST"})
+            message = await ws.recv()
+            print(message.trnm, message.body)
+        ```
+    """
+
+    WS_URL_PROD = "wss://api.kiwoom.com:10000/api/us/websocket"
+    WS_URL_DEV = "wss://mockapi.kiwoom.com:10000/api/us/websocket"
+
+    def __init__(
+        self,
+        token: str,
+        env: Literal["dev", "prod"] = "prod",
+        debug: bool = False,
+        queue_maxsize: int = 1000,
+        rate_limit_requests_per_second: float = 5.0,
+        rate_limit_burst: int = 3,
+    ):
+        """WebSocket 클라이언트 초기화.
+
+        Args:
+            token: 접근토큰 (LOGIN 프레임에 사용).
+            env: 환경. "prod":운영, "dev":모의투자.
+            debug: 디버그 로깅 활성화 여부.
+            queue_maxsize: 이벤트 큐 최대 크기 (0이면 무제한).
+            rate_limit_requests_per_second: 송신 rate limit.
+            rate_limit_burst: 송신 burst 한도.
+        """
+        self.token = token
+        self.env = env
+        self.debug = debug
+
+        self._ws_url = self.WS_URL_PROD if env == "prod" else self.WS_URL_DEV
+        self._event_queue: "asyncio.Queue[KiwoomWebSocketMessage]" = asyncio.Queue(maxsize=queue_maxsize)
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        self._connected = False
+        self._receive_task: Optional[asyncio.Task] = None
+        self._rate_limiter = TokenBucket(capacity=rate_limit_burst, refill_rate=rate_limit_requests_per_second)
+
+        if debug:
+            logger.enable("cluefin_openapi.kiwoom")
+
+    async def __aenter__(self) -> "KiwoomWebSocketClient":
+        await self.connect()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
+
+    @property
+    def connected(self) -> bool:
+        """WebSocket 연결 여부."""
+        return self._connected
+
+    # ------------------------------------------------------------------
+    # 연결 / 종료
+    # ------------------------------------------------------------------
+
+    async def connect(self) -> None:
+        """WebSocket 서버에 접속하고 LOGIN 인증까지 수행한다.
+
+        Raises:
+            KiwoomNetworkError: 접속/핸드셰이크 실패.
+            KiwoomAPIError: LOGIN 인증 실패 (return_code != 0).
+        """
+        parsed = urlparse(self._ws_url)
+        use_ssl = parsed.scheme == "wss"
+        host = parsed.hostname or ""
+        port = parsed.port or (443 if use_ssl else 80)
+        path = parsed.path or "/"
+
+        try:
+            ssl_context = ssl.create_default_context() if use_ssl else None
+            self._reader, self._writer = await asyncio.open_connection(host, port, ssl=ssl_context)
+            await self._websocket_handshake(host, port, path)
+        except (OSError, asyncio.IncompleteReadError) as e:
+            raise KiwoomNetworkError(f"Failed to connect to WebSocket: {e}") from e
+
+        await self._login()
+
+        self._connected = True
+        self._receive_task = asyncio.create_task(self._receive_loop())
+
+        if self.debug:
+            logger.debug("Kiwoom WebSocket connected: {}", self._ws_url)
+
+    async def close(self) -> None:
+        """WebSocket 연결을 종료한다."""
+        self._connected = False
+
+        if self._receive_task:
+            self._receive_task.cancel()
+            try:
+                await self._receive_task
+            except asyncio.CancelledError:
+                pass
+            self._receive_task = None
+
+        if self._writer:
+            try:
+                await self._send_frame(b"", opcode=0x8)  # Close frame
+            except Exception as exc:
+                if self.debug:
+                    logger.debug("Failed to send close frame: {}", exc)
+            self._writer.close()
+            try:
+                await self._writer.wait_closed()
+            except Exception as exc:
+                if self.debug:
+                    logger.debug("Failed to close writer: {}", exc)
+            self._writer = None
+            self._reader = None
+
+        if self.debug:
+            logger.debug("Kiwoom WebSocket closed")
+
+    async def _login(self) -> None:
+        """LOGIN 프레임을 전송하고 인증 응답을 확인한다.
+
+        LOGIN 응답 전 PING이 먼저 도착할 수 있으므로 그대로 회신하며 대기한다.
+        """
+        await self.send({"trnm": "LOGIN", "token": self.token})
+
+        while True:
+            message = await self._recv_json()
+            if message.trnm == "PING":
+                await self.send(message.body)
+                continue
+            if message.trnm == "LOGIN":
+                return_code = message.body.get("return_code")
+                if return_code not in (0, "0"):
+                    raise KiwoomAPIError(
+                        f"WebSocket LOGIN failed: {message.body.get('return_msg') or 'unknown error'}",
+                        response_data=message.body,
+                    )
+                return
+            # LOGIN 이전의 예상치 못한 프레임은 무시한다.
+            if self.debug:
+                logger.debug("Ignoring pre-LOGIN frame: {}", message.trnm)
+
+    # ------------------------------------------------------------------
+    # 송신 / 수신 (도메인 클래스에서 사용하는 공개 API)
+    # ------------------------------------------------------------------
+
+    async def send(self, message: Union[Dict[str, Any], BaseModel]) -> None:
+        """JSON 프레임을 송신한다.
+
+        Args:
+            message: 송신할 프레임. dict 또는 Pydantic 모델(``model_dump(by_alias=True)``로 직렬화).
+
+        Raises:
+            KiwoomNetworkError: 연결이 초기화되지 않았거나 송신 실패.
+            KiwoomAPIError: rate limit 초과.
+        """
+        if isinstance(message, BaseModel):
+            payload = message.model_dump(by_alias=True)
+        else:
+            payload = message
+
+        if not self._rate_limiter.wait_for_tokens(timeout=5.0):
+            raise KiwoomAPIError("WebSocket send rate limit exceeded")
+
+        if self.debug:
+            logger.debug("WS send: {}", payload)
+
+        await self._send_frame(json.dumps(payload).encode("utf-8"))
+
+    async def recv(self) -> KiwoomWebSocketMessage:
+        """다음 (PING이 아닌) 프레임을 이벤트 큐에서 꺼낸다.
+
+        요청-응답형 TR(조건검색 목록/요청 등)에서 응답 프레임을 기다릴 때 사용한다.
+        """
+        return await self._event_queue.get()
+
+    async def events(self):
+        """이벤트 큐의 프레임을 순회하는 async generator.
+
+        Yields:
+            KiwoomWebSocketMessage: PING을 제외한 수신 프레임.
+        """
+        while self._connected or not self._event_queue.empty():
+            try:
+                message = await asyncio.wait_for(self._event_queue.get(), timeout=1.0)
+                yield message
+            except asyncio.TimeoutError:
+                continue
+
+    # ------------------------------------------------------------------
+    # 수신 루프 / 메시지 처리
+    # ------------------------------------------------------------------
+
+    async def _receive_loop(self) -> None:
+        """수신 루프. PING은 회신하고 나머지 프레임은 큐에 넣는다."""
+        try:
+            while self._connected:
+                message = await self._recv_json()
+                if message.trnm == "PING":
+                    await self.send(message.body)
+                    continue
+                await self._emit(message)
+        except asyncio.CancelledError:
+            pass
+        except (asyncio.IncompleteReadError, ConnectionError, OSError) as e:
+            if self._connected:
+                logger.error("Kiwoom WebSocket receive error: {}", e)
+                self._connected = False
+
+    async def _emit(self, message: KiwoomWebSocketMessage) -> None:
+        """이벤트 큐에 메시지를 넣는다. 큐가 가득 차면 가장 오래된 항목을 버린다."""
+        try:
+            self._event_queue.put_nowait(message)
+        except asyncio.QueueFull:
+            logger.warning("Kiwoom WebSocket event queue full, dropping oldest message")
+            try:
+                self._event_queue.get_nowait()
+                self._event_queue.put_nowait(message)
+            except asyncio.QueueEmpty:
+                pass
+
+    async def _recv_json(self) -> KiwoomWebSocketMessage:
+        """텍스트 프레임 하나를 읽어 JSON으로 파싱한다.
+
+        Ping(0x9)/Pong(0xA)/Close(0x8) 제어 프레임을 처리하며, 텍스트 프레임을 만날 때까지
+        읽는다.
+        """
+        while True:
+            opcode, payload = await self._receive_frame()
+            if opcode in (0x1, 0x2):  # Text / Binary
+                raw = payload.decode("utf-8")
+                body = json.loads(raw)
+                trnm = body.get("trnm", "") if isinstance(body, dict) else ""
+                return KiwoomWebSocketMessage(trnm=trnm, body=body if isinstance(body, dict) else {}, raw=raw)
+            if opcode == 0x8:  # Close
+                self._connected = False
+                raise KiwoomNetworkError("WebSocket closed by server")
+            if opcode == 0x9:  # Ping (protocol-level)
+                await self._send_frame(payload, opcode=0xA)  # Pong
+            # Pong(0xA)은 무시
+
+    # ------------------------------------------------------------------
+    # 저수준 WebSocket 프레이밍 (RFC 6455)
+    # ------------------------------------------------------------------
+
+    async def _websocket_handshake(self, host: str, port: int, path: str) -> None:
+        """RFC 6455 WebSocket 핸드셰이크를 수행한다."""
+        if self._writer is None or self._reader is None:
+            raise KiwoomNetworkError("WebSocket handshake failed: connection not initialized")
+
+        ws_key = base64.b64encode(os.urandom(16)).decode()
+        handshake = (
+            f"GET {path} HTTP/1.1\r\n"
+            f"Host: {host}:{port}\r\n"
+            f"Upgrade: websocket\r\n"
+            f"Connection: Upgrade\r\n"
+            f"Sec-WebSocket-Key: {ws_key}\r\n"
+            f"Sec-WebSocket-Version: 13\r\n"
+            f"\r\n"
+        )
+        self._writer.write(handshake.encode())
+        await self._writer.drain()
+
+        response = await self._reader.readuntil(b"\r\n\r\n")
+        if b"101" not in response:
+            raise KiwoomNetworkError(f"WebSocket handshake failed: {response.decode(errors='replace')}")
+
+        # SHA1은 RFC 6455 WebSocket 프로토콜에서 요구하는 것으로 보안 용도가 아니다.
+        expected_accept = base64.b64encode(
+            hashlib.sha1(
+                (ws_key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode(),
+                usedforsecurity=False,
+            ).digest()
+        ).decode()
+        if expected_accept.encode() not in response:
+            raise KiwoomNetworkError("WebSocket handshake: invalid Sec-WebSocket-Accept")
+
+    async def _send_frame(self, data: bytes, opcode: int = 0x1) -> None:
+        """WebSocket 프레임을 송신한다 (클라이언트→서버는 마스킹 필수).
+
+        Args:
+            data: 송신 데이터.
+            opcode: WebSocket opcode (0x1:text, 0x8:close, 0x9:ping, 0xA:pong).
+        """
+        if self._writer is None:
+            raise KiwoomNetworkError("WebSocket send failed: connection not initialized")
+
+        length = len(data)
+        frame = bytearray()
+        frame.append(0x80 | opcode)  # FIN + opcode
+
+        mask_bit = 0x80  # 클라이언트→서버 프레임은 마스킹 필수
+        if length <= 125:
+            frame.append(mask_bit | length)
+        elif length <= 65535:
+            frame.append(mask_bit | 126)
+            frame.extend(struct.pack(">H", length))
+        else:
+            frame.append(mask_bit | 127)
+            frame.extend(struct.pack(">Q", length))
+
+        mask_key = os.urandom(4)
+        frame.extend(mask_key)
+        frame.extend(byte ^ mask_key[index % 4] for index, byte in enumerate(data))
+
+        self._writer.write(bytes(frame))
+        await self._writer.drain()
+
+    async def _receive_frame(self) -> tuple[int, bytes]:
+        """WebSocket 프레임 하나를 수신한다.
+
+        Returns:
+            (opcode, payload) 튜플.
+        """
+        if self._reader is None:
+            raise KiwoomNetworkError("WebSocket receive failed: connection not initialized")
+
+        header = await self._reader.readexactly(2)
+        opcode = header[0] & 0x0F
+        masked = (header[1] >> 7) & 1
+        length = header[1] & 0x7F
+
+        if length == 126:
+            length = struct.unpack(">H", await self._reader.readexactly(2))[0]
+        elif length == 127:
+            length = struct.unpack(">Q", await self._reader.readexactly(8))[0]
+
+        mask_key = await self._reader.readexactly(4) if masked else None
+        payload = await self._reader.readexactly(length)
+
+        if mask_key:
+            payload = bytes(byte ^ mask_key[index % 4] for index, byte in enumerate(payload))
+
+        return opcode, payload

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_socket_client.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_socket_client.py
@@ -321,7 +321,7 @@ class KiwoomWebSocketClient:
 
         # SHA1은 RFC 6455 WebSocket 프로토콜에서 요구하는 것으로 보안 용도가 아니다.
         expected_accept = base64.b64encode(
-            hashlib.sha1(
+            hashlib.sha1(  # nosemgrep
                 (ws_key + "258EAFA5-E914-47DA-95CA-C5AB0DC85B11").encode(),
                 usedforsecurity=False,
             ).digest()

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_condition_search_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_condition_search_unit.py
@@ -1,9 +1,9 @@
 """미국주식 조건검색(웹소켓) 메시지 모델 unit 테스트.
 
 usa20280/usa20281/usa20290/usa20291 4개 TR은 웹소켓 API이므로 HTTP 클라이언트
-테스트(run_post_case)를 적용할 수 없고, 클라이언트 구현도 아직 stub
-(``_overseas_condition_search.py``)이다. 따라서 요청 모델의 wire 포맷 dump와 응답
-모델의 field/alias 매핑만 검증한다.
+테스트(run_post_case)를 적용할 수 없다. 여기서는 요청 모델의 wire 포맷 dump와 응답
+모델의 field/alias 매핑을 검증한다. ``OverseasConditionSearch`` 도메인 래퍼의 요청
+송신·응답 파싱 동작은 ``test_overseas_condition_search_ws_unit.py``에서 검증한다.
 """
 
 import pytest

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_condition_search_ws_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_condition_search_ws_unit.py
@@ -1,0 +1,138 @@
+"""``OverseasConditionSearch`` 도메인 래퍼 unit 테스트.
+
+실제 WebSocket 없이 FakeSocketClient로 요청 프레임 송신과 응답 파싱, 그리고 실시간 푸시
+프레임이 섞여 있을 때 응답 프레임만 골라내는 ``_recv_until`` 동작을 검증한다.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from cluefin_openapi.kiwoom._overseas_condition_search import OverseasConditionSearch
+from cluefin_openapi.kiwoom._overseas_condition_search_types import (
+    OverseasConditionSearchListResponse,
+    OverseasConditionSearchRealtimeCancelResponse,
+    OverseasConditionSearchRealtimeResponse,
+    OverseasConditionSearchResponse,
+)
+from cluefin_openapi.kiwoom._socket_client import KiwoomWebSocketMessage
+
+
+class FakeSocketClient:
+    """송신 프레임을 기록하고, 미리 큐잉한 메시지를 recv()로 반환한다."""
+
+    def __init__(self, incoming: list[KiwoomWebSocketMessage] | None = None):
+        self.sent: list[dict] = []
+        self._incoming = list(incoming or [])
+
+    async def send(self, message):
+        self.sent.append(message.model_dump(by_alias=True) if isinstance(message, BaseModel) else message)
+
+    async def recv(self) -> KiwoomWebSocketMessage:
+        return self._incoming.pop(0)
+
+
+def _msg(body: dict) -> KiwoomWebSocketMessage:
+    return KiwoomWebSocketMessage(trnm=body.get("trnm", ""), body=body)
+
+
+class TestGetConditionSearchList:
+    @pytest.mark.asyncio
+    async def test_sends_gcnsrlst_and_parses_response(self):
+        socket = FakeSocketClient(
+            [_msg({"trnm": "GCNSRLST", "return_code": 0, "data": [{"seq": "0", "name": "조건식1"}]})]
+        )
+        condition = OverseasConditionSearch(socket)
+
+        result = await condition.get_condition_search_list()
+
+        assert socket.sent[0] == {"trnm": "GCNSRLST"}
+        assert isinstance(result, OverseasConditionSearchListResponse)
+        assert result.data[0].seq == "0"
+        assert result.data[0].name == "조건식1"
+
+
+class TestRequestConditionSearch:
+    @pytest.mark.asyncio
+    async def test_sends_gcnsrreq_search_type_0_and_parses(self):
+        socket = FakeSocketClient(
+            [
+                _msg(
+                    {
+                        "trnm": "GCNSRREQ",
+                        "return_code": 0,
+                        "seq": "0",
+                        "cont_yn": "N",
+                        "next_key": "",
+                        "data": [{"9001": "NVDA", "302": "엔비디아"}],
+                    }
+                )
+            ]
+        )
+        condition = OverseasConditionSearch(socket)
+
+        result = await condition.request_condition_search(seq="0")
+
+        assert socket.sent[0] == {
+            "trnm": "GCNSRREQ",
+            "seq": "0",
+            "search_type": "0",
+            "cont_yn": "N",
+            "next_key": "",
+        }
+        assert isinstance(result, OverseasConditionSearchResponse)
+        assert result.data[0].stock_code == "NVDA"
+        assert result.data[0].stock_name == "엔비디아"
+
+    @pytest.mark.asyncio
+    async def test_continuation_params_are_forwarded(self):
+        socket = FakeSocketClient([_msg({"trnm": "GCNSRREQ", "return_code": 0, "seq": "0", "data": []})])
+        condition = OverseasConditionSearch(socket)
+
+        await condition.request_condition_search(seq="0", cont_yn="Y", next_key="000123")
+
+        assert socket.sent[0]["cont_yn"] == "Y"
+        assert socket.sent[0]["next_key"] == "000123"
+
+
+class TestRealtimeConditionSearch:
+    @pytest.mark.asyncio
+    async def test_request_realtime_sends_search_type_1(self):
+        socket = FakeSocketClient(
+            [_msg({"trnm": "GCNSRREQ", "seq": "0", "data": [{"jmcode": "AAPL", "stexTp": "ND"}]})]
+        )
+        condition = OverseasConditionSearch(socket)
+
+        result = await condition.request_realtime_condition_search(seq="0")
+
+        assert socket.sent[0] == {"trnm": "GCNSRREQ", "seq": "0", "search_type": "1"}
+        assert isinstance(result, OverseasConditionSearchRealtimeResponse)
+        assert result.data[0].jmcode == "AAPL"
+        assert result.data[0].stex_tp == "ND"
+
+    @pytest.mark.asyncio
+    async def test_recv_until_skips_interleaved_real_frames(self):
+        """실시간 푸시 프레임(REAL)이 먼저 와도 GCNSRREQ 응답만 골라 반환한다."""
+        socket = FakeSocketClient(
+            [
+                _msg({"trnm": "REAL", "data": [{"type": "FE"}]}),
+                _msg({"trnm": "GCNSRREQ", "seq": "0", "data": []}),
+            ]
+        )
+        condition = OverseasConditionSearch(socket)
+
+        result = await condition.request_realtime_condition_search(seq="0")
+
+        assert isinstance(result, OverseasConditionSearchRealtimeResponse)
+        assert result.seq == "0"
+
+    @pytest.mark.asyncio
+    async def test_cancel_sends_gcnsrclr_and_parses_ack(self):
+        socket = FakeSocketClient([_msg({"trnm": "GCNSRCLR", "return_code": 0, "return_msg": "", "seq": "0"})])
+        condition = OverseasConditionSearch(socket)
+
+        result = await condition.cancel_realtime_condition_search(seq="0")
+
+        assert socket.sent[0] == {"trnm": "GCNSRCLR", "seq": "0"}
+        assert isinstance(result, OverseasConditionSearchRealtimeCancelResponse)
+        assert result.return_code == 0
+        assert result.seq == "0"

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_realtime_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_realtime_unit.py
@@ -1,8 +1,9 @@
 """미국주식 실시간 시세(웹소켓) 메시지 모델 unit 테스트.
 
 F4/F5/FE/FT 4개 TR은 웹소켓 API이므로 HTTP 클라이언트 테스트(run_post_case)를 적용할 수
-없고, 클라이언트 구현도 아직 stub(``_overseas_realtime.py``)이다. 따라서 등록/해지 요청
-프레임과 TR별 응답(values) 프레임의 pydantic 직렬화/역직렬화만 검증한다.
+없다. 등록/해지 요청 프레임과 TR별 응답(values) 프레임의 pydantic 직렬화/역직렬화를
+검증한다. ``OverseasRealtime`` 도메인 래퍼의 등록/해지 송신·프레임 파싱 동작은
+``test_overseas_realtime_ws_unit.py``에서 검증한다.
 """
 
 import pytest

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_realtime_ws_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_realtime_ws_unit.py
@@ -1,0 +1,109 @@
+"""``OverseasRealtime`` 도메인 래퍼 unit 테스트.
+
+실제 WebSocket 없이 FakeSocketClient로 등록/해지 프레임 송신과 REAL 프레임 파싱을
+검증한다.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from cluefin_openapi.kiwoom._overseas_realtime import OverseasRealtime
+from cluefin_openapi.kiwoom._overseas_realtime_types import (
+    OverseasRealtimeExecution,
+    OverseasRealtimeExecutionPrice,
+    OverseasRealtimeOrderConfirmation,
+    OverseasRealtimeRegisterItem,
+    OverseasRealtimeTenQuotes,
+)
+from cluefin_openapi.kiwoom._socket_client import KiwoomWebSocketMessage
+
+
+class FakeSocketClient:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send(self, message):
+        self.sent.append(message.model_dump(by_alias=True) if isinstance(message, BaseModel) else message)
+
+
+@pytest.fixture
+def socket() -> FakeSocketClient:
+    return FakeSocketClient()
+
+
+class TestRegisterRemove:
+    @pytest.mark.asyncio
+    async def test_register_builds_reg_frame_from_tuples(self, socket):
+        realtime = OverseasRealtime(socket)
+        await realtime.register(["F5", "FT"], [("NVDA", "ND"), ("AAPL", "ND")])
+        assert socket.sent[0] == {
+            "trnm": "REG",
+            "grp_no": "1",
+            "refresh": "1",
+            "data": [
+                {
+                    "item": [{"jmcode": "NVDA", "stex_tp": "ND"}, {"jmcode": "AAPL", "stex_tp": "ND"}],
+                    "type": ["F5", "FT"],
+                }
+            ],
+        }
+
+    @pytest.mark.asyncio
+    async def test_register_accepts_register_item_objects(self, socket):
+        realtime = OverseasRealtime(socket)
+        await realtime.register(["F4"], [OverseasRealtimeRegisterItem(jmcode="TSLA", stex_tp="NY")])
+        assert socket.sent[0]["data"][0]["item"] == [{"jmcode": "TSLA", "stex_tp": "NY"}]
+
+    @pytest.mark.asyncio
+    async def test_remove_builds_remove_frame(self, socket):
+        realtime = OverseasRealtime(socket)
+        await realtime.remove(["FT"], [("AAPL", "NA")], grp_no="2")
+        assert socket.sent[0] == {
+            "trnm": "REMOVE",
+            "grp_no": "2",
+            "refresh": "0",
+            "data": [{"item": [{"jmcode": "AAPL", "stex_tp": "NA"}], "type": ["FT"]}],
+        }
+
+
+class TestParse:
+    def test_parse_dispatches_execution_frame(self):
+        message = KiwoomWebSocketMessage(
+            trnm="REAL",
+            body={
+                "trnm": "REAL",
+                "data": [{"type": "F5", "item": "AAPL", "values": {"9001": "AAPL", "910": "190.00"}}],
+            },
+        )
+        parsed = OverseasRealtime.parse(message)
+        assert isinstance(parsed, OverseasRealtimeExecution)
+        assert parsed.data[0].values.stock_code == "AAPL"
+        assert parsed.data[0].values.execution_price == "190.00"
+
+    def test_parse_dispatches_order_confirmation_frame(self):
+        message = KiwoomWebSocketMessage(
+            trnm="REAL",
+            body={"trnm": "REAL", "data": [{"type": "F4", "item": "NVDA", "values": {"9001": "NVDA"}}]},
+        )
+        assert isinstance(OverseasRealtime.parse(message), OverseasRealtimeOrderConfirmation)
+
+    def test_parse_dispatches_execution_price_frame(self):
+        message = KiwoomWebSocketMessage(
+            trnm="REAL", body={"trnm": "REAL", "data": [{"type": "FE", "item": "TSLA", "values": {"10": "250.00"}}]}
+        )
+        assert isinstance(OverseasRealtime.parse(message), OverseasRealtimeExecutionPrice)
+
+    def test_parse_dispatches_ten_quotes_frame(self):
+        message = KiwoomWebSocketMessage(
+            trnm="REAL", body={"trnm": "REAL", "data": [{"type": "FT", "item": "NVDA", "values": {"41": "500.10"}}]}
+        )
+        assert isinstance(OverseasRealtime.parse(message), OverseasRealtimeTenQuotes)
+
+    def test_parse_returns_none_for_ack_frame(self):
+        """등록/해지 ACK 프레임(빈 data)은 대상 TR이 아니므로 None."""
+        message = KiwoomWebSocketMessage(trnm="REG", body={"trnm": "REG", "return_code": 0, "data": []})
+        assert OverseasRealtime.parse(message) is None
+
+    def test_parse_returns_none_for_unknown_type(self):
+        message = KiwoomWebSocketMessage(trnm="REAL", body={"trnm": "REAL", "data": [{"type": "0A"}]})
+        assert OverseasRealtime.parse(message) is None

--- a/packages/cluefin-openapi/tests/kiwoom/test_socket_client_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_socket_client_unit.py
@@ -1,0 +1,242 @@
+"""미국주식 WebSocket 클라이언트(``_socket_client``) unit 테스트.
+
+실제 네트워크 없이 FakeReader/FakeWriter로 프레임 codec, LOGIN, PING 회신을 검증한다.
+"""
+
+import asyncio
+import json
+import struct
+
+import pytest
+
+from cluefin_openapi.kiwoom._exceptions import KiwoomAPIError, KiwoomNetworkError
+from cluefin_openapi.kiwoom._socket_client import KiwoomWebSocketClient, KiwoomWebSocketMessage
+
+
+class FakeWriter:
+    def __init__(self):
+        self.writes: list[bytes] = []
+        self.closed = False
+
+    def write(self, data):
+        self.writes.append(data)
+
+    async def drain(self):
+        return None
+
+    def close(self):
+        self.closed = True
+
+    async def wait_closed(self):
+        return None
+
+
+class FakeReader:
+    def __init__(self, data: bytes = b"", handshake_response: bytes | None = None):
+        self.data = bytearray(data)
+        self.handshake_response = handshake_response or b""
+
+    async def readuntil(self, separator):
+        return self.handshake_response
+
+    async def readexactly(self, size):
+        if len(self.data) < size:
+            raise asyncio.IncompleteReadError(bytes(self.data), size)
+        chunk = bytes(self.data[:size])
+        del self.data[:size]
+        return chunk
+
+
+def _server_frame(payload: bytes, opcode: int = 0x1) -> bytes:
+    """서버→클라이언트 프레임(마스킹 없음)을 만든다."""
+    header = bytearray([0x80 | opcode])
+    length = len(payload)
+    if length <= 125:
+        header.append(length)
+    elif length <= 65535:
+        header.append(126)
+        header.extend(struct.pack(">H", length))
+    else:
+        header.append(127)
+        header.extend(struct.pack(">Q", length))
+    return bytes(header) + payload
+
+
+def _json_frame(obj: dict) -> bytes:
+    return _server_frame(json.dumps(obj).encode("utf-8"))
+
+
+def _decode_client_frame(frame: bytes) -> dict:
+    """클라이언트가 송신한 마스킹된 텍스트 프레임을 언마스킹해 JSON으로 되돌린다."""
+    length = frame[1] & 0x7F
+    offset = 2
+    if length == 126:
+        length = struct.unpack(">H", frame[2:4])[0]
+        offset = 4
+    elif length == 127:
+        length = struct.unpack(">Q", frame[2:10])[0]
+        offset = 10
+    mask_key = frame[offset : offset + 4]
+    payload = frame[offset + 4 : offset + 4 + length]
+    unmasked = bytes(byte ^ mask_key[i % 4] for i, byte in enumerate(payload))
+    return json.loads(unmasked.decode("utf-8"))
+
+
+@pytest.fixture
+def client() -> KiwoomWebSocketClient:
+    return KiwoomWebSocketClient(token="test-token", env="dev")
+
+
+class TestFraming:
+    @pytest.mark.parametrize("payload", [b"abc", b"x" * 126, b"x" * 66000])
+    @pytest.mark.asyncio
+    async def test_send_frame_masks_payload(self, client, payload):
+        client._writer = FakeWriter()
+        await client._send_frame(payload)
+        sent = client._writer.writes[0]
+        assert sent[0] == 0x81  # FIN + text
+        assert sent[1] & 0x80  # mask bit set
+
+    @pytest.mark.asyncio
+    async def test_send_frame_requires_writer(self, client):
+        with pytest.raises(KiwoomNetworkError):
+            await client._send_frame(b"abc")
+
+    @pytest.mark.parametrize("payload", [b"abc", b"x" * 126, b"x" * 66000])
+    @pytest.mark.asyncio
+    async def test_receive_frame_reads_unmasked(self, client, payload):
+        client._reader = FakeReader(_server_frame(payload))
+        opcode, received = await client._receive_frame()
+        assert opcode == 0x1
+        assert received == payload
+
+    @pytest.mark.asyncio
+    async def test_recv_json_parses_text_frame(self, client):
+        client._reader = FakeReader(_json_frame({"trnm": "REAL", "data": []}))
+        message = await client._recv_json()
+        assert isinstance(message, KiwoomWebSocketMessage)
+        assert message.trnm == "REAL"
+        assert message.body == {"trnm": "REAL", "data": []}
+
+    @pytest.mark.asyncio
+    async def test_recv_json_answers_protocol_ping(self, client):
+        client._writer = FakeWriter()
+        client._reader = FakeReader(_server_frame(b"", opcode=0x9) + _json_frame({"trnm": "REAL"}))
+        message = await client._recv_json()
+        assert message.trnm == "REAL"
+        # protocol ping(0x9) 수신시 pong(0xA)을 회신했는지 확인
+        assert client._writer.writes[0][0] == 0x80 | 0xA
+
+    @pytest.mark.asyncio
+    async def test_recv_json_close_frame_raises(self, client):
+        client._connected = True
+        client._reader = FakeReader(_server_frame(b"", opcode=0x8))
+        with pytest.raises(KiwoomNetworkError):
+            await client._recv_json()
+        assert client._connected is False
+
+
+class TestLogin:
+    @pytest.mark.asyncio
+    async def test_login_success(self, client):
+        client._writer = FakeWriter()
+        client._reader = FakeReader(_json_frame({"trnm": "LOGIN", "return_code": 0, "return_msg": ""}))
+        await client._login()
+        sent = _decode_client_frame(client._writer.writes[0])
+        assert sent == {"trnm": "LOGIN", "token": "test-token"}
+
+    @pytest.mark.asyncio
+    async def test_login_failure_raises(self, client):
+        client._writer = FakeWriter()
+        client._reader = FakeReader(_json_frame({"trnm": "LOGIN", "return_code": 1, "return_msg": "인증 실패"}))
+        with pytest.raises(KiwoomAPIError, match="인증 실패"):
+            await client._login()
+
+    @pytest.mark.asyncio
+    async def test_login_echoes_ping_before_login(self, client):
+        client._writer = FakeWriter()
+        client._reader = FakeReader(
+            _json_frame({"trnm": "PING", "seq": "1"}) + _json_frame({"trnm": "LOGIN", "return_code": 0})
+        )
+        await client._login()
+        # LOGIN 요청 1회 + PING 회신 1회 = 2회 송신
+        assert len(client._writer.writes) == 2
+
+
+class TestReceiveLoop:
+    @pytest.mark.asyncio
+    async def test_receive_loop_echoes_ping_and_queues_real(self, client):
+        client._writer = FakeWriter()
+        client._reader = FakeReader(
+            _json_frame({"trnm": "PING", "seq": "1"}) + _json_frame({"trnm": "REAL", "data": [{"type": "F5"}]})
+        )
+        client._connected = True
+        await client._receive_loop()  # reader 소진 후 IncompleteReadError로 종료
+        message = await client.recv()
+        assert message.trnm == "REAL"
+        # PING 회신이 송신되었는지
+        assert len(client._writer.writes) == 1
+
+    @pytest.mark.asyncio
+    async def test_emit_drops_oldest_when_full(self):
+        client = KiwoomWebSocketClient(token="t", env="dev", queue_maxsize=1)
+        await client._emit(KiwoomWebSocketMessage(trnm="A"))
+        await client._emit(KiwoomWebSocketMessage(trnm="B"))
+        message = await client.recv()
+        assert message.trnm == "B"
+
+
+class TestSend:
+    @pytest.mark.asyncio
+    async def test_send_serializes_pydantic_by_alias(self, client):
+        from cluefin_openapi.kiwoom._overseas_realtime_types import (
+            OverseasRealtimeRegisterData,
+            OverseasRealtimeRegisterItem,
+            OverseasRealtimeRequest,
+        )
+
+        client._writer = FakeWriter()
+        request = OverseasRealtimeRequest(
+            trnm="REG",
+            grp_no="1",
+            refresh="1",
+            data=[
+                OverseasRealtimeRegisterData(
+                    item=[OverseasRealtimeRegisterItem(jmcode="NVDA", stex_tp="ND")], type=["F5"]
+                )
+            ],
+        )
+        await client.send(request)
+        assert _decode_client_frame(client._writer.writes[0]) == {
+            "trnm": "REG",
+            "grp_no": "1",
+            "refresh": "1",
+            "data": [{"item": [{"jmcode": "NVDA", "stex_tp": "ND"}], "type": ["F5"]}],
+        }
+
+
+class TestConnect:
+    @pytest.mark.asyncio
+    async def test_connect_performs_handshake_login_and_starts_loop(self, client, monkeypatch):
+        writer = FakeWriter()
+        # 핸드셰이크 응답에 올바른 Sec-WebSocket-Accept를 넣기 위해 검증을 우회한다.
+        reader = FakeReader(
+            _json_frame({"trnm": "LOGIN", "return_code": 0}),
+            handshake_response=b"HTTP/1.1 101 Switching Protocols\r\n\r\n",
+        )
+
+        async def fake_open_connection(host, port, ssl=None):
+            return reader, writer
+
+        monkeypatch.setattr(asyncio, "open_connection", fake_open_connection)
+        monkeypatch.setattr(client, "_websocket_handshake", _noop_handshake)
+
+        await client.connect()
+        assert client.connected is True
+        assert client._receive_task is not None
+        await client.close()
+        assert client.connected is False
+
+
+async def _noop_handshake(*args, **kwargs):
+    return None


### PR DESCRIPTION
## 관련 이슈

<!-- Closes #이슈번호 형태로 관련 이슈를 연결해주세요 -->
_(관련 이슈 없음)_

## 변경 사항

`pass` stub이던 미국주식 조건검색(`_overseas_condition_search`)·실시간 시세(`_overseas_realtime`) 클래스를 실제 웹소켓 통신으로 구현했습니다. 요청/응답 Pydantic 모델(type)은 이미 존재했고, 이를 서버와 주고받는 통신 계층이 비어 있던 것을 채웠습니다.

- **`_socket_client.py` 신규** — 두 도메인이 공유하는 `KiwoomWebSocketClient`. `wss://…:10000/api/us/websocket` 접속, RFC 6455 프레이밍, LOGIN 인증, PING 자동 회신, 이벤트 큐, 송신 rate limit. 외부 의존성 없이 raw asyncio로 구현 (기존 `kis/_socket_client.py`와 동일한 방식).
- **`OverseasConditionSearch`** — GCNSRLST/GCNSRREQ(0·1)/GCNSRCLR 프레임 송신 + 응답 파싱. 실시간 푸시(REAL)가 섞여 와도 해당 요청 응답만 골라내는 `_recv_until`.
- **`OverseasRealtime`** — REG/REMOVE 등록·해지 송신 + REAL 프레임을 `type`(F4/F5/FE/FT)별 응답 모델로 파싱.
- `kiwoom/__init__.py` export 추가, `AGENTS.md`의 "not yet wired" 문구 갱신.

## 변경 유형

- [ ] 버그 수정 (`fix`)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 기존 기능 개선 (`feat`)
- [ ] 리팩토링 (`refactor`)
- [ ] 테스트 추가/수정 (`test`)
- [ ] 문서 수정 (`docs`)
- [ ] 의존성 업데이트 (`chore`)
- [ ] CI/CD (`ci`)

## 영향 범위

- [x] cluefin-openapi
- [ ] cluefin-ta
- [ ] cluefin-xbrl
- [ ] cluefin-cli
- [ ] cluefin-desk
- [ ] 루트 프로젝트 설정

## 테스트

소켓 클라이언트는 FakeReader/FakeWriter로 프레임 codec·LOGIN·PING을, 도메인 래퍼는 FakeSocketClient로 송신 프레임·응답 파싱을 검증합니다 (테스트 40여 개 추가). openapi 패키지 non-integration 1148개 전부 통과.

- [x] 단위 테스트 통과 (`uv run pytest -m "not integration"`)
- [ ] 통합 테스트 통과 (`uv run pytest -m "integration"`)
- [ ] 테스트 불필요 (문서, 설정 변경 등)

## 체크리스트

- [x] `uv run ruff format . && uv run ruff check . --fix` 실행
- [x] 커밋 메시지가 컨벤션을 따름 (`type(scope): 설명`)
- [x] `.env`, 시크릿, 인증 정보 미포함
- [x] 관련 문서 업데이트 완료 (해당 시)

## 참고 사항 (선택)

- 웹소켓 클라이언트는 async 라이프사이클 특성상 동기 HTTP `Client`의 `@property`로 배선하지 않았습니다. `KiwoomWebSocketClient(token, env)`를 직접 생성해 도메인 클래스에 주입하는 방식입니다 (KIS 선례와 동일).
- 실제 서버 연결이 필요한 `integration`/`realtime` 테스트는 시장 시간·자격증명이 필요해 이 변경에서는 실행하지 않았습니다.
