### PR TITLE
chore(deps): soupsieve 2.8.1 → 2.8.4 보안 업데이트

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -2289,11 +2289,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.1"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/89/23/adf3796d740536d63a6fbda113d07e60c734b6ed5d3058d1e47fc0495e47/soupsieve-2.8.1.tar.gz", hash = "sha256:4cf733bc50fa805f5df4b8ef4740fc0e0fa6218cf3006269afd3f9d6d80fd350", size = 117856, upload-time = "2025-12-18T13:50:34.655Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/48/f3/b67d6ea49ca9154453b6d70b34ea22f3996b9fa55da105a79d8732227adc/soupsieve-2.8.1-py3-none-any.whl", hash = "sha256:a11fe2a6f3d76ab3cf2de04eb339c1be5b506a8a47f2ceb6d139803177f85434", size = 36710, upload-time = "2025-12-18T13:50:33.267Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 관련 이슈

Dependabot alerts [#32](https://github.com/kgcrom/cluefin/security/dependabot/32), [#33](https://github.com/kgcrom/cluefin/security/dependabot/33)

## 변경 사항

`soupsieve` 2.8.1 → 2.8.4 업그레이드 (`uv.lock`만 변경).

- [GHSA-836r-79rf-4m37](https://github.com/advisories/GHSA-836r-79rf-4m37): Selector 파서 ReDoS (high)
- [GHSA-2wc2-fm75-p42x](https://github.com/advisories/GHSA-2wc2-fm75-p42x): 대량 콤마 구분 selector 리스트로 인한 메모리 고갈 (high)

`soupsieve`는 `beautifulsoup4`(cluefin-cli 직접 의존성)의 하위 의존성이라 `uv lock --upgrade-package soupsieve`로 lock 파일만 갱신했습니다.

## 변경 유형

- [ ] 버그 수정 (`fix`)
- [ ] 새로운 기능 추가 (`feat`)
- [ ] 기존 기능 개선 (`feat`)
- [ ] 리팩토링 (`refactor`)
- [ ] 테스트 추가/수정 (`test`)
- [ ] 문서 수정 (`docs`)
- [x] 의존성 업데이트 (`chore`)
- [ ] CI/CD (`ci`)

## 영향 범위

- [ ] cluefin-openapi
- [ ] cluefin-ta
- [ ] cluefin-xbrl
- [ ] cluefin-cli
- [ ] cluefin-desk
- [x] 루트 프로젝트 설정

## 테스트

- [ ] 단위 테스트 통과 (`uv run pytest -m "not integration"`)
- [ ] 통합 테스트 통과 (`uv run pytest -m "integration"`)
- [x] 테스트 불필요 (문서, 설정 변경 등)

lock 파일 패치 버전 갱신만 포함되어 코드 변경이 없습니다.

## 체크리스트

- [ ] `uv run ruff format . && uv run ruff check . --fix` 실행
- [x] 커밋 메시지가 컨벤션을 따름 (`type(scope): 설명`)
- [x] `.env`, 시크릿, 인증 정보 미포함
- [ ] 관련 문서 업데이트 완료 (해당 시)

## 참고 사항 (선택)

브레이킹 체인지 없음 (soupsieve 패치 릴리스).
