### PR TITLE
feat(kiwoom): 국내주식 조건검색·실시간 시세 웹소켓 구현

### DIFF
--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/__init__.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/__init__.py
@@ -3,6 +3,7 @@
 from ._auth import Auth
 from ._client import Client
 from ._domestic_condition_search import DomesticConditionSearch
+from ._domestic_realtime import DomesticRealtime
 from ._error_codes import KIWOOM_ERROR_CODES, error_type_for_code, resolve_kiwoom_error
 from ._exceptions import (
     KiwoomAPIError,
@@ -23,6 +24,7 @@ __all__ = [
     "Auth",
     "Client",
     "DomesticConditionSearch",
+    "DomesticRealtime",
     "KiwoomAPIError",
     "KiwoomAuthenticationError",
     "KiwoomAuthorizationError",

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/__init__.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/__init__.py
@@ -2,6 +2,7 @@
 
 from ._auth import Auth
 from ._client import Client
+from ._domestic_condition_search import DomesticConditionSearch
 from ._error_codes import KIWOOM_ERROR_CODES, error_type_for_code, resolve_kiwoom_error
 from ._exceptions import (
     KiwoomAPIError,
@@ -21,6 +22,7 @@ __all__ = [
     "KIWOOM_ERROR_CODES",
     "Auth",
     "Client",
+    "DomesticConditionSearch",
     "KiwoomAPIError",
     "KiwoomAuthenticationError",
     "KiwoomAuthorizationError",

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_condition_search.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_condition_search.py
@@ -1,0 +1,135 @@
+"""국내주식 조건검색 (웹소켓).
+
+운영: wss://api.kiwoom.com:10000/api/dostk/websocket
+모의투자: wss://mockapi.kiwoom.com:10000/api/dostk/websocket (KRX만 지원)
+
+``KiwoomWebSocketClient``(LOGIN/PING 처리)를 감싸 조건검색 요청 프레임을 송신하고 응답을
+파싱한다. 목록조회/요청 일반/해제는 요청-응답형이고, 요청 실시간(search_type=1)은 이후
+편입/이탈 이벤트가 실시간 푸시(trnm=REAL)로 도착한다. 국내는 거래소구분 ``stex_tp="K"``
+(KRX)를 요청에 포함한다. (미국주식 ``_overseas_condition_search`` 와 대칭.)
+
+TR:
+- ka10171 조건검색 목록조회   CNSRLST → DomesticConditionSearchListResponse
+- ka10172 조건검색 요청 일반   CNSRREQ(search_type=0) → DomesticConditionSearchResponse
+- ka10173 조건검색 요청 실시간 CNSRREQ(search_type=1) → DomesticConditionSearchRealtimeResponse
+- ka10174 조건검색 실시간 해제 CNSRCLR → DomesticConditionSearchRealtimeCancelResponse
+"""
+
+from typing import Literal
+
+from ._domestic_condition_search_types import (
+    DomesticConditionSearchListRequest,
+    DomesticConditionSearchListResponse,
+    DomesticConditionSearchRealtimeCancelRequest,
+    DomesticConditionSearchRealtimeCancelResponse,
+    DomesticConditionSearchRealtimeRequest,
+    DomesticConditionSearchRealtimeResponse,
+    DomesticConditionSearchRequest,
+    DomesticConditionSearchResponse,
+)
+from ._socket_client import KiwoomWebSocketClient, KiwoomWebSocketMessage
+
+
+class DomesticConditionSearch:
+    """국내주식 조건검색 WebSocket API.
+
+    Example:
+        ```python
+        async with KiwoomWebSocketClient(token="...", env="prod", market="domestic") as ws:
+            condition = DomesticConditionSearch(ws)
+            search_list = await condition.get_condition_search_list()
+            result = await condition.request_condition_search(seq="0")
+            print(result.data)
+        ```
+    """
+
+    def __init__(self, socket_client: KiwoomWebSocketClient):
+        self.socket_client = socket_client
+
+    async def get_condition_search_list(self) -> DomesticConditionSearchListResponse:
+        """국내주식 조건검색 목록조회 (ka10171, CNSRLST).
+
+        Returns:
+            DomesticConditionSearchListResponse: 조건검색식 목록.
+        """
+        await self.socket_client.send(DomesticConditionSearchListRequest(trnm="CNSRLST"))
+        message = await self._recv_until("CNSRLST")
+        return DomesticConditionSearchListResponse.model_validate(message.body)
+
+    async def request_condition_search(
+        self,
+        seq: str,
+        stex_tp: Literal["K"] = "K",
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> DomesticConditionSearchResponse:
+        """국내주식 조건검색 요청 일반 (ka10172, CNSRREQ search_type=0).
+
+        Args:
+            seq: 조건검색식 일련번호.
+            stex_tp: 거래소구분. "K":KRX.
+            cont_yn: 연속조회여부. "Y":연속조회요청, "N":연속조회미요청.
+            next_key: 연속조회키.
+
+        Returns:
+            DomesticConditionSearchResponse: 조건검색 결과.
+        """
+        await self.socket_client.send(
+            DomesticConditionSearchRequest(
+                trnm="CNSRREQ",
+                seq=seq,
+                search_type="0",
+                stex_tp=stex_tp,
+                cont_yn=cont_yn,
+                next_key=next_key,
+            )
+        )
+        message = await self._recv_until("CNSRREQ")
+        return DomesticConditionSearchResponse.model_validate(message.body)
+
+    async def request_realtime_condition_search(
+        self,
+        seq: str,
+        stex_tp: Literal["K"] = "K",
+    ) -> DomesticConditionSearchRealtimeResponse:
+        """국내주식 조건검색 요청 실시간 (ka10173, CNSRREQ search_type=1).
+
+        요청 직후 현재 편입 종목이 응답으로 반환되며, 이후 편입/이탈 이벤트는 실시간 푸시로
+        도착한다 (``socket_client.events()``로 수신, ``DomesticConditionSearchRealtimePush``).
+
+        Args:
+            seq: 조건검색식 일련번호.
+            stex_tp: 거래소구분. "K":KRX.
+
+        Returns:
+            DomesticConditionSearchRealtimeResponse: 실시간 조건검색 초기 결과.
+        """
+        await self.socket_client.send(
+            DomesticConditionSearchRealtimeRequest(trnm="CNSRREQ", seq=seq, search_type="1", stex_tp=stex_tp)
+        )
+        message = await self._recv_until("CNSRREQ")
+        return DomesticConditionSearchRealtimeResponse.model_validate(message.body)
+
+    async def cancel_realtime_condition_search(self, seq: str) -> DomesticConditionSearchRealtimeCancelResponse:
+        """국내주식 조건검색 실시간 해제 (ka10174, CNSRCLR).
+
+        Args:
+            seq: 조건검색식 일련번호.
+
+        Returns:
+            DomesticConditionSearchRealtimeCancelResponse: 해제 ACK.
+        """
+        await self.socket_client.send(DomesticConditionSearchRealtimeCancelRequest(trnm="CNSRCLR", seq=seq))
+        message = await self._recv_until("CNSRCLR")
+        return DomesticConditionSearchRealtimeCancelResponse.model_validate(message.body)
+
+    async def _recv_until(self, trnm: str) -> KiwoomWebSocketMessage:
+        """지정한 ``trnm`` 응답 프레임이 올 때까지 수신한다.
+
+        실시간 조건검색이 함께 켜져 있으면 REAL 푸시 프레임이 섞여 들어올 수 있으므로
+        요청에 대응하는 응답 프레임만 골라 반환한다.
+        """
+        while True:
+            message = await self.socket_client.recv()
+            if message.trnm == trnm:
+                return message

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_condition_search_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_condition_search_types.py
@@ -1,0 +1,214 @@
+"""국내주식 조건검색 (웹소켓) 요청/응답 모델.
+
+웹소켓 프레임은 HTTP 응답이 아니므로 ``KiwoomHttpBody``를 상속하지 않고 순수
+``BaseModel``로 정의한다. 응답 ``data`` List<Map> 요소 중 숫자 FID 키를 사용하는
+필드는 의미 있는 영어 필드명 + ``alias``로 매핑하고 ``populate_by_name=True``를
+설정한다. (미국주식 ``_overseas_condition_search_types.py`` 와 대칭.)
+
+- 운영: wss://api.kiwoom.com:10000/api/dostk/websocket
+- 모의투자: wss://mockapi.kiwoom.com:10000/api/dostk/websocket (KRX만 지원)
+
+TR/trnm: 목록조회 CNSRLST(ka10171), 요청 일반/실시간은 CNSRREQ(ka10172/ka10173)를
+공유하며 ``search_type`` 0/1 로 구분, 실시간 해제 CNSRCLR(ka10174). 요청에는
+``stex_tp``(거래소구분, 국내는 K:KRX)를 포함한다.
+
+ka10173(실시간)은 응답이 두 종류다: 최초 조회 응답(trnm CNSRREQ, data=[{jmcode}])과
+이후 실시간 편입/이탈 푸시(trnm REAL, data=[{type, name, values{...}}]). 각각
+``DomesticConditionSearchRealtimeResponse`` / ``DomesticConditionSearchRealtimePush``.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
+
+# ---------------------------------------------------------------------------
+# ka10171 조건검색 목록조회
+# ---------------------------------------------------------------------------
+
+
+class DomesticConditionSearchListRequest(BaseModel):
+    """ka10171 조건검색 목록조회 요청."""
+
+    model_config = ConfigDict(title="국내주식 조건검색 목록조회 요청")
+
+    trnm: Literal["CNSRLST"] = Field(description="TR명. CNSRLST 고정값")
+
+
+class DomesticConditionSearchListItem(BaseModel):
+    """조건검색식 목록 항목."""
+
+    model_config = ConfigDict(title="조건검색식 목록 항목")
+
+    seq: str = Field(default="", description="조건검색식 일련번호")
+    name: str = Field(default="", description="조건검색식 명")
+
+
+class DomesticConditionSearchListResponse(BaseModel):
+    """ka10171 조건검색 목록조회 응답."""
+
+    model_config = ConfigDict(title="국내주식 조건검색 목록조회 응답")
+
+    return_code: int | None = Field(default=None, description="결과코드. 정상:0")
+    return_msg: str = Field(default="", description="결과메시지. 정상인 경우는 메시지 없음")
+    trnm: str = Field(default="", description="서비스명. CNSRLST 고정값")
+    data: list[DomesticConditionSearchListItem] = Field(default_factory=list, description="조건검색식 목록")
+
+
+# ---------------------------------------------------------------------------
+# ka10172 조건검색 요청 일반
+# ---------------------------------------------------------------------------
+
+
+class DomesticConditionSearchRequest(BaseModel):
+    """ka10172 조건검색 요청 일반."""
+
+    model_config = ConfigDict(title="국내주식 조건검색 요청 일반")
+
+    trnm: Literal["CNSRREQ"] = Field(description="서비스명. CNSRREQ 고정값")
+    seq: str = Field(description="조건검색식 일련번호")
+    search_type: Literal["0"] = Field(description="조회타입. 0:조건검색")
+    stex_tp: Literal["K"] = Field(default="K", description="거래소구분. K:KRX")
+    cont_yn: Literal["Y", "N"] = Field(default="N", description="연속조회여부. Y:연속조회요청, N:연속조회미요청")
+    next_key: str = Field(default="", description="연속조회키")
+
+
+class DomesticConditionSearchResultItem(BaseModel):
+    """조건검색 결과 데이터 항목 (일반 조회).
+
+    값은 좌측 0-padding + 부호 포함 문자열로 내려온다 (예: 등락율 '00001500'=+1.50%,
+    '-0001500'=-1.50%). 파싱/부호 해석은 소비 측 책임.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, title="조건검색 결과 데이터 항목")
+
+    stock_code: str = Field(
+        default="", alias="9001", description="종목코드. 접두어 1자리+종목코드 6자리 (A:주식/J:ELW/Q:ETN)"
+    )
+    stock_name: str = Field(default="", alias="302", description="종목명")
+    current_price: str = Field(default="", alias="10", description="현재가. 단위:원, 0-padding 부호포함 9자리")
+    prev_day_diff_sign: str = Field(
+        default="", alias="25", description="전일대비기호. 1:상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비. 단위:원, 0-padding 부호포함 9자리")
+    fluctuation_rate: str = Field(
+        default="", alias="12", description="등락율. 0-padding 부호포함 8자리 (예: 00001500=+1.50%)"
+    )
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량. 단위:1주, 0-padding 부호포함 10자리")
+    open_price: str = Field(default="", alias="16", description="시가. 단위:원, 0-padding 부호포함 9자리")
+    high_price: str = Field(default="", alias="17", description="고가. 단위:원, 0-padding 부호포함 9자리")
+    low_price: str = Field(default="", alias="18", description="저가. 단위:원, 0-padding 부호포함 9자리")
+
+
+class DomesticConditionSearchResponse(BaseModel):
+    """ka10172 조건검색 요청 일반 응답."""
+
+    model_config = ConfigDict(title="국내주식 조건검색 요청 일반 응답")
+
+    return_code: int | None = Field(default=None, description="결과코드. 정상:0 나머지:에러")
+    return_msg: str = Field(default="", description="결과메시지. 정상인 경우는 메시지 없음")
+    trnm: str = Field(default="", description="서비스명. CNSRREQ")
+    seq: str = Field(default="", description="조건검색식 일련번호")
+    cont_yn: str = Field(default="", description="연속조회여부. 연속 데이터가 존재하는경우 Y, 없으면 N")
+    next_key: str = Field(default="", description="연속조회키. 연속조회여부가 Y일경우 다음 조회시 필요한 조회값")
+    data: list[DomesticConditionSearchResultItem] = Field(default_factory=list, description="검색결과데이터")
+
+
+# ---------------------------------------------------------------------------
+# ka10173 조건검색 요청 실시간
+# ---------------------------------------------------------------------------
+
+
+class DomesticConditionSearchRealtimeRequest(BaseModel):
+    """ka10173 조건검색 요청 실시간."""
+
+    model_config = ConfigDict(title="국내주식 조건검색 요청 실시간")
+
+    trnm: Literal["CNSRREQ"] = Field(description="서비스명. CNSRREQ 고정값")
+    seq: str = Field(description="조건검색식 일련번호")
+    search_type: Literal["1"] = Field(description="조회타입. 1:조건검색+실시간조건검색")
+    stex_tp: Literal["K"] = Field(default="K", description="거래소구분. K:KRX")
+
+
+class DomesticConditionSearchRealtimeResultItem(BaseModel):
+    """ka10173 최초 조회 응답 데이터 항목 (편입 종목 목록)."""
+
+    model_config = ConfigDict(title="조건검색 실시간 조회 데이터 항목")
+
+    jmcode: str = Field(default="", description="종목코드. 접두어 1자리+종목코드 6자리 (A:주식/J:ELW/Q:ETN)")
+
+
+class DomesticConditionSearchRealtimeResponse(BaseModel):
+    """ka10173 조건검색 요청 실시간 - 최초 조회 응답 (trnm=CNSRREQ)."""
+
+    model_config = ConfigDict(title="국내주식 조건검색 요청 실시간 응답")
+
+    return_code: int | None = Field(default=None, description="결과코드. 정상:0 나머지:에러")
+    return_msg: str = Field(default="", description="결과메시지. 정상인 경우는 메시지 없음")
+    trnm: str = Field(default="", description="서비스명. CNSRREQ")
+    seq: str = Field(default="", description="조건검색식 일련번호")
+    data: list[DomesticConditionSearchRealtimeResultItem] = Field(default_factory=list, description="검색결과데이터")
+
+
+class DomesticConditionSearchRealtimeValues(BaseModel):
+    """ka10173 실시간 푸시 프레임의 values 오브젝트 (FID 매핑)."""
+
+    model_config = ConfigDict(populate_by_name=True, title="조건검색 실시간 수신 값")
+
+    seq_no: str = Field(default="", alias="841", description="일련번호")
+    stock_code: str = Field(default="", alias="9001", description="종목코드")
+    insert_delete: str = Field(default="", alias="843", description="삽입삭제 구분. I:삽입, D:삭제")
+    exec_time: str = Field(default="", alias="20", description="체결시간")
+    buy_sell: str = Field(default="", alias="907", description="매도/수 구분")
+    exchange: str = Field(default="", alias="9081", description="거래소 구분")
+
+
+class DomesticConditionSearchRealtimeDataItem(BaseModel):
+    """ka10173 실시간 푸시 프레임의 data 항목."""
+
+    model_config = ConfigDict(title="조건검색 실시간 데이터 항목")
+
+    type: str = Field(description="실시간 항목. TR명(0A,0B...)")
+    name: str = Field(description="실시간 항목명")
+    values: DomesticConditionSearchRealtimeValues = Field(description="실시간 수신 값")
+
+
+class DomesticConditionSearchRealtimePush(BaseModel):
+    """ka10173 조건검색 실시간 편입/이탈 푸시 프레임 (trnm=REAL).
+
+    스펙상 data/trnm 모두 Required=Y 인 실시간 이벤트 프레임.
+    """
+
+    model_config = ConfigDict(title="국내주식 조건검색 실시간 푸시")
+
+    trnm: Literal["REAL"] = Field(description="서비스명. REAL 고정값")
+    data: list[DomesticConditionSearchRealtimeDataItem] = Field(description="검색결과데이터")
+
+
+# ---------------------------------------------------------------------------
+# ka10174 조건검색 실시간 해제
+# ---------------------------------------------------------------------------
+
+
+class DomesticConditionSearchRealtimeCancelRequest(BaseModel):
+    """ka10174 조건검색 실시간 해제 요청."""
+
+    model_config = ConfigDict(title="국내주식 조건검색 실시간 해제 요청")
+
+    trnm: Literal["CNSRCLR"] = Field(description="서비스명. CNSRCLR 고정값")
+    seq: str = Field(description="조건검색식 일련번호")
+
+
+class DomesticConditionSearchRealtimeCancelResponse(BaseModel):
+    """ka10174 조건검색 실시간 해제 응답.
+
+    스펙상 네 필드 모두 Required=Y(단순 ACK 프레임)이므로 다른 TR과 달리 기본값을
+    부여하지 않는다.
+    """
+
+    model_config = ConfigDict(title="국내주식 조건검색 실시간 해제 응답")
+
+    return_code: int = Field(description="결과코드. 정상:0 나머지:에러")
+    return_msg: str = Field(description="결과메시지. 정상인 경우는 메시지 없음")
+    trnm: Literal["CNSRCLR"] = Field(description="서비스명. CNSRCLR 고정값")
+    seq: str = Field(description="조건검색식 일련번호")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_realtime.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_realtime.py
@@ -1,22 +1,172 @@
+"""국내주식 실시간 시세 (웹소켓).
+
+운영: wss://api.kiwoom.com:10000/api/dostk/websocket
+모의투자: wss://mockapi.kiwoom.com:10000/api/dostk/websocket (KRX만 지원)
+
+``KiwoomWebSocketClient``(LOGIN/PING 처리)를 감싸 실시간 시세 등록/해지(REG/REMOVE)
+프레임을 송신하고, 수신한 REAL 프레임을 TR별 응답 모델로 파싱한다. 국내는 등록 요소
+``item``이 거래소별 종목/업종코드 문자열(KRX:039490, NXT:039490_NX, SOR:039490_AL)이다.
+(미국주식 ``_overseas_realtime`` 와 대칭.)
+
+TR (type):
+- 00 주문체결        → DomesticRealtimeOrderExecution
+- 04 잔고            → DomesticRealtimeBalance
+- 0A 주식기세        → DomesticRealtimeStockMomentum
+- 0B 주식체결        → DomesticRealtimeStockExecution
+- 0C 주식우선호가    → DomesticRealtimeStockPriorityQuote
+- 0D 주식호가잔량    → DomesticRealtimeStockQuoteRemaining
+- 0E 주식시간외호가  → DomesticRealtimeStockAfterHoursQuote
+- 0F 주식당일거래원  → DomesticRealtimeStockCurrentDayTrader
+- 0G ETF NAV         → DomesticRealtimeEtfNav
+- 0H 주식예상체결    → DomesticRealtimeStockExpectedExecution
+- 0I 국제금환산가격  → DomesticRealtimeIntlGoldPrice
+- 0J 업종지수        → DomesticRealtimeIndustryIndex
+- 0U 업종등락        → DomesticRealtimeIndustryFluctuation
+- 0g 주식종목정보    → DomesticRealtimeStockItemInfo
+- 0m ELW 이론가      → DomesticRealtimeElwTheoreticalPrice
+- 0s 장시작시간      → DomesticRealtimeMarketStartTime
+- 0u ELW 지표        → DomesticRealtimeElwIndicator
+- 0w 종목프로그램매매 → DomesticRealtimeStockProgramTrading
+- 1h VI발동/해제     → DomesticRealtimeViActivation
+"""
+
+from typing import Iterable, Optional
+
+from pydantic import BaseModel
+
+from ._domestic_realtime_types import (
+    DomesticRealtimeBalance,
+    DomesticRealtimeElwIndicator,
+    DomesticRealtimeElwTheoreticalPrice,
+    DomesticRealtimeEtfNav,
+    DomesticRealtimeIndustryFluctuation,
+    DomesticRealtimeIndustryIndex,
+    DomesticRealtimeIntlGoldPrice,
+    DomesticRealtimeMarketStartTime,
+    DomesticRealtimeOrderExecution,
+    DomesticRealtimeRegisterData,
+    DomesticRealtimeRequest,
+    DomesticRealtimeStockAfterHoursQuote,
+    DomesticRealtimeStockCurrentDayTrader,
+    DomesticRealtimeStockExecution,
+    DomesticRealtimeStockExpectedExecution,
+    DomesticRealtimeStockItemInfo,
+    DomesticRealtimeStockMomentum,
+    DomesticRealtimeStockPriorityQuote,
+    DomesticRealtimeStockProgramTrading,
+    DomesticRealtimeStockQuoteRemaining,
+    DomesticRealtimeViActivation,
+)
+from ._socket_client import KiwoomWebSocketClient, KiwoomWebSocketMessage
+
+# 수신한 REAL 프레임의 ``data[].type`` → 응답 모델 매핑
+_FRAME_MODELS = {
+    "00": DomesticRealtimeOrderExecution,
+    "04": DomesticRealtimeBalance,
+    "0A": DomesticRealtimeStockMomentum,
+    "0B": DomesticRealtimeStockExecution,
+    "0C": DomesticRealtimeStockPriorityQuote,
+    "0D": DomesticRealtimeStockQuoteRemaining,
+    "0E": DomesticRealtimeStockAfterHoursQuote,
+    "0F": DomesticRealtimeStockCurrentDayTrader,
+    "0G": DomesticRealtimeEtfNav,
+    "0H": DomesticRealtimeStockExpectedExecution,
+    "0I": DomesticRealtimeIntlGoldPrice,
+    "0J": DomesticRealtimeIndustryIndex,
+    "0U": DomesticRealtimeIndustryFluctuation,
+    "0g": DomesticRealtimeStockItemInfo,
+    "0m": DomesticRealtimeElwTheoreticalPrice,
+    "0s": DomesticRealtimeMarketStartTime,
+    "0u": DomesticRealtimeElwIndicator,
+    "0w": DomesticRealtimeStockProgramTrading,
+    "1h": DomesticRealtimeViActivation,
+}
+
+
 class DomesticRealtime:
-    pass
+    """국내주식 실시간 시세 WebSocket API.
 
+    Example:
+        ```python
+        async with KiwoomWebSocketClient(token="...", env="prod", market="domestic") as ws:
+            realtime = DomesticRealtime(ws)
+            await realtime.register(["0B", "0D"], ["005930", "000660"])
+            async for message in ws.events():
+                parsed = realtime.parse(message)
+                if parsed is not None:
+                    print(parsed)
+        ```
+    """
 
-# 주문체결	OO	get_order_execution
-# 잔고	04	get_balance
-# 주식기세	OA	get_stock_momentum
-# 주식체결	OB	get_stock_execution
-# 주식우선호가	OC	get_stock_priority_quote
-# 주식호가잔량	OD	get_stock_remaining_order_quantity
-# 주식시간외호가	OE	get_stock_after_hours_quote
-# 주식당일거래원	OF	get_stock_current_day_traders
-# ETF NAV	OG	get_etf_nav
-# 주식예상체결	OH	get_stock_expected_execution
-# 업종지수	OJ	get_industry_index
-# 업종등락	OU	get_industry_fluctuation
-# 주식종목정보	Og	get_stock_item_info
-# ELW 이론가	Om	get_elw_theoretical_price
-# 장시작시간	Os	get_market_start_time
-# ELW지표	Ou	get_elw_indicator
-# 종목별프로그램매매	Ow	get_program_trading_by_stock
-# VI발동/해제	1h	get_vi_activation_release
+    def __init__(self, socket_client: KiwoomWebSocketClient):
+        self.socket_client = socket_client
+
+    async def register(
+        self,
+        types: Iterable[str],
+        items: Iterable[str],
+        grp_no: str = "1",
+        refresh: str = "1",
+    ) -> None:
+        """실시간 시세를 등록(REG)한다.
+
+        Args:
+            types: 등록할 TR type 리스트 (예: ["0B", "0D"]).
+            items: 등록할 종목코드 리스트. 거래소별 종목/업종코드
+                (KRX:039490, NXT:039490_NX, SOR:039490_AL).
+            grp_no: 그룹번호. Defaults to "1".
+            refresh: 기존등록유지여부. "1":기존유지(Default), "0":기존등록 item/type 해지.
+        """
+        await self._send("REG", types, items, grp_no, refresh)
+
+    async def remove(
+        self,
+        types: Iterable[str],
+        items: Iterable[str],
+        grp_no: str = "1",
+    ) -> None:
+        """실시간 시세를 해지(REMOVE)한다.
+
+        Args:
+            types: 해지할 TR type 리스트.
+            items: 해지할 종목코드 리스트.
+            grp_no: 그룹번호. Defaults to "1".
+        """
+        # 해지시 refresh 값은 스펙상 불필요하지만 필수 필드이므로 "0"을 전달한다.
+        await self._send("REMOVE", types, items, grp_no, "0")
+
+    async def _send(
+        self,
+        trnm: str,
+        types: Iterable[str],
+        items: Iterable[str],
+        grp_no: str,
+        refresh: str,
+    ) -> None:
+        request = DomesticRealtimeRequest(
+            trnm=trnm,
+            grp_no=grp_no,
+            refresh=refresh,
+            data=[DomesticRealtimeRegisterData(item=list(items), type=list(types))],
+        )
+        await self.socket_client.send(request)
+
+    @staticmethod
+    def parse(message: KiwoomWebSocketMessage) -> Optional[BaseModel]:
+        """수신 프레임을 TR type에 맞는 응답 모델로 파싱한다.
+
+        ``data[].type``으로 TR을 판별하며, 실시간 대상이 아닌 프레임(빈 data, LOGIN/PING
+        등)은 ``None``을 반환한다.
+
+        Args:
+            message: 수신한 WebSocket 메시지.
+
+        Returns:
+            파싱된 응답 모델. 대상 TR이 아니면 None.
+        """
+        data = message.body.get("data") or []
+        tr_type = data[0].get("type") if data and isinstance(data[0], dict) else None
+        model = _FRAME_MODELS.get(tr_type)
+        if model is None:
+            return None
+        return model.model_validate(message.body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_realtime_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_realtime_types.py
@@ -1,0 +1,1255 @@
+"""국내주식 실시간 시세 (웹소켓) 요청/응답 모델.
+
+웹소켓 프레임은 HTTP 응답이 아니므로 ``KiwoomHttpBody``를 상속하지 않고 순수
+``BaseModel``로 정의한다. 응답 ``values`` Map은 숫자 FID 키를 사용하므로 의미 있는
+영어 필드명 + ``alias``(FID)로 매핑하고 ``populate_by_name=True``를 설정한다.
+(미국주식 ``_overseas_realtime_types.py`` 와 대칭.)
+
+이 모듈은 openapi.kiwoom.com 실시간시세 가이드(jobTpCode=14)의 19개 TR 스펙에서
+생성되었다. FID 매핑은 각 TR 응답표를 그대로 반영한다.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+from pydantic.config import ConfigDict
+
+# ---------------------------------------------------------------------------
+# 공통 등록/해지 요청 모델 (전체 TR 공유, REG/REMOVE)
+# ---------------------------------------------------------------------------
+
+
+class DomesticRealtimeRegisterData(BaseModel):
+    """실시간 등록 리스트 항목."""
+
+    model_config = ConfigDict(title="실시간 등록 리스트 항목")
+
+    item: list[str] = Field(
+        default_factory=list,
+        description="실시간 등록 요소. 거래소별 종목/업종코드 리스트 (KRX:039490, NXT:039490_NX, SOR:039490_AL)",
+    )
+    type: list[str] = Field(default_factory=list, description="실시간 항목. TR명 리스트 (0A, 0B ...)")
+
+
+class DomesticRealtimeRequest(BaseModel):
+    """실시간 등록/해지 요청 (REG/REMOVE)."""
+
+    model_config = ConfigDict(title="국내주식 실시간 시세 등록/해지 요청")
+
+    trnm: Literal["REG", "REMOVE"] = Field(description="서비스명. REG:등록, REMOVE:해지")
+    grp_no: str = Field(description="그룹번호")
+    refresh: Literal["0", "1"] = Field(
+        description="기존등록유지여부. 등록(REG)시 0:기존등록 item/type 해지, 1:기존등록 유지(Default). 해지(REMOVE)시 값 불필요"
+    )
+    data: list[DomesticRealtimeRegisterData] = Field(default_factory=list, description="실시간 등록 리스트")
+
+
+# ---------------------------------------------------------------------------
+# TR별 values 모델
+# ---------------------------------------------------------------------------
+
+
+class DomesticRealtimeOrderExecutionValues(BaseModel):
+    """00 주문체결 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주문체결 values")
+
+    account_no: str = Field(default="", alias="9201", description="계좌번호. 고유 계좌번호 10자리")
+    order_no: str = Field(default="", alias="9203", description="주문번호. 주문번호 7자리")
+    manager_id: str = Field(default="", alias="9205", description="관리자사번")
+    stock_code: str = Field(default="", alias="9001", description="종목코드,업종코드")
+    order_business_type: str = Field(default="", alias="912", description="주문업무분류")
+    order_status: str = Field(default="", alias="913", description="주문상태. 접수, 체결, 확인, 취소, 거부")
+    stock_name: str = Field(default="", alias="302", description="종목명")
+    order_quantity: str = Field(default="", alias="900", description="주문수량. 단위: 1주")
+    order_price: str = Field(default="", alias="901", description="주문가격. 단위: 원")
+    unexecuted_quantity: str = Field(default="", alias="902", description="미체결수량. 단위: 1주")
+    cumulative_execution_amount: str = Field(default="", alias="903", description="체결누계금액. 단위: 원")
+    original_order_no: str = Field(
+        default="", alias="904", description="원주문번호. 원 주문이 없는 경우 '0000000'으로 출력"
+    )
+    order_type: str = Field(
+        default="",
+        alias="905",
+        description='주문구분. "+/-", 매도, 매수, 매도정정, 매수정정, 매수취소, 매도취소 / / ※ 영웅문4에서 적색으로 표기되어있으면 +가, 청색으로 표기되어있으면 -가 앞에 기재됩니다',
+    )
+    trade_type: str = Field(
+        default="",
+        alias="906",
+        description="매매구분. 보통, 시장가, 조건부지정가, 최유리지정가, 최우선지정가, 보통(IOC), 시장가(IOC), 최유리(IOC), 보통(FOK), 시장가(FOK), 최유리(FOK), 스톰지정가, 중간가, 중간가(IOC), 중간가(FOK), 장전시간외, 장후시간외, 시간외대량, 시간외바스켓, 시간외자사주, 시간외단일가",
+    )
+    sell_buy_type: str = Field(default="", alias="907", description="매도수구분. 1:매도, 2:매수")
+    order_execution_time: str = Field(default="", alias="908", description="주문/체결시간. HHmmss")
+    execution_no: str = Field(default="", alias="909", description="체결번호")
+    execution_price: str = Field(default="", alias="910", description="체결가")
+    execution_quantity: str = Field(default="", alias="911", description="체결량")
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    best_ask_price: str = Field(default="", alias="27", description="(최우선)매도호가. 단위: 원, 부호가 포함된 숫자")
+    best_bid_price: str = Field(default="", alias="28", description="(최우선)매수호가. 단위: 원, 부호가 포함된 숫자")
+    unit_execution_price: str = Field(default="", alias="914", description="단위체결가")
+    unit_execution_quantity: str = Field(default="", alias="915", description="단위체결량")
+    today_trade_commission: str = Field(default="", alias="938", description="당일매매수수료")
+    today_trade_tax: str = Field(default="", alias="939", description="당일매매세금")
+    rejection_reason: str = Field(default="", alias="919", description="거부사유")
+    screen_no: str = Field(default="", alias="920", description="화면번호. HTS화면번호")
+    terminal_no: str = Field(default="", alias="921", description="터미널번호")
+    credit_type2: str = Field(default="", alias="922", description="신용구분. 실시간 체결용")
+    loan_date2: str = Field(default="", alias="923", description="대출일. 실시간 체결용")
+    after_hours_single_price_current_price: str = Field(default="", alias="10010", description="시간외단일가_현재가")
+    exchange_type2: str = Field(default="", alias="2134", description="거래소구분. 0:통합,1:KRX,2:NXT")
+    exchange_type_name: str = Field(default="", alias="2135", description="거래소구분명. 통합,KRX,NXT")
+    sor_yn: str = Field(default="", alias="2136", description="SOR여부. Y,N")
+
+
+class DomesticRealtimeBalanceValues(BaseModel):
+    """04 잔고 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 잔고 values")
+
+    account_no: str = Field(default="", alias="9201", description="계좌번호. 고유 계좌번호 10자리")
+    stock_code: str = Field(default="", alias="9001", description="종목코드,업종코드")
+    credit_type: str = Field(default="", alias="917", description="신용구분")
+    loan_date: str = Field(default="", alias="916", description="대출일. YYYYMMDD")
+    stock_name: str = Field(default="", alias="302", description="종목명")
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    holding_quantity: str = Field(default="", alias="930", description="보유수량. 단위: 1주")
+    purchase_unit_price: str = Field(default="", alias="931", description="매입단가. 단위: 원")
+    total_purchase_price: str = Field(default="", alias="932", description="총매입가(당일누적). 단위: 원")
+    orderable_quantity: str = Field(default="", alias="933", description="주문가능수량. 단위: 1주")
+    today_net_buy_quantity: str = Field(default="", alias="945", description="당일순매수량. 단위: 1주")
+    sell_buy_type2: str = Field(default="", alias="946", description="매도/매수구분. 계약,주")
+    today_total_sell_profit_loss: str = Field(default="", alias="950", description="당일총매도손익")
+    extra_item2: str = Field(default="", alias="951", description="Extra Item")
+    best_ask_price: str = Field(default="", alias="27", description="(최우선)매도호가. 단위: 원, 부호가 포함된 숫자")
+    best_bid_price: str = Field(default="", alias="28", description="(최우선)매수호가. 단위: 원, 부호가 포함된 숫자")
+    base_price: str = Field(default="", alias="307", description="기준가. 단위: 원")
+    profit_loss_rate: str = Field(
+        default="", alias="8019", description="손익률(실현손익). 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    credit_amount: str = Field(default="", alias="957", description="신용금액")
+    credit_interest: str = Field(default="", alias="958", description="신용이자")
+    maturity_date: str = Field(default="", alias="918", description="만기일. YYYYMMDD")
+    today_realized_profit_loss_securities: str = Field(default="", alias="990", description="당일실현손익(유가)")
+    today_realized_profit_loss_rate_securities: str = Field(default="", alias="991", description="당일실현손익율(유가)")
+    today_realized_profit_loss_credit: str = Field(default="", alias="992", description="당일실현손익(신용)")
+    today_realized_profit_loss_rate_credit: str = Field(default="", alias="993", description="당일실현손익율(신용)")
+    collateral_loan_quantity: str = Field(default="", alias="959", description="담보대출수량")
+    extra_item: str = Field(default="", alias="924", description="Extra Item")
+
+
+class DomesticRealtimeStockMomentumValues(BaseModel):
+    """0A 주식기세 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식기세 values")
+
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비. 단위: 원, 부호가 포함된 숫자")
+    fluctuation_rate: str = Field(
+        default="", alias="12", description="등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    best_ask_price: str = Field(default="", alias="27", description="(최우선)매도호가. 단위: 원, 부호가 포함된 숫자")
+    best_bid_price: str = Field(default="", alias="28", description="(최우선)매수호가. 단위: 원, 부호가 포함된 숫자")
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량. 단위: 1주")
+    acc_trade_value: str = Field(default="", alias="14", description="누적거래대금. 단위: 백만원")
+    open_price: str = Field(default="", alias="16", description="시가. 단위: 원, 부호가 포함된 숫자")
+    high_price: str = Field(default="", alias="17", description="고가. 단위: 원, 부호가 포함된 숫자")
+    low_price: str = Field(default="", alias="18", description="저가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff_sign: str = Field(
+        default="", alias="25", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+    prev_day_volume_diff: str = Field(
+        default="", alias="26", description="전일거래량대비(계약,주). 단위: 1주, 부호가 포함된 숫자"
+    )
+    trade_value_change: str = Field(default="", alias="29", description="거래대금증감. 단위: 원, 부호가 포함된 숫자")
+    prev_day_volume_ratio: str = Field(
+        default="",
+        alias="30",
+        description="전일거래량대비(비율). 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율",
+    )
+    turnover_rate: str = Field(
+        default="", alias="31", description="거래회전율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    trade_cost: str = Field(default="", alias="32", description="거래비용")
+    market_cap: str = Field(default="", alias="311", description="시가총액(억). 단위: 억원")
+    upper_limit_time: str = Field(default="", alias="567", description="상한가발생시간. HHmmss")
+    lower_limit_time: str = Field(default="", alias="568", description="하한가발생시간. HHmmss")
+
+
+class DomesticRealtimeStockExecutionValues(BaseModel):
+    """0B 주식체결 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식체결 values")
+
+    execution_time: str = Field(default="", alias="20", description="체결시간. HHmmss")
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비. 단위: 원, 부호가 포함된 숫자")
+    fluctuation_rate: str = Field(
+        default="", alias="12", description="등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    best_ask_price: str = Field(default="", alias="27", description="(최우선)매도호가. 단위: 원, 부호가 포함된 숫자")
+    best_bid_price: str = Field(default="", alias="28", description="(최우선)매수호가. 단위: 원, 부호가 포함된 숫자")
+    trade_volume: str = Field(default="", alias="15", description="거래량. +는 매수체결,-는 매도체결")
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량. 단위: 1주")
+    acc_trade_value: str = Field(default="", alias="14", description="누적거래대금. 단위: 백만원")
+    open_price: str = Field(default="", alias="16", description="시가. 단위: 원, 부호가 포함된 숫자")
+    high_price: str = Field(default="", alias="17", description="고가. 단위: 원, 부호가 포함된 숫자")
+    low_price: str = Field(default="", alias="18", description="저가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff_sign: str = Field(
+        default="", alias="25", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+    prev_day_volume_diff: str = Field(
+        default="", alias="26", description="전일거래량대비(계약,주). 단위: 1주, 부호가 포함된 숫자"
+    )
+    trade_value_change: str = Field(default="", alias="29", description="거래대금증감. 단위: 원, 부호가 포함된 숫자")
+    prev_day_volume_ratio: str = Field(
+        default="",
+        alias="30",
+        description="전일거래량대비(비율). 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율",
+    )
+    turnover_rate: str = Field(
+        default="", alias="31", description="거래회전율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    trade_cost: str = Field(default="", alias="32", description="거래비용")
+    execution_strength: str = Field(
+        default="", alias="228", description="체결강도. 단위: %, 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    market_cap: str = Field(default="", alias="311", description="시가총액(억)")
+    market_type: str = Field(default="", alias="290", description="장구분. 1: 장전 시간외 , 2: 장중 , 3: 장후 시간외")
+    ko_approach: str = Field(default="", alias="691", description="K.O 접근도")
+    upper_limit_time: str = Field(default="", alias="567", description="상한가발생시간. HHmmss")
+    lower_limit_time: str = Field(default="", alias="568", description="하한가발생시간. HHmmss")
+    prev_same_time_volume_ratio: str = Field(default="", alias="851", description="전일 동시간 거래량 비율")
+    open_time: str = Field(default="", alias="1890", description="시가시간")
+    high_time: str = Field(default="", alias="1891", description="고가시간")
+    low_time: str = Field(default="", alias="1892", description="저가시간")
+    sell_execution_volume: str = Field(default="", alias="1030", description="매도체결량")
+    buy_execution_volume: str = Field(default="", alias="1031", description="매수체결량")
+    buy_ratio2: str = Field(default="", alias="1032", description="매수비율")
+    sell_execution_count: str = Field(default="", alias="1071", description="매도체결건수")
+    buy_execution_count: str = Field(default="", alias="1072", description="매수체결건수")
+    instant_trade_value: str = Field(default="", alias="1313", description="순간거래대금")
+    sell_execution_volume_single: str = Field(default="", alias="1315", description="매도체결량_단건")
+    buy_execution_volume_single: str = Field(default="", alias="1316", description="매수체결량_단건")
+    net_buy_execution_volume: str = Field(default="", alias="1314", description="순매수체결량")
+    cfd_margin: str = Field(default="", alias="1497", description="CFD증거금")
+    maintenance_margin: str = Field(default="", alias="1498", description="유지증거금")
+    today_avg_trade_price: str = Field(default="", alias="620", description="당일거래평균가")
+    cfd_trade_cost: str = Field(default="", alias="732", description="CFD거래비용")
+    short_sell_trade_cost: str = Field(default="", alias="852", description="대주거래비용")
+    exchange_type3: str = Field(default="", alias="9081", description="거래소구분")
+
+
+class DomesticRealtimeStockPriorityQuoteValues(BaseModel):
+    """0C 주식우선호가 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식우선호가 values")
+
+    best_ask_price: str = Field(default="", alias="27", description="(최우선)매도호가. 단위: 원, 부호가 포함된 숫자")
+    best_bid_price: str = Field(default="", alias="28", description="(최우선)매수호가. 단위: 원, 부호가 포함된 숫자")
+
+
+class DomesticRealtimeStockQuoteRemainingValues(BaseModel):
+    """0D 주식호가잔량 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식호가잔량 values")
+
+    quote_time: str = Field(default="", alias="21", description="호가시간. HHmmss")
+    ask_price_1: str = Field(default="", alias="41", description="매도호가1. 단위: 원, 부호가 포함된 숫자")
+    ask_volume_1: str = Field(default="", alias="61", description="매도호가수량1. 단위: 1주")
+    ask_prev_diff_1: str = Field(default="", alias="81", description="매도호가직전대비1")
+    bid_price_1: str = Field(default="", alias="51", description="매수호가1. 단위: 원, 부호가 포함된 숫자")
+    bid_volume_1: str = Field(default="", alias="71", description="매수호가수량1. 단위: 1주")
+    bid_prev_diff_1: str = Field(default="", alias="91", description="매수호가직전대비1")
+    ask_price_2: str = Field(default="", alias="42", description="매도호가2. 단위: 원, 부호가 포함된 숫자")
+    ask_volume_2: str = Field(default="", alias="62", description="매도호가수량2. 단위: 1주")
+    ask_prev_diff_2: str = Field(default="", alias="82", description="매도호가직전대비2")
+    bid_price_2: str = Field(default="", alias="52", description="매수호가2. 단위: 원, 부호가 포함된 숫자")
+    bid_volume_2: str = Field(default="", alias="72", description="매수호가수량2. 단위: 1주")
+    bid_prev_diff_2: str = Field(default="", alias="92", description="매수호가직전대비2")
+    ask_price_3: str = Field(default="", alias="43", description="매도호가3. 단위: 원, 부호가 포함된 숫자")
+    ask_volume_3: str = Field(default="", alias="63", description="매도호가수량3. 단위: 1주")
+    ask_prev_diff_3: str = Field(default="", alias="83", description="매도호가직전대비3")
+    bid_price_3: str = Field(default="", alias="53", description="매수호가3. 단위: 원, 부호가 포함된 숫자")
+    bid_volume_3: str = Field(default="", alias="73", description="매수호가수량3. 단위: 1주")
+    bid_prev_diff_3: str = Field(default="", alias="93", description="매수호가직전대비3")
+    ask_price_4: str = Field(default="", alias="44", description="매도호가4. 단위: 원, 부호가 포함된 숫자")
+    ask_volume_4: str = Field(default="", alias="64", description="매도호가수량4. 단위: 1주")
+    ask_prev_diff_4: str = Field(default="", alias="84", description="매도호가직전대비4")
+    bid_price_4: str = Field(default="", alias="54", description="매수호가4. 단위: 원, 부호가 포함된 숫자")
+    bid_volume_4: str = Field(default="", alias="74", description="매수호가수량4. 단위: 1주")
+    bid_prev_diff_4: str = Field(default="", alias="94", description="매수호가직전대비4")
+    ask_price_5: str = Field(default="", alias="45", description="매도호가5. 단위: 원, 부호가 포함된 숫자")
+    ask_volume_5: str = Field(default="", alias="65", description="매도호가수량5. 단위: 1주")
+    ask_prev_diff_5: str = Field(default="", alias="85", description="매도호가직전대비5")
+    bid_price_5: str = Field(default="", alias="55", description="매수호가5. 단위: 원, 부호가 포함된 숫자")
+    bid_volume_5: str = Field(default="", alias="75", description="매수호가수량5. 단위: 1주")
+    bid_prev_diff_5: str = Field(default="", alias="95", description="매수호가직전대비5")
+    ask_price_6: str = Field(default="", alias="46", description="매도호가6. 단위: 원, 부호가 포함된 숫자")
+    ask_volume_6: str = Field(default="", alias="66", description="매도호가수량6. 단위: 1주")
+    ask_prev_diff_6: str = Field(default="", alias="86", description="매도호가직전대비6")
+    bid_price_6: str = Field(default="", alias="56", description="매수호가6. 단위: 원, 부호가 포함된 숫자")
+    bid_volume_6: str = Field(default="", alias="76", description="매수호가수량6. 단위: 1주")
+    bid_prev_diff_6: str = Field(default="", alias="96", description="매수호가직전대비6")
+    ask_price_7: str = Field(default="", alias="47", description="매도호가7. 단위: 원, 부호가 포함된 숫자")
+    ask_volume_7: str = Field(default="", alias="67", description="매도호가수량7. 단위: 1주")
+    ask_prev_diff_7: str = Field(default="", alias="87", description="매도호가직전대비7")
+    bid_price_7: str = Field(default="", alias="57", description="매수호가7. 단위: 원, 부호가 포함된 숫자")
+    bid_volume_7: str = Field(default="", alias="77", description="매수호가수량7. 단위: 1주")
+    bid_prev_diff_7: str = Field(default="", alias="97", description="매수호가직전대비7")
+    ask_price_8: str = Field(default="", alias="48", description="매도호가8. 단위: 원, 부호가 포함된 숫자")
+    ask_volume_8: str = Field(default="", alias="68", description="매도호가수량8. 단위: 1주")
+    ask_prev_diff_8: str = Field(default="", alias="88", description="매도호가직전대비8")
+    bid_price_8: str = Field(default="", alias="58", description="매수호가8. 단위: 원, 부호가 포함된 숫자")
+    bid_volume_8: str = Field(default="", alias="78", description="매수호가수량8. 단위: 1주")
+    bid_prev_diff_8: str = Field(default="", alias="98", description="매수호가직전대비8")
+    ask_price_9: str = Field(default="", alias="49", description="매도호가9. 단위: 원, 부호가 포함된 숫자")
+    ask_volume_9: str = Field(default="", alias="69", description="매도호가수량9. 단위: 1주")
+    ask_prev_diff_9: str = Field(default="", alias="89", description="매도호가직전대비9")
+    bid_price_9: str = Field(default="", alias="59", description="매수호가9. 단위: 원, 부호가 포함된 숫자")
+    bid_volume_9: str = Field(default="", alias="79", description="매수호가수량9. 단위: 1주")
+    bid_prev_diff_9: str = Field(default="", alias="99", description="매수호가직전대비9")
+    ask_price_10: str = Field(default="", alias="50", description="매도호가10. 단위: 원, 부호가 포함된 숫자")
+    ask_volume_10: str = Field(default="", alias="70", description="매도호가수량10. 단위: 1주")
+    bid_price_10: str = Field(default="", alias="60", description="매수호가10. 단위: 원, 부호가 포함된 숫자")
+    ask_prev_diff_10: str = Field(default="", alias="90", description="매도호가직전대비10")
+    bid_volume_10: str = Field(default="", alias="80", description="매수호가수량10. 단위: 1주")
+    bid_prev_diff_10: str = Field(default="", alias="100", description="매수호가직전대비10")
+    total_ask_volume: str = Field(default="", alias="121", description="매도호가총잔량. 단위: 1주")
+    total_ask_volume_prev_diff: str = Field(default="", alias="122", description="매도호가총잔량직전대비")
+    total_bid_volume: str = Field(default="", alias="125", description="매수호가총잔량. 단위: 1주")
+    total_bid_volume_prev_diff: str = Field(default="", alias="126", description="매수호가총잔량직전대비")
+    expected_execution_price: str = Field(default="", alias="23", description="예상체결가. 단위: 원")
+    expected_execution_quantity: str = Field(default="", alias="24", description="예상체결수량. 단위: 1주")
+    net_buy_remaining: str = Field(default="", alias="128", description="순매수잔량. 단위: 1주, 부호가 포함된 숫자")
+    buy_ratio: str = Field(default="", alias="129", description="매수비율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율")
+    net_sell_remaining: str = Field(default="", alias="138", description="순매도잔량. 단위: 1주, 부호가 포함된 숫자")
+    sell_ratio: str = Field(
+        default="", alias="139", description="매도비율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    expected_execution_prev_close_diff: str = Field(default="", alias="200", description="예상체결가전일종가대비")
+    expected_execution_prev_close_diff_rate: str = Field(
+        default="", alias="201", description="예상체결가전일종가대비등락율"
+    )
+    expected_execution_prev_close_diff_sign: str = Field(
+        default="", alias="238", description="예상체결가전일종가대비기호"
+    )
+    expected_execution_price2: str = Field(
+        default="", alias="291", description="예상체결가. 예상체결 시간동안에만 유효한 값"
+    )
+    expected_execution_volume: str = Field(default="", alias="292", description="예상체결량")
+    expected_execution_prev_diff_sign: str = Field(default="", alias="293", description="예상체결가전일대비기호")
+    expected_execution_prev_diff: str = Field(default="", alias="294", description="예상체결가전일대비")
+    expected_execution_prev_diff_rate: str = Field(default="", alias="295", description="예상체결가전일대비등락율")
+    krx_ask_volume_1: str = Field(default="", alias="6044", description="KRX 매도호가잔량1")
+    krx_ask_volume_2: str = Field(default="", alias="6045", description="KRX 매도호가잔량2")
+    krx_ask_volume_3: str = Field(default="", alias="6046", description="KRX 매도호가잔량3")
+    krx_ask_volume_4: str = Field(default="", alias="6047", description="KRX 매도호가잔량4")
+    krx_ask_volume_5: str = Field(default="", alias="6048", description="KRX 매도호가잔량5")
+    krx_ask_volume_6: str = Field(default="", alias="6049", description="KRX 매도호가잔량6")
+    krx_ask_volume_7: str = Field(default="", alias="6050", description="KRX 매도호가잔량7")
+    krx_ask_volume_8: str = Field(default="", alias="6051", description="KRX 매도호가잔량8")
+    krx_ask_volume_9: str = Field(default="", alias="6052", description="KRX 매도호가잔량9")
+    krx_ask_volume_10: str = Field(default="", alias="6053", description="KRX 매도호가잔량10")
+    krx_bid_volume_1: str = Field(default="", alias="6054", description="KRX 매수호가잔량1")
+    krx_bid_volume_2: str = Field(default="", alias="6055", description="KRX 매수호가잔량2")
+    krx_bid_volume_3: str = Field(default="", alias="6056", description="KRX 매수호가잔량3")
+    krx_bid_volume_4: str = Field(default="", alias="6057", description="KRX 매수호가잔량4")
+    krx_bid_volume_5: str = Field(default="", alias="6058", description="KRX 매수호가잔량5")
+    krx_bid_volume_6: str = Field(default="", alias="6059", description="KRX 매수호가잔량6")
+    krx_bid_volume_7: str = Field(default="", alias="6060", description="KRX 매수호가잔량7")
+    krx_bid_volume_8: str = Field(default="", alias="6061", description="KRX 매수호가잔량8")
+    krx_bid_volume_9: str = Field(default="", alias="6062", description="KRX 매수호가잔량9")
+    krx_bid_volume_10: str = Field(default="", alias="6063", description="KRX 매수호가잔량10")
+    krx_total_ask_volume: str = Field(default="", alias="6064", description="KRX 매도호가총잔량")
+    krx_total_bid_volume: str = Field(default="", alias="6065", description="KRX 매수호가총잔량")
+    nxt_ask_volume_1: str = Field(default="", alias="6066", description="NXT 매도호가잔량1")
+    nxt_ask_volume_2: str = Field(default="", alias="6067", description="NXT 매도호가잔량2")
+    nxt_ask_volume_3: str = Field(default="", alias="6068", description="NXT 매도호가잔량3")
+    nxt_ask_volume_4: str = Field(default="", alias="6069", description="NXT 매도호가잔량4")
+    nxt_ask_volume_5: str = Field(default="", alias="6070", description="NXT 매도호가잔량5")
+    nxt_ask_volume_6: str = Field(default="", alias="6071", description="NXT 매도호가잔량6")
+    nxt_ask_volume_7: str = Field(default="", alias="6072", description="NXT 매도호가잔량7")
+    nxt_ask_volume_8: str = Field(default="", alias="6073", description="NXT 매도호가잔량8")
+    nxt_ask_volume_9: str = Field(default="", alias="6074", description="NXT 매도호가잔량9")
+    nxt_ask_volume_10: str = Field(default="", alias="6075", description="NXT 매도호가잔량10")
+    nxt_bid_volume_1: str = Field(default="", alias="6076", description="NXT 매수호가잔량1")
+    nxt_bid_volume_2: str = Field(default="", alias="6077", description="NXT 매수호가잔량2")
+    nxt_bid_volume_3: str = Field(default="", alias="6078", description="NXT 매수호가잔량3")
+    nxt_bid_volume_4: str = Field(default="", alias="6079", description="NXT 매수호가잔량4")
+    nxt_bid_volume_5: str = Field(default="", alias="6080", description="NXT 매수호가잔량5")
+    nxt_bid_volume_6: str = Field(default="", alias="6081", description="NXT 매수호가잔량6")
+    nxt_bid_volume_7: str = Field(default="", alias="6082", description="NXT 매수호가잔량7")
+    nxt_bid_volume_8: str = Field(default="", alias="6083", description="NXT 매수호가잔량8")
+    nxt_bid_volume_9: str = Field(default="", alias="6084", description="NXT 매수호가잔량9")
+    nxt_bid_volume_10: str = Field(default="", alias="6085", description="NXT 매수호가잔량10")
+    nxt_total_ask_volume: str = Field(default="", alias="6086", description="NXT 매도호가총잔량")
+    nxt_total_bid_volume: str = Field(default="", alias="6087", description="NXT 매수호가총잔량")
+    krx_mid_price_total_ask_volume_change: str = Field(
+        default="", alias="6100", description="KRX 중간가 매도 총잔량 증감"
+    )
+    krx_mid_price_total_ask_volume: str = Field(default="", alias="6101", description="KRX 중간가 매도 총잔량")
+    krx_mid_price: str = Field(default="", alias="6102", description="KRX 중간가")
+    krx_mid_price_total_bid_volume: str = Field(default="", alias="6103", description="KRX 중간가 매수 총잔량")
+    krx_mid_price_total_bid_volume_change: str = Field(
+        default="", alias="6104", description="KRX 중간가 매수 총잔량 증감"
+    )
+    nxt_mid_price_total_ask_volume_change: str = Field(
+        default="", alias="6105", description="NXT중간가 매도 총잔량 증감"
+    )
+    nxt_mid_price_total_ask_volume: str = Field(default="", alias="6106", description="NXT중간가 매도 총잔량")
+    nxt_mid_price: str = Field(default="", alias="6107", description="NXT중간가")
+    nxt_mid_price_total_bid_volume: str = Field(default="", alias="6108", description="NXT중간가 매수 총잔량")
+    nxt_mid_price_total_bid_volume_change: str = Field(
+        default="", alias="6109", description="NXT중간가 매수 총잔량 증감"
+    )
+    krx_mid_price_diff: str = Field(default="", alias="6110", description="KRX중간가대비. 기준가대비")
+    krx_mid_price_diff_sign: str = Field(default="", alias="6111", description="KRX중간가대비 기호. 기준가대비")
+    krx_mid_price_diff_rate: str = Field(default="", alias="6112", description="KRX중간가대비등락율. 기준가대비")
+    nxt_mid_price_diff: str = Field(default="", alias="6113", description="NXT중간가대비. 기준가대비")
+    nxt_mid_price_diff_sign: str = Field(default="", alias="6114", description="NXT중간가대비 기호. 기준가대비")
+    nxt_mid_price_diff_rate: str = Field(default="", alias="6115", description="NXT중간가대비등락율. 기준가대비")
+
+
+class DomesticRealtimeStockAfterHoursQuoteValues(BaseModel):
+    """0E 주식시간외호가 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식시간외호가 values")
+
+    quote_time: str = Field(default="", alias="21", description="호가시간. HHmmss")
+    after_hours_total_ask_volume: str = Field(default="", alias="131", description="시간외매도호가총잔량. 단위: 1주")
+    after_hours_total_ask_volume_prev_diff: str = Field(
+        default="", alias="132", description="시간외매도호가총잔량직전대비. 단위: 1주, 부호가 포함된 숫자"
+    )
+    after_hours_total_bid_volume: str = Field(default="", alias="135", description="시간외매수호가총잔량. 단위: 1주")
+    after_hours_total_bid_volume_prev_diff: str = Field(
+        default="", alias="136", description="시간외매수호가총잔량직전대비. 단위: 1주, 부호가 포함된 숫자"
+    )
+
+
+class DomesticRealtimeStockCurrentDayTraderValues(BaseModel):
+    """0F 주식당일거래원 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식당일거래원 values")
+
+    ask_trader_name_1: str = Field(default="", alias="141", description="매도거래원1")
+    ask_trader_volume_1: str = Field(default="", alias="161", description="매도거래원수량1. 단위: 1주")
+    ask_trader_change_1: str = Field(
+        default="", alias="166", description="매도거래원별증감1. 단위: 1주, 부호가 포함된 숫자"
+    )
+    ask_trader_code_1: str = Field(default="", alias="146", description="매도거래원코드1")
+    ask_trader_color_1: str = Field(default="", alias="271", description="매도거래원색깔1")
+    bid_trader_name_1: str = Field(default="", alias="151", description="매수거래원1")
+    bid_trader_volume_1: str = Field(default="", alias="171", description="매수거래원수량1. 단위: 1주")
+    bid_trader_change_1: str = Field(
+        default="", alias="176", description="매수거래원별증감1. 단위: 1주, 부호가 포함된 숫자"
+    )
+    bid_trader_code_1: str = Field(default="", alias="156", description="매수거래원코드1")
+    bid_trader_color_1: str = Field(default="", alias="281", description="매수거래원색깔1")
+    ask_trader_name_2: str = Field(default="", alias="142", description="매도거래원2")
+    ask_trader_volume_2: str = Field(default="", alias="162", description="매도거래원수량2. 단위: 1주")
+    ask_trader_change_2: str = Field(
+        default="", alias="167", description="매도거래원별증감2. 단위: 1주, 부호가 포함된 숫자"
+    )
+    ask_trader_code_2: str = Field(default="", alias="147", description="매도거래원코드2")
+    ask_trader_color_2: str = Field(default="", alias="272", description="매도거래원색깔2")
+    bid_trader_name_2: str = Field(default="", alias="152", description="매수거래원2")
+    bid_trader_volume_2: str = Field(default="", alias="172", description="매수거래원수량2. 단위: 1주")
+    bid_trader_change_2: str = Field(
+        default="", alias="177", description="매수거래원별증감2. 단위: 1주, 부호가 포함된 숫자"
+    )
+    bid_trader_code_2: str = Field(default="", alias="157", description="매수거래원코드2")
+    bid_trader_color_2: str = Field(default="", alias="282", description="매수거래원색깔2")
+    ask_trader_name_3: str = Field(default="", alias="143", description="매도거래원3")
+    ask_trader_volume_3: str = Field(default="", alias="163", description="매도거래원수량3. 단위: 1주")
+    ask_trader_change_3: str = Field(
+        default="", alias="168", description="매도거래원별증감3. 단위: 1주, 부호가 포함된 숫자"
+    )
+    ask_trader_code_3: str = Field(default="", alias="148", description="매도거래원코드3")
+    ask_trader_color_3: str = Field(default="", alias="273", description="매도거래원색깔3")
+    bid_trader_name_3: str = Field(default="", alias="153", description="매수거래원3")
+    bid_trader_volume_3: str = Field(default="", alias="173", description="매수거래원수량3. 단위: 1주")
+    bid_trader_change_3: str = Field(
+        default="", alias="178", description="매수거래원별증감3. 단위: 1주, 부호가 포함된 숫자"
+    )
+    bid_trader_code_3: str = Field(default="", alias="158", description="매수거래원코드3")
+    bid_trader_color_3: str = Field(default="", alias="283", description="매수거래원색깔3")
+    ask_trader_name_4: str = Field(default="", alias="144", description="매도거래원4")
+    ask_trader_volume_4: str = Field(default="", alias="164", description="매도거래원수량4. 단위: 1주")
+    ask_trader_change_4: str = Field(
+        default="", alias="169", description="매도거래원별증감4. 단위: 1주, 부호가 포함된 숫자"
+    )
+    ask_trader_code_4: str = Field(default="", alias="149", description="매도거래원코드4")
+    ask_trader_color_4: str = Field(default="", alias="274", description="매도거래원색깔4")
+    bid_trader_name_4: str = Field(default="", alias="154", description="매수거래원4")
+    bid_trader_volume_4: str = Field(default="", alias="174", description="매수거래원수량4. 단위: 1주")
+    bid_trader_change_4: str = Field(
+        default="", alias="179", description="매수거래원별증감4. 단위: 1주, 부호가 포함된 숫자"
+    )
+    bid_trader_code_4: str = Field(default="", alias="159", description="매수거래원코드4")
+    bid_trader_color_4: str = Field(default="", alias="284", description="매수거래원색깔4")
+    ask_trader_name_5: str = Field(default="", alias="145", description="매도거래원5")
+    ask_trader_volume_5: str = Field(default="", alias="165", description="매도거래원수량5. 단위: 1주")
+    ask_trader_change_5: str = Field(
+        default="", alias="170", description="매도거래원별증감5. 단위: 1주, 부호가 포함된 숫자"
+    )
+    ask_trader_code_5: str = Field(default="", alias="150", description="매도거래원코드5")
+    ask_trader_color_5: str = Field(default="", alias="275", description="매도거래원색깔5")
+    bid_trader_name_5: str = Field(default="", alias="155", description="매수거래원5")
+    bid_trader_volume_5: str = Field(default="", alias="175", description="매수거래원수량5. 단위: 1주")
+    bid_trader_change_5: str = Field(
+        default="", alias="180", description="매수거래원별증감5. 단위: 1주, 부호가 포함된 숫자"
+    )
+    bid_trader_code_5: str = Field(default="", alias="160", description="매수거래원코드5")
+    bid_trader_color_5: str = Field(default="", alias="285", description="매수거래원색깔5")
+    foreign_est_sell_sum: str = Field(default="", alias="261", description="외국계매도추정합")
+    foreign_est_sell_sum_change: str = Field(default="", alias="262", description="외국계매도추정합변동")
+    foreign_est_buy_sum: str = Field(default="", alias="263", description="외국계매수추정합")
+    foreign_est_buy_sum_change: str = Field(default="", alias="264", description="외국계매수추정합변동")
+    foreign_est_net_buy_sum: str = Field(default="", alias="267", description="외국계순매수추정합")
+    foreign_est_net_buy_change: str = Field(default="", alias="268", description="외국계순매수변동")
+    exchange_type: str = Field(default="", alias="337", description="거래소구분")
+
+
+class DomesticRealtimeEtfNavValues(BaseModel):
+    """0G ETF NAV values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 ETF NAV values")
+
+    nav: str = Field(default="", alias="36", description="NAV. 부호 포함 소수점 둘째 자리까지 포맷된 숫자")
+    nav_prev_day_diff: str = Field(
+        default="", alias="37", description="NAV전일대비. 부호 포함 소수점 둘째 자리까지 포맷된 숫자"
+    )
+    nav_fluctuation_rate: str = Field(
+        default="", alias="38", description="NAV등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    tracking_error_rate: str = Field(
+        default="", alias="39", description="추적오차율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    execution_time: str = Field(default="", alias="20", description="체결시간. HHmmss")
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비. 단위: 원, 부호가 포함된 숫자")
+    fluctuation_rate: str = Field(
+        default="", alias="12", description="등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량. 단위: 1주")
+    prev_day_diff_sign: str = Field(
+        default="", alias="25", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+    elw_gearing_ratio: str = Field(default="", alias="667", description="ELW기어링비율")
+    elw_breakeven_rate: str = Field(default="", alias="668", description="ELW손익분기율")
+    elw_capital_support_point: str = Field(default="", alias="669", description="ELW자본지지점")
+    nav_index_gap_rate: str = Field(default="", alias="265", description="NAV/지수괴리율")
+    nav_etf_gap_rate: str = Field(default="", alias="266", description="NAV/ETF괴리율")
+
+
+class DomesticRealtimeStockExpectedExecutionValues(BaseModel):
+    """0H 주식예상체결 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식예상체결 values")
+
+    execution_time: str = Field(default="", alias="20", description="체결시간. HHmmss")
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비. 단위: 원, 부호가 포함된 숫자")
+    fluctuation_rate: str = Field(
+        default="", alias="12", description="등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    trade_volume: str = Field(default="", alias="15", description="거래량. +는 매수체결, -는 매도체결")
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량. 단위: 1주")
+    prev_day_diff_sign: str = Field(
+        default="", alias="25", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+
+
+class DomesticRealtimeIntlGoldPriceValues(BaseModel):
+    """0I 국제금환산가격 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 국제금환산가격 values")
+
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff_sign: str = Field(
+        default="", alias="25", description="전일대비기호. 1:상한, 2:상승, 3:없음, 4:하한, 5:하락"
+    )
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비. 단위: 원, 부호가 포함된 숫자")
+    fluctuation_rate: str = Field(
+        default="", alias="12", description="등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+
+
+class DomesticRealtimeIndustryIndexValues(BaseModel):
+    """0J 업종지수 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 업종지수 values")
+
+    execution_time: str = Field(default="", alias="20", description="체결시간. HHmmss")
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비. 단위: 원, 부호가 포함된 숫자")
+    fluctuation_rate: str = Field(
+        default="", alias="12", description="등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    trade_volume: str = Field(default="", alias="15", description="거래량. +는 매수체결,-는 매도체결")
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량. 단위: 1주")
+    acc_trade_value: str = Field(default="", alias="14", description="누적거래대금. 단위: 백만원")
+    open_price: str = Field(default="", alias="16", description="시가. 단위: 원, 부호가 포함된 숫자")
+    high_price: str = Field(default="", alias="17", description="고가. 단위: 원, 부호가 포함된 숫자")
+    low_price: str = Field(default="", alias="18", description="저가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff_sign: str = Field(
+        default="", alias="25", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+    prev_day_volume_diff: str = Field(default="", alias="26", description="전일거래량대비. 계약,주")
+
+
+class DomesticRealtimeIndustryFluctuationValues(BaseModel):
+    """0U 업종등락 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 업종등락 values")
+
+    execution_time: str = Field(default="", alias="20", description="체결시간. HHmmss")
+    advancing_count: str = Field(default="", alias="252", description="상승종목수")
+    upper_limit_count: str = Field(default="", alias="251", description="상한종목수")
+    unchanged_count: str = Field(default="", alias="253", description="보합종목수")
+    declining_count: str = Field(default="", alias="255", description="하락종목수")
+    lower_limit_count: str = Field(default="", alias="254", description="하한종목수")
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량. 단위: 1주")
+    acc_trade_value: str = Field(default="", alias="14", description="누적거래대금. 단위: 백만원")
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비. 단위: 원, 부호가 포함된 숫자")
+    fluctuation_rate: str = Field(
+        default="", alias="12", description="등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    traded_stock_count: str = Field(default="", alias="256", description="거래형성종목수. 계약,주")
+    traded_ratio: str = Field(
+        default="", alias="257", description="거래형성비율. 단위: %, 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    prev_day_diff_sign: str = Field(
+        default="", alias="25", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+
+
+class DomesticRealtimeStockItemInfoValues(BaseModel):
+    """0g 주식종목정보 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식종목정보 values")
+
+    discretionary_extension: str = Field(default="", alias="297", description="임의연장")
+    pre_market_extension: str = Field(default="", alias="592", description="장전임의연장")
+    post_market_extension: str = Field(default="", alias="593", description="장후임의연장")
+    upper_limit_price: str = Field(default="", alias="305", description="상한가. 단위: 원, 부호가 포함된 숫자")
+    lower_limit_price: str = Field(default="", alias="306", description="하한가. 단위: 원, 부호가 포함된 숫자")
+    base_price: str = Field(default="", alias="307", description="기준가. 단위: 원")
+    early_termination_elw: str = Field(default="", alias="689", description="조기종료ELW발생")
+    currency_unit: str = Field(default="", alias="594", description="통화단위")
+    margin_rate_display: str = Field(default="", alias="382", description="증거금율표시")
+    stock_info: str = Field(default="", alias="370", description="종목정보")
+
+
+class DomesticRealtimeElwTheoreticalPriceValues(BaseModel):
+    """0m ELW 이론가 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 ELW 이론가 values")
+
+    execution_time: str = Field(default="", alias="20", description="체결시간. HHmmss")
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    elw_theoretical_price: str = Field(default="", alias="670", description="ELW이론가")
+    elw_implied_volatility: str = Field(default="", alias="671", description="ELW내재변동성")
+    elw_delta: str = Field(default="", alias="672", description="ELW델타")
+    elw_gamma: str = Field(default="", alias="673", description="ELW감마")
+    elw_theta: str = Field(default="", alias="674", description="ELW쎄타")
+    elw_vega: str = Field(default="", alias="675", description="ELW베가")
+    elw_rho: str = Field(default="", alias="676", description="ELW로")
+    lp_quote_implied_volatility: str = Field(default="", alias="706", description="LP호가내재변동성")
+
+
+class DomesticRealtimeMarketStartTimeValues(BaseModel):
+    """0s 장시작시간 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 장시작시간 values")
+
+    market_operation_type: str = Field(
+        default="",
+        alias="215",
+        description="장운영구분. 0 : 장시작전 알림(8:40~), 3 : 장시작(09:00), 2 : 장마감 알림(15:20~), 4 : 장마감(15:30), 8 : 정규장마감(거래소 수신시 15:30 이후), 9 : 전체장마감(거래소 수신시 18:00 이후), a : 시간외 종가매매 시작(15:40), b : 시간외 종가매매 종료(16:00), c : 시간외 단일가 시작(16:00), d : 시간외 단일가 종료(18:00), e : 선옵 장마감전 동시호가 종료, f : 선물옵션 장운영시간 알림(조기개장 상품), o : 선옵 장시작, s : 선옵 장마감전 동시호가 시작, P : NXT 프리마켓 시작 알림, Q : NXT 프리마켓 종료 알림, R : NXT 메인마켓 시작 알림, S : NXT 메인마켓 종료 알림, T : NXT 에프터마켓 단일가 시작 알림, U : NXT 에프터마켓 시작 알림, V : NXT 에프터마켓 종료 알림",
+    )
+    execution_time: str = Field(default="", alias="20", description="체결시간. HHmmss")
+    market_start_remaining_time: str = Field(default="", alias="214", description="장시작예상잔여시간. HHmmss")
+
+
+class DomesticRealtimeElwIndicatorValues(BaseModel):
+    """0u ELW 지표 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 ELW 지표 values")
+
+    execution_time: str = Field(default="", alias="20", description="체결시간. HHmmss")
+    elw_parity: str = Field(default="", alias="666", description="ELW패리티")
+    elw_premium: str = Field(default="", alias="1211", description="ELW프리미엄")
+    elw_gearing_ratio: str = Field(default="", alias="667", description="ELW기어링비율")
+    elw_breakeven_rate: str = Field(default="", alias="668", description="ELW손익분기율")
+    elw_capital_support_point: str = Field(default="", alias="669", description="ELW자본지지점")
+
+
+class DomesticRealtimeStockProgramTradingValues(BaseModel):
+    """0w 종목프로그램매매 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 종목프로그램매매 values")
+
+    execution_time: str = Field(default="", alias="20", description="체결시간. HHmmss")
+    current_price: str = Field(default="", alias="10", description="현재가. 단위: 원, 부호가 포함된 숫자")
+    prev_day_diff_sign: str = Field(
+        default="", alias="25", description="전일대비기호. 1: 상한가, 2:상승, 3:보합, 4:하한가, 5:하락"
+    )
+    prev_day_diff: str = Field(default="", alias="11", description="전일대비. 단위: 원, 부호가 포함된 숫자")
+    fluctuation_rate: str = Field(
+        default="", alias="12", description="등락율. 단위: %, 부호 포함 소수점 둘째 자리까지 포맷된 백분율"
+    )
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량. 단위: 1주")
+    sell_quantity: str = Field(default="", alias="202", description="매도수량. 단위: 1주")
+    sell_amount: str = Field(default="", alias="204", description="매도금액. 단위: 원")
+    buy_quantity: str = Field(default="", alias="206", description="매수수량. 단위: 1주")
+    buy_amount: str = Field(default="", alias="208", description="매수금액")
+    net_buy_quantity: str = Field(default="", alias="210", description="순매수수량")
+    net_buy_quantity_change: str = Field(default="", alias="211", description="순매수수량증감. 계약,주")
+    net_buy_amount: str = Field(default="", alias="212", description="순매수금액")
+    net_buy_amount_change: str = Field(default="", alias="213", description="순매수금액증감")
+    market_start_remaining_time: str = Field(default="", alias="214", description="장시작예상잔여시간")
+    market_operation_type: str = Field(default="", alias="215", description="장운영구분")
+    investor_ticker: str = Field(default="", alias="216", description="투자자별ticker")
+
+
+class DomesticRealtimeViActivationValues(BaseModel):
+    """1h VI발동/해제 values."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 VI발동/해제 values")
+
+    stock_code: str = Field(default="", alias="9001", description="종목코드")
+    stock_name: str = Field(default="", alias="302", description="종목명")
+    acc_trade_volume: str = Field(default="", alias="13", description="누적거래량. 단위: 1주")
+    acc_trade_value: str = Field(default="", alias="14", description="누적거래대금. 단위: 백만원")
+    vi_activation_type: str = Field(default="", alias="9068", description="VI발동구분")
+    kospi_kosdaq_type: str = Field(default="", alias="9008", description="KOSPI,KOSDAQ,전체구분")
+    pre_market_type: str = Field(default="", alias="9075", description="장전구분")
+    vi_activation_price: str = Field(default="", alias="1221", description="VI발동가격. 단위: 원")
+    trade_execution_time: str = Field(default="", alias="1223", description="매매체결처리시각. HHmmss")
+    vi_release_time: str = Field(default="", alias="1224", description="VI해제시각. HHmmss")
+    vi_apply_type: str = Field(default="", alias="1225", description="VI적용구분. 정적/동적/동적+정적")
+    base_price_static: str = Field(default="", alias="1236", description="기준가격 정적. 계약,주")
+    base_price_dynamic: str = Field(default="", alias="1237", description="기준가격 동적")
+    gap_rate_static: str = Field(default="", alias="1238", description="괴리율 정적")
+    gap_rate_dynamic: str = Field(default="", alias="1239", description="괴리율 동적")
+    vi_activation_fluctuation_rate: str = Field(default="", alias="1489", description="VI발동가 등락율")
+    vi_activation_count: str = Field(default="", alias="1490", description="VI발동횟수")
+    activation_direction_type: str = Field(default="", alias="9069", description="발동방향구분")
+    extra_item3: str = Field(default="", alias="1279", description="Extra Item")
+
+
+# ---------------------------------------------------------------------------
+# TR별 응답 프레임 모델
+# ---------------------------------------------------------------------------
+
+
+class DomesticRealtimeOrderExecutionDataItem(BaseModel):
+    """00 주문체결 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주문체결 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeOrderExecutionValues = Field(
+        default_factory=DomesticRealtimeOrderExecutionValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeOrderExecution(BaseModel):
+    """00 국내주식 실시간 주문체결 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 주문체결 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeOrderExecutionDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class DomesticRealtimeBalanceDataItem(BaseModel):
+    """04 잔고 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 잔고 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeBalanceValues = Field(
+        default_factory=DomesticRealtimeBalanceValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeBalance(BaseModel):
+    """04 국내주식 실시간 잔고 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 잔고 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeBalanceDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class DomesticRealtimeStockMomentumDataItem(BaseModel):
+    """0A 주식기세 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식기세 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeStockMomentumValues = Field(
+        default_factory=DomesticRealtimeStockMomentumValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeStockMomentum(BaseModel):
+    """0A 국내주식 실시간 주식기세 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 주식기세 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeStockMomentumDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class DomesticRealtimeStockExecutionDataItem(BaseModel):
+    """0B 주식체결 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식체결 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeStockExecutionValues = Field(
+        default_factory=DomesticRealtimeStockExecutionValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeStockExecution(BaseModel):
+    """0B 국내주식 실시간 주식체결 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 주식체결 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeStockExecutionDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class DomesticRealtimeStockPriorityQuoteDataItem(BaseModel):
+    """0C 주식우선호가 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식우선호가 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeStockPriorityQuoteValues = Field(
+        default_factory=DomesticRealtimeStockPriorityQuoteValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeStockPriorityQuote(BaseModel):
+    """0C 국내주식 실시간 주식우선호가 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 주식우선호가 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeStockPriorityQuoteDataItem] = Field(
+        default_factory=list, description="실시간 등록리스트"
+    )
+
+
+class DomesticRealtimeStockQuoteRemainingDataItem(BaseModel):
+    """0D 주식호가잔량 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식호가잔량 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeStockQuoteRemainingValues = Field(
+        default_factory=DomesticRealtimeStockQuoteRemainingValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeStockQuoteRemaining(BaseModel):
+    """0D 국내주식 실시간 주식호가잔량 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 주식호가잔량 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeStockQuoteRemainingDataItem] = Field(
+        default_factory=list, description="실시간 등록리스트"
+    )
+
+
+class DomesticRealtimeStockAfterHoursQuoteDataItem(BaseModel):
+    """0E 주식시간외호가 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식시간외호가 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeStockAfterHoursQuoteValues = Field(
+        default_factory=DomesticRealtimeStockAfterHoursQuoteValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeStockAfterHoursQuote(BaseModel):
+    """0E 국내주식 실시간 주식시간외호가 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 주식시간외호가 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeStockAfterHoursQuoteDataItem] = Field(
+        default_factory=list, description="실시간 등록리스트"
+    )
+
+
+class DomesticRealtimeStockCurrentDayTraderDataItem(BaseModel):
+    """0F 주식당일거래원 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식당일거래원 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeStockCurrentDayTraderValues = Field(
+        default_factory=DomesticRealtimeStockCurrentDayTraderValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeStockCurrentDayTrader(BaseModel):
+    """0F 국내주식 실시간 주식당일거래원 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 주식당일거래원 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeStockCurrentDayTraderDataItem] = Field(
+        default_factory=list, description="실시간 등록리스트"
+    )
+
+
+class DomesticRealtimeEtfNavDataItem(BaseModel):
+    """0G ETF NAV 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 ETF NAV data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeEtfNavValues = Field(
+        default_factory=DomesticRealtimeEtfNavValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeEtfNav(BaseModel):
+    """0G 국내주식 실시간 ETF NAV 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 ETF NAV 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeEtfNavDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class DomesticRealtimeStockExpectedExecutionDataItem(BaseModel):
+    """0H 주식예상체결 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식예상체결 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeStockExpectedExecutionValues = Field(
+        default_factory=DomesticRealtimeStockExpectedExecutionValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeStockExpectedExecution(BaseModel):
+    """0H 국내주식 실시간 주식예상체결 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 주식예상체결 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeStockExpectedExecutionDataItem] = Field(
+        default_factory=list, description="실시간 등록리스트"
+    )
+
+
+class DomesticRealtimeIntlGoldPriceDataItem(BaseModel):
+    """0I 국제금환산가격 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 국제금환산가격 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeIntlGoldPriceValues = Field(
+        default_factory=DomesticRealtimeIntlGoldPriceValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeIntlGoldPrice(BaseModel):
+    """0I 국내주식 실시간 국제금환산가격 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 국제금환산가격 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeIntlGoldPriceDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class DomesticRealtimeIndustryIndexDataItem(BaseModel):
+    """0J 업종지수 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 업종지수 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeIndustryIndexValues = Field(
+        default_factory=DomesticRealtimeIndustryIndexValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeIndustryIndex(BaseModel):
+    """0J 국내주식 실시간 업종지수 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 업종지수 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeIndustryIndexDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class DomesticRealtimeIndustryFluctuationDataItem(BaseModel):
+    """0U 업종등락 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 업종등락 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeIndustryFluctuationValues = Field(
+        default_factory=DomesticRealtimeIndustryFluctuationValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeIndustryFluctuation(BaseModel):
+    """0U 국내주식 실시간 업종등락 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 업종등락 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeIndustryFluctuationDataItem] = Field(
+        default_factory=list, description="실시간 등록리스트"
+    )
+
+
+class DomesticRealtimeStockItemInfoDataItem(BaseModel):
+    """0g 주식종목정보 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 주식종목정보 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeStockItemInfoValues = Field(
+        default_factory=DomesticRealtimeStockItemInfoValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeStockItemInfo(BaseModel):
+    """0g 국내주식 실시간 주식종목정보 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 주식종목정보 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeStockItemInfoDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class DomesticRealtimeElwTheoreticalPriceDataItem(BaseModel):
+    """0m ELW 이론가 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 ELW 이론가 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeElwTheoreticalPriceValues = Field(
+        default_factory=DomesticRealtimeElwTheoreticalPriceValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeElwTheoreticalPrice(BaseModel):
+    """0m 국내주식 실시간 ELW 이론가 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 ELW 이론가 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeElwTheoreticalPriceDataItem] = Field(
+        default_factory=list, description="실시간 등록리스트"
+    )
+
+
+class DomesticRealtimeMarketStartTimeDataItem(BaseModel):
+    """0s 장시작시간 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 장시작시간 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeMarketStartTimeValues = Field(
+        default_factory=DomesticRealtimeMarketStartTimeValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeMarketStartTime(BaseModel):
+    """0s 국내주식 실시간 장시작시간 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 장시작시간 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeMarketStartTimeDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class DomesticRealtimeElwIndicatorDataItem(BaseModel):
+    """0u ELW 지표 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 ELW 지표 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeElwIndicatorValues = Field(
+        default_factory=DomesticRealtimeElwIndicatorValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeElwIndicator(BaseModel):
+    """0u 국내주식 실시간 ELW 지표 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 ELW 지표 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeElwIndicatorDataItem] = Field(default_factory=list, description="실시간 등록리스트")
+
+
+class DomesticRealtimeStockProgramTradingDataItem(BaseModel):
+    """0w 종목프로그램매매 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 종목프로그램매매 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeStockProgramTradingValues = Field(
+        default_factory=DomesticRealtimeStockProgramTradingValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeStockProgramTrading(BaseModel):
+    """0w 국내주식 실시간 종목프로그램매매 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 종목프로그램매매 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeStockProgramTradingDataItem] = Field(
+        default_factory=list, description="실시간 등록리스트"
+    )
+
+
+class DomesticRealtimeViActivationDataItem(BaseModel):
+    """1h VI발동/해제 실시간 등록리스트 항목."""
+
+    model_config = ConfigDict(populate_by_name=True, title="국내주식 실시간 VI발동/해제 data 항목")
+
+    type: str = Field(default="", description="실시간항목. TR명")
+    name: str = Field(default="", description="실시간 항목명")
+    item: str = Field(default="", description="실시간 등록 요소. 종목코드")
+    values: DomesticRealtimeViActivationValues = Field(
+        default_factory=DomesticRealtimeViActivationValues, description="실시간 값 리스트"
+    )
+
+
+class DomesticRealtimeViActivation(BaseModel):
+    """1h 국내주식 실시간 VI발동/해제 응답 프레임."""
+
+    model_config = ConfigDict(title="국내주식 실시간 VI발동/해제 응답")
+
+    return_code: int | None = Field(
+        default=None, description="결과코드. 등록/해지요청시에만 전송 0:정상,1:오류, 실시간 수신시 미전송"
+    )
+    return_msg: str = Field(default="", description="결과메시지")
+    trnm: str = Field(default="", description="서비스명. 등록/해지요청시 요청값 반환, 실시간수신시 REAL 반환")
+    data: list[DomesticRealtimeViActivationDataItem] = Field(default_factory=list, description="실시간 등록리스트")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_socket_client.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_socket_client.py
@@ -1,12 +1,15 @@
-"""미국주식 실시간 WebSocket 클라이언트.
+"""키움 실시간 WebSocket 클라이언트.
 
-실시간 시세(``_overseas_realtime``)와 조건검색(``_overseas_condition_search``)이 공유하는
-저수준 WebSocket 클라이언트다. Python 표준 라이브러리(asyncio)만 사용하며 외부 의존성을
-추가하지 않는다 (KIS ``_socket_client``와 동일한 방식).
+미국주식 실시간 시세(``_overseas_realtime``)/조건검색(``_overseas_condition_search``)과
+국내주식 조건검색(``_domestic_condition_search``)이 공유하는 저수준 WebSocket 클라이언트다.
+Python 표준 라이브러리(asyncio)만 사용하며 외부 의존성을 추가하지 않는다
+(KIS ``_socket_client``와 동일한 방식).
 
-WebSocket URL:
-- 운영: wss://api.kiwoom.com:10000/api/us/websocket
-- 모의투자: wss://mockapi.kiwoom.com:10000/api/us/websocket
+WebSocket URL은 ``market``으로 국내(dostk)/미국(us) 엔드포인트를 선택한다:
+- 미국 운영: wss://api.kiwoom.com:10000/api/us/websocket
+- 미국 모의투자: wss://mockapi.kiwoom.com:10000/api/us/websocket
+- 국내 운영: wss://api.kiwoom.com:10000/api/dostk/websocket
+- 국내 모의투자: wss://mockapi.kiwoom.com:10000/api/dostk/websocket (KRX만 지원)
 
 프로토콜 (JSON 텍스트 프레임):
 - 접속 후 ``{"trnm": "LOGIN", "token": <access_token>}`` 전송 → LOGIN 응답(return_code) 수신
@@ -44,28 +47,37 @@ class KiwoomWebSocketMessage:
 
 
 class KiwoomWebSocketClient:
-    """미국주식 실시간 WebSocket 클라이언트.
+    """키움 실시간 WebSocket 클라이언트.
 
     LOGIN 인증과 PING/PONG 유지는 이 클라이언트가 처리하고, 그 외 프레임은 이벤트 큐로
-    전달한다. ``OverseasRealtime``/``OverseasConditionSearch``가 이 클라이언트를 감싸
-    도메인별 요청 프레임을 송신하고 응답을 파싱한다.
+    전달한다. ``OverseasRealtime``/``OverseasConditionSearch``/``DomesticConditionSearch``가
+    이 클라이언트를 감싸 도메인별 요청 프레임을 송신하고 응답을 파싱한다. 접속 URL은
+    ``market``으로 국내(dostk)/미국(us) 엔드포인트를 선택한다.
 
     Example:
         ```python
+        # 미국주식 조건검색
         async with KiwoomWebSocketClient(token="...", env="prod") as ws:
             await ws.send({"trnm": "GCNSRLST"})
             message = await ws.recv()
             print(message.trnm, message.body)
+
+        # 국내주식 조건검색
+        async with KiwoomWebSocketClient(token="...", env="prod", market="domestic") as ws:
+            await ws.send({"trnm": "CNSRLST"})
+            message = await ws.recv()
         ```
     """
 
-    WS_URL_PROD = "wss://api.kiwoom.com:10000/api/us/websocket"
-    WS_URL_DEV = "wss://mockapi.kiwoom.com:10000/api/us/websocket"
+    WS_HOST_PROD = "wss://api.kiwoom.com:10000"
+    WS_HOST_DEV = "wss://mockapi.kiwoom.com:10000"
+    WS_PATH = {"domestic": "/api/dostk/websocket", "overseas": "/api/us/websocket"}
 
     def __init__(
         self,
         token: str,
         env: Literal["dev", "prod"] = "prod",
+        market: Literal["domestic", "overseas"] = "overseas",
         debug: bool = False,
         queue_maxsize: int = 1000,
         rate_limit_requests_per_second: float = 5.0,
@@ -76,6 +88,7 @@ class KiwoomWebSocketClient:
         Args:
             token: 접근토큰 (LOGIN 프레임에 사용).
             env: 환경. "prod":운영, "dev":모의투자.
+            market: 시장. "overseas":미국주식(us), "domestic":국내주식(dostk).
             debug: 디버그 로깅 활성화 여부.
             queue_maxsize: 이벤트 큐 최대 크기 (0이면 무제한).
             rate_limit_requests_per_second: 송신 rate limit.
@@ -83,9 +96,11 @@ class KiwoomWebSocketClient:
         """
         self.token = token
         self.env = env
+        self.market = market
         self.debug = debug
 
-        self._ws_url = self.WS_URL_PROD if env == "prod" else self.WS_URL_DEV
+        host = self.WS_HOST_PROD if env == "prod" else self.WS_HOST_DEV
+        self._ws_url = f"{host}{self.WS_PATH[market]}"
         self._event_queue: "asyncio.Queue[KiwoomWebSocketMessage]" = asyncio.Queue(maxsize=queue_maxsize)
         self._reader: Optional[asyncio.StreamReader] = None
         self._writer: Optional[asyncio.StreamWriter] = None

--- a/packages/cluefin-openapi/tests/kiwoom/test_domestic_condition_search_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_domestic_condition_search_unit.py
@@ -1,0 +1,279 @@
+"""국내주식 조건검색(웹소켓) 메시지 모델 unit 테스트.
+
+ka10171/ka10172/ka10173/ka10174 4개 TR은 웹소켓 API이므로 HTTP 클라이언트
+테스트(run_post_case)를 적용할 수 없다. 여기서는 요청 모델의 wire 포맷 dump와 응답
+모델의 field/alias 매핑을 검증한다. ``DomesticConditionSearch`` 도메인 래퍼의 요청
+송신·응답 파싱 동작은 ``test_domestic_condition_search_ws_unit.py``에서 검증한다.
+(미국주식 ``test_overseas_condition_search_unit`` 과 대칭.)
+"""
+
+import pytest
+
+from cluefin_openapi.kiwoom._domestic_condition_search_types import (
+    DomesticConditionSearchListItem,
+    DomesticConditionSearchListRequest,
+    DomesticConditionSearchListResponse,
+    DomesticConditionSearchRealtimeCancelRequest,
+    DomesticConditionSearchRealtimeCancelResponse,
+    DomesticConditionSearchRealtimePush,
+    DomesticConditionSearchRealtimeRequest,
+    DomesticConditionSearchRealtimeResponse,
+    DomesticConditionSearchRequest,
+    DomesticConditionSearchResponse,
+    DomesticConditionSearchResultItem,
+)
+
+# ---------------------------------------------------------------------------
+# ka10171 조건검색 목록조회
+# ---------------------------------------------------------------------------
+
+
+class TestDomesticConditionSearchList:
+    def test_request_dump_matches_wire_format(self):
+        request = DomesticConditionSearchListRequest(trnm="CNSRLST")
+        assert request.model_dump(by_alias=True) == {"trnm": "CNSRLST"}
+
+    def test_invalid_trnm_raises(self):
+        with pytest.raises(ValueError):
+            DomesticConditionSearchListRequest(trnm="INVALID")
+
+    def test_response_validates_and_maps_fields(self):
+        payload = {
+            "return_code": 0,
+            "return_msg": "",
+            "trnm": "CNSRLST",
+            "data": [
+                {"seq": "0", "name": "조건식1"},
+                {"seq": "1", "name": "조건식2"},
+            ],
+        }
+
+        response = DomesticConditionSearchListResponse.model_validate(payload)
+
+        assert response.return_code == 0
+        assert response.trnm == "CNSRLST"
+        assert len(response.data) == 2
+        assert response.data[0] == DomesticConditionSearchListItem(seq="0", name="조건식1")
+        assert response.data[1].seq == "1"
+        assert response.data[1].name == "조건식2"
+
+
+# ---------------------------------------------------------------------------
+# ka10172 조건검색 요청 일반
+# ---------------------------------------------------------------------------
+
+
+class TestDomesticConditionSearchRequest:
+    def test_request_dump_matches_wire_format(self):
+        request = DomesticConditionSearchRequest(
+            trnm="CNSRREQ",
+            seq="0",
+            search_type="0",
+            stex_tp="K",
+            cont_yn="N",
+            next_key="",
+        )
+
+        assert request.model_dump(by_alias=True) == {
+            "trnm": "CNSRREQ",
+            "seq": "0",
+            "search_type": "0",
+            "stex_tp": "K",
+            "cont_yn": "N",
+            "next_key": "",
+        }
+
+    def test_request_defaults(self):
+        request = DomesticConditionSearchRequest(trnm="CNSRREQ", seq="0", search_type="0")
+        assert request.stex_tp == "K"
+        assert request.cont_yn == "N"
+        assert request.next_key == ""
+
+    def test_invalid_search_type_raises(self):
+        """ka10172는 search_type이 반드시 '0' (일반조회)."""
+        with pytest.raises(ValueError):
+            DomesticConditionSearchRequest(trnm="CNSRREQ", seq="0", search_type="1")
+
+    def test_invalid_stex_tp_raises(self):
+        with pytest.raises(ValueError):
+            DomesticConditionSearchRequest(trnm="CNSRREQ", seq="0", search_type="0", stex_tp="Z")
+
+    def test_response_maps_fid_keys_by_alias(self):
+        """ka10172 결과 항목: FID 숫자키(9001→stock_code 등) 매핑."""
+        payload = {
+            "return_code": 0,
+            "return_msg": "",
+            "trnm": "CNSRREQ",
+            "seq": "0",
+            "cont_yn": "N",
+            "next_key": "",
+            "data": [
+                {
+                    "9001": "005930",
+                    "302": "삼성전자",
+                    "10": "70000",
+                    "25": "2",
+                    "11": "1000",
+                    "12": "1.45",
+                    "13": "1000000",
+                    "16": "69000",
+                    "17": "71000",
+                    "18": "68500",
+                }
+            ],
+        }
+
+        response = DomesticConditionSearchResponse.model_validate(payload)
+
+        assert response.trnm == "CNSRREQ"
+        assert response.cont_yn == "N"
+        item = response.data[0]
+        assert item.stock_code == "005930"
+        assert item.stock_name == "삼성전자"
+        assert item.current_price == "70000"
+        assert item.prev_day_diff_sign == "2"
+        assert item.prev_day_diff == "1000"
+        assert item.fluctuation_rate == "1.45"
+        assert item.acc_trade_volume == "1000000"
+        assert item.open_price == "69000"
+        assert item.high_price == "71000"
+        assert item.low_price == "68500"
+
+    def test_populate_by_name_round_trip(self):
+        item = DomesticConditionSearchResultItem(stock_code="005930", stock_name="삼성전자", current_price="70000")
+        dumped = item.model_dump(by_alias=True)
+        assert dumped["9001"] == "005930"
+        assert dumped["302"] == "삼성전자"
+        assert dumped["10"] == "70000"
+
+    def test_response_continuation_frame(self):
+        """cont_yn=Y 인 연속조회 프레임 - next_key 채워짐."""
+        payload = {
+            "return_code": 0,
+            "return_msg": "",
+            "trnm": "CNSRREQ",
+            "seq": "0",
+            "cont_yn": "Y",
+            "next_key": "000123",
+            "data": [],
+        }
+        response = DomesticConditionSearchResponse.model_validate(payload)
+        assert response.cont_yn == "Y"
+        assert response.next_key == "000123"
+
+
+# ---------------------------------------------------------------------------
+# ka10173 조건검색 요청 실시간
+# ---------------------------------------------------------------------------
+
+
+class TestDomesticConditionSearchRealtimeRequest:
+    def test_request_dump_matches_wire_format(self):
+        request = DomesticConditionSearchRealtimeRequest(trnm="CNSRREQ", seq="0", search_type="1", stex_tp="K")
+        assert request.model_dump(by_alias=True) == {
+            "trnm": "CNSRREQ",
+            "seq": "0",
+            "search_type": "1",
+            "stex_tp": "K",
+        }
+
+    def test_invalid_search_type_raises(self):
+        """ka10173은 search_type이 반드시 '1' (조건검색+실시간조건검색)."""
+        with pytest.raises(ValueError):
+            DomesticConditionSearchRealtimeRequest(trnm="CNSRREQ", seq="0", search_type="0")
+
+    def test_response_maps_fields(self):
+        payload = {
+            "return_code": 0,
+            "return_msg": "",
+            "trnm": "CNSRREQ",
+            "seq": "0",
+            "data": [{"jmcode": "005930"}],
+        }
+
+        response = DomesticConditionSearchRealtimeResponse.model_validate(payload)
+
+        assert response.trnm == "CNSRREQ"
+        assert response.seq == "0"
+        assert response.data[0].jmcode == "005930"
+
+    def test_response_empty_data_real_push(self):
+        """실시간 편입/이탈 이벤트가 없을 때도 data는 빈 리스트로 검증 가능."""
+        payload = {"trnm": "CNSRREQ", "seq": "0", "data": []}
+        response = DomesticConditionSearchRealtimeResponse.model_validate(payload)
+        assert response.return_code is None
+        assert response.data == []
+
+
+class TestDomesticConditionSearchRealtimePush:
+    """ka10173 실시간 편입/이탈 푸시 프레임 (trnm=REAL, values FID 매핑)."""
+
+    def test_push_frame_maps_values_fid_keys(self):
+        payload = {
+            "trnm": "REAL",
+            "data": [
+                {
+                    "type": "0A",
+                    "name": "005930",
+                    "values": {
+                        "841": "1",
+                        "9001": "A005930",
+                        "843": "I",
+                        "20": "093000",
+                        "907": "2",
+                        "9081": "1",
+                    },
+                }
+            ],
+        }
+
+        push = DomesticConditionSearchRealtimePush.model_validate(payload)
+
+        assert push.trnm == "REAL"
+        item = push.data[0]
+        assert item.type == "0A"
+        assert item.name == "005930"
+        assert item.values.seq_no == "1"
+        assert item.values.stock_code == "A005930"
+        assert item.values.insert_delete == "I"
+        assert item.values.exec_time == "093000"
+        assert item.values.buy_sell == "2"
+        assert item.values.exchange == "1"
+
+    def test_invalid_trnm_raises(self):
+        with pytest.raises(ValueError):
+            DomesticConditionSearchRealtimePush.model_validate({"trnm": "CNSRREQ", "data": []})
+
+    def test_data_required(self):
+        """스펙상 data/trnm 모두 Required=Y - data 누락시 검증 실패."""
+        with pytest.raises(ValueError):
+            DomesticConditionSearchRealtimePush.model_validate({"trnm": "REAL"})
+
+
+# ---------------------------------------------------------------------------
+# ka10174 조건검색 실시간 해제
+# ---------------------------------------------------------------------------
+
+
+class TestDomesticConditionSearchRealtimeCancel:
+    def test_request_dump_matches_wire_format(self):
+        request = DomesticConditionSearchRealtimeCancelRequest(trnm="CNSRCLR", seq="0")
+        assert request.model_dump(by_alias=True) == {"trnm": "CNSRCLR", "seq": "0"}
+
+    def test_invalid_trnm_raises(self):
+        with pytest.raises(ValueError):
+            DomesticConditionSearchRealtimeCancelRequest(trnm="INVALID", seq="0")
+
+    def test_response_requires_all_fields(self):
+        """스펙상 4개 필드 모두 Required=Y (단순 ACK 프레임) - 누락시 검증 실패."""
+        response = DomesticConditionSearchRealtimeCancelResponse.model_validate(
+            {"return_code": 0, "return_msg": "", "trnm": "CNSRCLR", "seq": "0"}
+        )
+        assert response.return_code == 0
+        assert response.trnm == "CNSRCLR"
+        assert response.seq == "0"
+
+        with pytest.raises(ValueError):
+            DomesticConditionSearchRealtimeCancelResponse.model_validate(
+                {"return_code": 0, "return_msg": "", "trnm": "CNSRCLR"}
+            )

--- a/packages/cluefin-openapi/tests/kiwoom/test_domestic_condition_search_ws_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_domestic_condition_search_ws_unit.py
@@ -1,0 +1,137 @@
+"""``DomesticConditionSearch`` 도메인 래퍼 unit 테스트.
+
+실제 WebSocket 없이 FakeSocketClient로 요청 프레임 송신과 응답 파싱, 그리고 실시간 푸시
+프레임이 섞여 있을 때 응답 프레임만 골라내는 ``_recv_until`` 동작을 검증한다.
+(미국주식 ``test_overseas_condition_search_ws_unit`` 과 대칭.)
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from cluefin_openapi.kiwoom._domestic_condition_search import DomesticConditionSearch
+from cluefin_openapi.kiwoom._domestic_condition_search_types import (
+    DomesticConditionSearchListResponse,
+    DomesticConditionSearchRealtimeCancelResponse,
+    DomesticConditionSearchRealtimeResponse,
+    DomesticConditionSearchResponse,
+)
+from cluefin_openapi.kiwoom._socket_client import KiwoomWebSocketMessage
+
+
+class FakeSocketClient:
+    """송신 프레임을 기록하고, 미리 큐잉한 메시지를 recv()로 반환한다."""
+
+    def __init__(self, incoming: list[KiwoomWebSocketMessage] | None = None):
+        self.sent: list[dict] = []
+        self._incoming = list(incoming or [])
+
+    async def send(self, message):
+        self.sent.append(message.model_dump(by_alias=True) if isinstance(message, BaseModel) else message)
+
+    async def recv(self) -> KiwoomWebSocketMessage:
+        return self._incoming.pop(0)
+
+
+def _msg(body: dict) -> KiwoomWebSocketMessage:
+    return KiwoomWebSocketMessage(trnm=body.get("trnm", ""), body=body)
+
+
+class TestGetConditionSearchList:
+    @pytest.mark.asyncio
+    async def test_sends_cnsrlst_and_parses_response(self):
+        socket = FakeSocketClient(
+            [_msg({"trnm": "CNSRLST", "return_code": 0, "data": [{"seq": "0", "name": "조건식1"}]})]
+        )
+        condition = DomesticConditionSearch(socket)
+
+        result = await condition.get_condition_search_list()
+
+        assert socket.sent[0] == {"trnm": "CNSRLST"}
+        assert isinstance(result, DomesticConditionSearchListResponse)
+        assert result.data[0].seq == "0"
+        assert result.data[0].name == "조건식1"
+
+
+class TestRequestConditionSearch:
+    @pytest.mark.asyncio
+    async def test_sends_cnsrreq_search_type_0_and_parses(self):
+        socket = FakeSocketClient(
+            [
+                _msg(
+                    {
+                        "trnm": "CNSRREQ",
+                        "return_code": 0,
+                        "seq": "0",
+                        "cont_yn": "N",
+                        "next_key": "",
+                        "data": [{"9001": "005930", "302": "삼성전자"}],
+                    }
+                )
+            ]
+        )
+        condition = DomesticConditionSearch(socket)
+
+        result = await condition.request_condition_search(seq="0")
+
+        assert socket.sent[0] == {
+            "trnm": "CNSRREQ",
+            "seq": "0",
+            "search_type": "0",
+            "stex_tp": "K",
+            "cont_yn": "N",
+            "next_key": "",
+        }
+        assert isinstance(result, DomesticConditionSearchResponse)
+        assert result.data[0].stock_code == "005930"
+        assert result.data[0].stock_name == "삼성전자"
+
+    @pytest.mark.asyncio
+    async def test_continuation_params_are_forwarded(self):
+        socket = FakeSocketClient([_msg({"trnm": "CNSRREQ", "return_code": 0, "seq": "0", "data": []})])
+        condition = DomesticConditionSearch(socket)
+
+        await condition.request_condition_search(seq="0", cont_yn="Y", next_key="000123")
+
+        assert socket.sent[0]["cont_yn"] == "Y"
+        assert socket.sent[0]["next_key"] == "000123"
+
+
+class TestRealtimeConditionSearch:
+    @pytest.mark.asyncio
+    async def test_request_realtime_sends_search_type_1(self):
+        socket = FakeSocketClient([_msg({"trnm": "CNSRREQ", "seq": "0", "data": [{"jmcode": "005930"}]})])
+        condition = DomesticConditionSearch(socket)
+
+        result = await condition.request_realtime_condition_search(seq="0")
+
+        assert socket.sent[0] == {"trnm": "CNSRREQ", "seq": "0", "search_type": "1", "stex_tp": "K"}
+        assert isinstance(result, DomesticConditionSearchRealtimeResponse)
+        assert result.data[0].jmcode == "005930"
+
+    @pytest.mark.asyncio
+    async def test_recv_until_skips_interleaved_real_frames(self):
+        """실시간 푸시 프레임(REAL)이 먼저 와도 CNSRREQ 응답만 골라 반환한다."""
+        socket = FakeSocketClient(
+            [
+                _msg({"trnm": "REAL", "data": [{"type": "0A", "name": "005930", "values": {"9001": "A005930"}}]}),
+                _msg({"trnm": "CNSRREQ", "seq": "0", "data": []}),
+            ]
+        )
+        condition = DomesticConditionSearch(socket)
+
+        result = await condition.request_realtime_condition_search(seq="0")
+
+        assert isinstance(result, DomesticConditionSearchRealtimeResponse)
+        assert result.seq == "0"
+
+    @pytest.mark.asyncio
+    async def test_cancel_sends_cnsrclr_and_parses_ack(self):
+        socket = FakeSocketClient([_msg({"trnm": "CNSRCLR", "return_code": 0, "return_msg": "", "seq": "0"})])
+        condition = DomesticConditionSearch(socket)
+
+        result = await condition.cancel_realtime_condition_search(seq="0")
+
+        assert socket.sent[0] == {"trnm": "CNSRCLR", "seq": "0"}
+        assert isinstance(result, DomesticConditionSearchRealtimeCancelResponse)
+        assert result.return_code == 0
+        assert result.seq == "0"

--- a/packages/cluefin-openapi/tests/kiwoom/test_domestic_realtime_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_domestic_realtime_unit.py
@@ -1,0 +1,126 @@
+"""국내주식 실시간 시세(웹소켓) 메시지 모델 unit 테스트.
+
+19개 실시간 TR은 웹소켓 API이므로 HTTP 클라이언트 테스트(run_post_case)를 적용할 수
+없다. 여기서는 등록/해지 요청 모델의 wire 포맷 dump와 대표 TR 응답 모델의 FID(alias)
+매핑을 검증한다. ``DomesticRealtime`` 도메인 래퍼의 송신·파싱 동작은
+``test_domestic_realtime_ws_unit.py``에서 검증한다.
+(미국주식 ``test_overseas_realtime_unit`` 과 대칭.)
+"""
+
+import pytest
+
+from cluefin_openapi.kiwoom._domestic_realtime_types import (
+    DomesticRealtimeEtfNavValues,
+    DomesticRealtimeIndustryFluctuationValues,
+    DomesticRealtimeOrderExecutionValues,
+    DomesticRealtimeRegisterData,
+    DomesticRealtimeRequest,
+    DomesticRealtimeStockExecutionValues,
+    DomesticRealtimeStockQuoteRemainingValues,
+)
+
+# ---------------------------------------------------------------------------
+# 공통 등록/해지 요청
+# ---------------------------------------------------------------------------
+
+
+class TestDomesticRealtimeRequest:
+    def test_reg_request_dump_matches_wire_format(self):
+        request = DomesticRealtimeRequest(
+            trnm="REG",
+            grp_no="1",
+            refresh="1",
+            data=[DomesticRealtimeRegisterData(item=["005930", "000660"], type=["0B", "0D"])],
+        )
+        assert request.model_dump(by_alias=True) == {
+            "trnm": "REG",
+            "grp_no": "1",
+            "refresh": "1",
+            "data": [{"item": ["005930", "000660"], "type": ["0B", "0D"]}],
+        }
+
+    def test_invalid_trnm_raises(self):
+        with pytest.raises(ValueError):
+            DomesticRealtimeRequest(trnm="INVALID", grp_no="1", refresh="1")
+
+    def test_invalid_refresh_raises(self):
+        with pytest.raises(ValueError):
+            DomesticRealtimeRequest(trnm="REG", grp_no="1", refresh="2")
+
+
+# ---------------------------------------------------------------------------
+# TR별 values FID 매핑
+# ---------------------------------------------------------------------------
+
+
+class TestValuesFidMapping:
+    def test_stock_execution_maps_fid_keys_by_alias(self):
+        """0B 주식체결: FID 숫자키(20→execution_time 등) 매핑."""
+        values = DomesticRealtimeStockExecutionValues.model_validate(
+            {"20": "165208", "10": "-20800", "11": "-50", "12": "-0.24", "13": "30379732", "25": "5"}
+        )
+        assert values.execution_time == "165208"
+        assert values.current_price == "-20800"
+        assert values.prev_day_diff == "-50"
+        assert values.fluctuation_rate == "-0.24"
+        assert values.acc_trade_volume == "30379732"
+        assert values.prev_day_diff_sign == "5"
+
+    def test_order_execution_maps_account_and_order_fields(self):
+        """00 주문체결: 계좌/주문 관련 FID 매핑."""
+        values = DomesticRealtimeOrderExecutionValues.model_validate(
+            {"9201": "1111111111", "9203": "0000018", "9001": "005930", "913": "접수", "900": "1", "907": "2"}
+        )
+        assert values.account_no == "1111111111"
+        assert values.order_no == "0000018"
+        assert values.stock_code == "005930"
+        assert values.order_status == "접수"
+        assert values.order_quantity == "1"
+        assert values.sell_buy_type == "2"
+
+    def test_etf_nav_has_nav_specific_fields(self):
+        """0G ETF NAV: 0g(주식종목정보)와 코드는 유사하나 NAV 전용 FID를 가진다."""
+        values = DomesticRealtimeEtfNavValues.model_validate(
+            {"36": "+7488.27", "37": "+1.20", "38": "+0.02", "39": "0.02", "265": "-0.01", "266": "-0.02"}
+        )
+        assert values.nav == "+7488.27"
+        assert values.nav_prev_day_diff == "+1.20"
+        assert values.nav_fluctuation_rate == "+0.02"
+        assert values.tracking_error_rate == "0.02"
+        assert values.nav_index_gap_rate == "-0.01"
+        assert values.nav_etf_gap_rate == "-0.02"
+
+    def test_industry_fluctuation_has_counts(self):
+        """0U 업종등락: 상승/하락 종목수 등 업종 전용 FID."""
+        values = DomesticRealtimeIndustryFluctuationValues.model_validate(
+            {"252": "46", "251": "0", "253": "5", "255": "40", "254": "3", "256": "94"}
+        )
+        assert values.advancing_count == "46"
+        assert values.upper_limit_count == "0"
+        assert values.unchanged_count == "5"
+        assert values.declining_count == "40"
+        assert values.lower_limit_count == "3"
+        assert values.traded_stock_count == "94"
+
+    def test_quote_remaining_numbered_series_map_in_order(self):
+        """0D 주식호가잔량: 매도/매수 호가 번호 시리즈가 순서대로 매핑."""
+        values = DomesticRealtimeStockQuoteRemainingValues.model_validate(
+            {"41": "20800", "50": "20300", "51": "20750", "60": "20200", "61": "1000", "71": "2000"}
+        )
+        assert values.ask_price_1 == "20800"
+        assert values.ask_price_10 == "20300"
+        assert values.bid_price_1 == "20750"
+        assert values.bid_price_10 == "20200"
+        assert values.ask_volume_1 == "1000"
+        assert values.bid_volume_1 == "2000"
+
+    def test_populate_by_name_round_trip(self):
+        values = DomesticRealtimeStockExecutionValues(current_price="-20800", execution_time="165208")
+        dumped = values.model_dump(by_alias=True)
+        assert dumped["10"] == "-20800"
+        assert dumped["20"] == "165208"
+
+    def test_unmapped_fid_keys_are_ignored(self):
+        """알 수 없는 FID 키는 무시하고 매핑된 필드만 채운다."""
+        values = DomesticRealtimeStockExecutionValues.model_validate({"10": "70000", "99999": "x"})
+        assert values.current_price == "70000"

--- a/packages/cluefin-openapi/tests/kiwoom/test_domestic_realtime_ws_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_domestic_realtime_ws_unit.py
@@ -1,0 +1,157 @@
+"""``DomesticRealtime`` 도메인 래퍼 unit 테스트.
+
+실제 WebSocket 없이 FakeSocketClient로 등록/해지 프레임 송신과 REAL 프레임 파싱을
+검증한다. (미국주식 ``test_overseas_realtime_ws_unit`` 과 대칭.)
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from cluefin_openapi.kiwoom._domestic_realtime import DomesticRealtime
+from cluefin_openapi.kiwoom._domestic_realtime_types import (
+    DomesticRealtimeEtfNav,
+    DomesticRealtimeIndustryFluctuation,
+    DomesticRealtimeOrderExecution,
+    DomesticRealtimeStockExecution,
+    DomesticRealtimeStockQuoteRemaining,
+    DomesticRealtimeViActivation,
+)
+from cluefin_openapi.kiwoom._socket_client import KiwoomWebSocketMessage
+
+
+class FakeSocketClient:
+    def __init__(self):
+        self.sent: list[dict] = []
+
+    async def send(self, message):
+        self.sent.append(message.model_dump(by_alias=True) if isinstance(message, BaseModel) else message)
+
+
+@pytest.fixture
+def socket() -> FakeSocketClient:
+    return FakeSocketClient()
+
+
+class TestRegisterRemove:
+    @pytest.mark.asyncio
+    async def test_register_builds_reg_frame(self, socket):
+        realtime = DomesticRealtime(socket)
+        await realtime.register(["0B", "0D"], ["005930", "000660"])
+        assert socket.sent[0] == {
+            "trnm": "REG",
+            "grp_no": "1",
+            "refresh": "1",
+            "data": [{"item": ["005930", "000660"], "type": ["0B", "0D"]}],
+        }
+
+    @pytest.mark.asyncio
+    async def test_register_forwards_grp_no_and_refresh(self, socket):
+        realtime = DomesticRealtime(socket)
+        await realtime.register(["0B"], ["005930"], grp_no="3", refresh="0")
+        assert socket.sent[0]["grp_no"] == "3"
+        assert socket.sent[0]["refresh"] == "0"
+
+    @pytest.mark.asyncio
+    async def test_remove_builds_remove_frame(self, socket):
+        realtime = DomesticRealtime(socket)
+        await realtime.remove(["0D"], ["005930"], grp_no="2")
+        assert socket.sent[0] == {
+            "trnm": "REMOVE",
+            "grp_no": "2",
+            "refresh": "0",
+            "data": [{"item": ["005930"], "type": ["0D"]}],
+        }
+
+
+class TestParse:
+    def test_parse_dispatches_stock_execution_frame(self):
+        message = KiwoomWebSocketMessage(
+            trnm="REAL",
+            body={
+                "trnm": "REAL",
+                "data": [
+                    {
+                        "type": "0B",
+                        "name": "주식체결",
+                        "item": "005930",
+                        "values": {"20": "165208", "10": "-20800", "12": "-0.24", "13": "30379732"},
+                    }
+                ],
+            },
+        )
+        parsed = DomesticRealtime.parse(message)
+        assert isinstance(parsed, DomesticRealtimeStockExecution)
+        values = parsed.data[0].values
+        assert values.execution_time == "165208"
+        assert values.current_price == "-20800"
+        assert values.fluctuation_rate == "-0.24"
+        assert values.acc_trade_volume == "30379732"
+
+    def test_parse_dispatches_order_execution_frame(self):
+        message = KiwoomWebSocketMessage(
+            trnm="REAL",
+            body={
+                "trnm": "REAL",
+                "data": [{"type": "00", "item": "005930", "values": {"9001": "005930", "913": "체결"}}],
+            },
+        )
+        parsed = DomesticRealtime.parse(message)
+        assert isinstance(parsed, DomesticRealtimeOrderExecution)
+        assert parsed.data[0].values.stock_code == "005930"
+        assert parsed.data[0].values.order_status == "체결"
+
+    def test_parse_dispatches_etf_nav_frame(self):
+        """0G(ETF NAV)와 0g(주식종목정보)는 코드 대소문자만 다르지만 FID가 완전히 다르다."""
+        message = KiwoomWebSocketMessage(
+            trnm="REAL",
+            body={
+                "trnm": "REAL",
+                "data": [{"type": "0G", "item": "069500", "values": {"36": "+7488.27", "39": "0.02", "265": "-0.01"}}],
+            },
+        )
+        parsed = DomesticRealtime.parse(message)
+        assert isinstance(parsed, DomesticRealtimeEtfNav)
+        assert parsed.data[0].values.nav == "+7488.27"
+        assert parsed.data[0].values.tracking_error_rate == "0.02"
+        assert parsed.data[0].values.nav_index_gap_rate == "-0.01"
+
+    def test_parse_dispatches_industry_fluctuation_frame(self):
+        message = KiwoomWebSocketMessage(
+            trnm="REAL",
+            body={"trnm": "REAL", "data": [{"type": "0U", "item": "001", "values": {"252": "46", "254": "3"}}]},
+        )
+        parsed = DomesticRealtime.parse(message)
+        assert isinstance(parsed, DomesticRealtimeIndustryFluctuation)
+        assert parsed.data[0].values.advancing_count == "46"
+        assert parsed.data[0].values.lower_limit_count == "3"
+
+    def test_parse_dispatches_quote_remaining_frame(self):
+        message = KiwoomWebSocketMessage(
+            trnm="REAL",
+            body={"trnm": "REAL", "data": [{"type": "0D", "item": "005930", "values": {"41": "20800", "61": "1000"}}]},
+        )
+        parsed = DomesticRealtime.parse(message)
+        assert isinstance(parsed, DomesticRealtimeStockQuoteRemaining)
+        assert parsed.data[0].values.ask_price_1 == "20800"
+        assert parsed.data[0].values.ask_volume_1 == "1000"
+
+    def test_parse_dispatches_vi_activation_frame(self):
+        message = KiwoomWebSocketMessage(
+            trnm="REAL",
+            body={
+                "trnm": "REAL",
+                "data": [{"type": "1h", "item": "005930", "values": {"9001": "005930", "1221": "21000"}}],
+            },
+        )
+        parsed = DomesticRealtime.parse(message)
+        assert isinstance(parsed, DomesticRealtimeViActivation)
+        assert parsed.data[0].values.vi_activation_price == "21000"
+
+    def test_parse_returns_none_for_ack_frame(self):
+        """등록/해지 ACK 프레임(빈 data)은 대상 TR이 아니므로 None."""
+        message = KiwoomWebSocketMessage(trnm="REG", body={"trnm": "REG", "return_code": 0, "data": []})
+        assert DomesticRealtime.parse(message) is None
+
+    def test_parse_returns_none_for_unknown_type(self):
+        message = KiwoomWebSocketMessage(trnm="REAL", body={"trnm": "REAL", "data": [{"type": "ZZ"}]})
+        assert DomesticRealtime.parse(message) is None


### PR DESCRIPTION
## 관련 이슈

<!-- Closes #이슈번호 형태로 관련 이슈를 연결해주세요 -->

## 변경 사항

국내주식 웹소켓 API를 stub에서 실제 구현으로 완성했다. 미국주식(`_overseas_*`) 구조와 대칭이며, 공유 `KiwoomWebSocketClient`에 `market` 파라미터를 추가해 국내(`/api/dostk/websocket`)·미국(`/api/us/websocket`) 엔드포인트를 함께 지원한다.

- **조건검색**(`DomesticConditionSearch`): 목록조회(ka10171)·요청 일반/실시간(ka10172/73)·실시간 해제(ka10174). 국내는 거래소구분 `stex_tp="K"`(KRX) 포함.
- **실시간 시세**(`DomesticRealtime`): 19개 TR(주문체결·잔고·주식호가잔량·VI발동 등) 등록/해지(REG/REMOVE)·수신 프레임 파싱. FID 매핑은 키움 실시간시세 가이드에서 확보했다.

## 변경 유형

- [ ] 버그 수정 (`fix`)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 기존 기능 개선 (`feat`)
- [ ] 리팩토링 (`refactor`)
- [ ] 테스트 추가/수정 (`test`)
- [ ] 문서 수정 (`docs`)
- [ ] 의존성 업데이트 (`chore`)
- [ ] CI/CD (`ci`)

## 영향 범위

- [x] cluefin-openapi
- [ ] cluefin-ta
- [ ] cluefin-xbrl
- [ ] cluefin-cli
- [ ] cluefin-desk
- [ ] 루트 프로젝트 설정

## 테스트

웹소켓 API라 HTTP 테스트(run_post_case)를 적용할 수 없어, FakeSocketClient로 요청 프레임 송신·응답 파싱을 검증하고 응답 모델 FID/alias 매핑을 단위 테스트로 확인했다. 19개 실시간 TR은 실제 가이드 예제 payload로 round-trip을 검증했다.

- [x] 단위 테스트 통과 (`uv run pytest -m "not integration"`)
- [ ] 통합 테스트 통과 (`uv run pytest -m "integration"`)
- [ ] 테스트 불필요 (문서, 설정 변경 등)

## 체크리스트

- [x] `uv run ruff format . && uv run ruff check . --fix` 실행
- [x] 커밋 메시지가 컨벤션을 따름 (`type(scope): 설명`)
- [x] `.env`, 시크릿, 인증 정보 미포함
- [ ] 관련 문서 업데이트 완료 (해당 시)

## 참고 사항 (선택)

실시간 시세는 장중(09:00–15:30 KST)에만 데이터가 흐르므로 통합 테스트는 별도 진행이 필요하다.
