### PR TITLE
fix(kiwoom): 국내·미국주식 API 스펙을 공식 문서와 전수 대조해 정정

### DIFF
--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_account.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_account.py
@@ -963,6 +963,7 @@ class DomesticAccount:
         stk_cd: Optional[str] = None,
         crnc_cd: Optional[str] = None,
         frgn_stex_code: Optional[str] = None,
+        qry_sort_tp: Optional[str] = None,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[DomesticAccountConsignmentComprehensiveTransactionHistory]:
@@ -977,6 +978,7 @@ class DomesticAccount:
             stk_cd (Optional[str], optional): 종목코드. Defaults to None.
             crnc_cd (Optional[str], optional): 통화코드. Defaults to None.
             frgn_stex_code (Optional[str], optional): 해외거래소코드. Defaults to None.
+            qry_sort_tp (Optional[str], optional): 조회정렬구분 (1:최근거래순, 2:과거거래순, 미입력시 과거거래순). Defaults to None.
             cont_yn (Literal["Y", "N"], optional): 연속 조회 여부. Defaults to "N".
             next_key (str, optional): 다음 키. Defaults to "".
 
@@ -1008,6 +1010,9 @@ class DomesticAccount:
 
         if frgn_stex_code is not None:
             body["frgn_stex_code"] = frgn_stex_code
+
+        if qry_sort_tp is not None:
+            body["qry_sort_tp"] = qry_sort_tp
 
         response = self.client._post(self.path, headers, body)
 

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_account_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_account_types.py
@@ -337,7 +337,7 @@ class DomesticAccountDepositBalanceDetails(BaseModel, KiwoomHttpBody):
     nrpy_loan: str = Field(default="", description="미상환융자금", max_length=15)
     loan_sum: str = Field(default="", description="융자금합계", max_length=15)
     ls_sum: str = Field(default="", description="대주금합계", max_length=15)
-    crd_grnt_ch: str = Field(default="", description="신용담보비율", max_length=15, alias="crd_grnt_rt")
+    crd_grnt_rt: str = Field(default="", description="신용담보비율", max_length=15)
     mdstrm_usfe: str = Field(default="", description="중도이용료", max_length=15)
     min_ord_alow_yn: str = Field(default="", description="최소주문가능금액", max_length=15)
     loan_remn_evlt_amt: str = Field(default="", description="대출총평가금액", max_length=15)
@@ -349,6 +349,12 @@ class DomesticAccountDepositBalanceDetails(BaseModel, KiwoomHttpBody):
     d1_out_rep_mor: str = Field(default="", description="d+1미수변제소요금", max_length=15)
     d1_sel_exct_amt: str = Field(default="", description="d+1매도정산금", max_length=15)
     d1_pymn_alow_amt: str = Field(default="", description="d+1출금가능금액", max_length=15)
+    d2_entra: str = Field(default="", description="d+2추정예수금", max_length=15)
+    d2_slby_exct_amt: str = Field(default="", description="d+2매도매수정산금", max_length=15)
+    d2_buy_exct_amt: str = Field(default="", description="d+2매수정산금", max_length=15)
+    d2_out_rep_mor: str = Field(default="", description="d+2미수변제소요금", max_length=15)
+    d2_sel_exct_amt: str = Field(default="", description="d+2매도정산금", max_length=15)
+    d2_pymn_alow_amt: str = Field(default="", description="d+2출금가능금액", max_length=15)
     stk_ord_allow_amt_50: str = Field(
         default="", description="50%종목주문가능금액", max_length=15, alias="50stk_ord_alow_amt"
     )
@@ -478,7 +484,7 @@ class DomesticAccountExecutionBalance(BaseModel, KiwoomHttpBody):
     ord_alow_amt_100: str = Field(default="", description="100%주문가능금액", max_length=12, alias="100ord_alow_amt")
     crd_loan_tot: str = Field(default="", description="신용융자합계", max_length=12)
     crd_loan_ls_tot: str = Field(default="", description="신용융자대주합계", max_length=12)
-    crd_grnt_rt: str = Field(default="", description="신용담보비율", max_length=12, alias="crd_grnt_ch")
+    crd_grnt_rt: str = Field(default="", description="신용담보비율", max_length=12)
     dpst_grnt_use_amt_amt: str = Field(default="", description="예탁담보대출금액", max_length=12)
     grnt_loan_amt: str = Field(default="", description="매도담보대출금액", max_length=12)
     stk_cntr_remn: list[DomesticAccountExecutionBalanceItem] = Field(
@@ -522,36 +528,33 @@ class DomesticAccountOrderExecutionDetails(BaseModel, KiwoomHttpBody):
 
 
 class DomesticAccountNextDaySettlementDetailsItem(BaseModel):
-    ord_no: str = Field(default="", description="주문번호", max_length=7)
+    seq: str = Field(default="", description="일련번호", max_length=7)
     stk_cd: str = Field(default="", description="종목번호", max_length=12)
-    trde_tp: str = Field(default="", description="매매구분", max_length=20)
-    crd_tp: str = Field(default="", description="신용구분", max_length=20)
-    ord_qty: str = Field(default="", description="주문수량", max_length=10)
-    ord_uv: str = Field(default="", description="주문단가", max_length=10)
-    cnfm_qty: str = Field(default="", description="확인수량", max_length=10)
-    acpt_tp: str = Field(default="", description="접수구분", max_length=20)
-    rsrv_tp: str = Field(default="", description="반대여부", max_length=20)
-    ord_tm: str = Field(default="", description="주문시간", max_length=8)
-    ori_ord: str = Field(default="", description="원주문", max_length=7)
-    stk_nm: str = Field(default="", description="종목명", max_length=40)
-    io_tp_nm: str = Field(default="", description="주문구분", max_length=20)
     loan_dt: str = Field(default="", description="대출일", max_length=8)
-    cntr_qty: str = Field(default="", description="체결수량", max_length=10)
-    cntr_uv: str = Field(default="", description="체결단가", max_length=10)
-    ord_remnq: str = Field(default="", description="주문잔량", max_length=10)
-    comm_ord_tp: str = Field(default="", description="통신구분", max_length=20)
-    mdfy_cncl: str = Field(default="", description="정정취소", max_length=20)
-    cnfm_tm: str = Field(default="", description="확인시간", max_length=8)
-    dmst_stex_tp: str = Field(default="", description="국내거래소구분", max_length=8)
-    cond_uv: str = Field(default="", description="스톱가", max_length=10)
+    qty: str = Field(default="", description="수량", max_length=12)
+    engg_amt: str = Field(default="", description="약정금액", max_length=12)
+    cmsn: str = Field(default="", description="수수료", max_length=12)
+    incm_tax: str = Field(default="", description="소득세", max_length=12)
+    rstx: str = Field(default="", description="농특세", max_length=12)
+    stk_nm: str = Field(default="", description="종목명", max_length=40)
+    sell_tp: str = Field(default="", description="매도수구분", max_length=10)
+    unp: str = Field(default="", description="단가", max_length=12)
+    exct_amt: str = Field(default="", description="정산금액", max_length=12)
+    trde_tax: str = Field(default="", description="거래세", max_length=12)
+    resi_tax: str = Field(default="", description="주민세", max_length=12)
+    crd_tp: str = Field(default="", description="신용구분", max_length=20)
 
 
 class DomesticAccountNextDaySettlementDetails(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="계좌별익일결제예정내역요청 응답")
 
-    acnt_ord_cntr_prps_dtl: list[DomesticAccountOrderExecutionDetailsItem] = Field(
+    trde_dt: str = Field(default="", description="매매일자", max_length=8)
+    setl_dt: str = Field(default="", description="결제일자", max_length=8)
+    sell_amt_sum: str = Field(default="", description="매도정산합", max_length=12)
+    buy_amt_sum: str = Field(default="", description="매수정산합", max_length=12)
+    acnt_nxdy_setl_frcs_prps_array: list[DomesticAccountNextDaySettlementDetailsItem] = Field(
         default_factory=list,
-        description="계좌별주문체결내역상세",
+        description="계좌별익일결제예정내역배열",
     )
 
 
@@ -586,9 +589,9 @@ class DomesticAccountOrderExecutionStatus(BaseModel, KiwoomHttpBody):
     sell_grntl_engg_amt: str = Field(default="", description="매도약정금액", max_length=12)
     buy_engg_amt: str = Field(default="", description="매수약정금액", max_length=12)
     engg_amt: str = Field(default="", description="약정금액", max_length=12)
-    acnt_ord_cntr_prst: list[DomesticAccountOrderExecutionStatusItem] = Field(
+    acnt_ord_cntr_prst_array: list[DomesticAccountOrderExecutionStatusItem] = Field(
         default_factory=list,
-        description="계좌별주문체결현황",
+        description="계좌별주문체결현황배열",
     )
 
 
@@ -607,9 +610,9 @@ class DomesticAccountAvailableWithdrawalAmount(BaseModel, KiwoomHttpBody):
     profa_60ord_alowq: str = Field(default="", description="증거금60%주문가능수량", max_length=10)
     profa_rdex_60ord_alow_amt: str = Field(default="", description="증거금감면60%주문가능금액", max_length=12)
     profa_rdex_60ord_alowq: str = Field(default="", description="증거금감면60%주문가능수량", max_length=10)
-    prfa_100ord_allow_amt: str = Field(default="", description="증거금100%주문가능금액", max_length=12)
+    profa_100ord_alow_amt: str = Field(default="", description="증거금100%주문가능금액", max_length=12)
     profa_100ord_alowq: str = Field(default="", description="증거금100%주문가능수량", max_length=10)
-    pred_reu_allowa: str = Field(default="", description="전일재사용가능금액", max_length=12)
+    pred_reu_alowa: str = Field(default="", description="전일재사용가능금액", max_length=12)
     tdy_reu_alowa: str = Field(default="", description="금일재사용가능금액", max_length=12)
     entr: str = Field(default="", description="예수금", max_length=12)
     repl_amt: str = Field(default="", description="대용금", max_length=12)
@@ -655,8 +658,8 @@ class DomesticAccountAvailableOrderQuantityByMarginRate(BaseModel, KiwoomHttpBod
     profa_100ord_alowq: str = Field(default="", description="증거금100%주문가능수량", max_length=12)
     profa_100pred_reu_amt: str = Field(default="", description="증거금100%전일재사용금액", max_length=12)
     profa_100tdy_reu_amt: str = Field(default="", description="증거금100%금일재사용금액", max_length=12)
-    min_ord_allow_amt: str = Field(default="", description="미수불가주문가능금액", max_length=12)
-    min_ord_allowq: str = Field(default="", description="미수불가주문가능수량", max_length=12)
+    min_ord_alow_amt: str = Field(default="", description="미수불가주문가능금액", max_length=12)
+    min_ord_alowq: str = Field(default="", description="미수불가주문가능수량", max_length=12)
     min_pred_reu_amt: str = Field(default="", description="미수불가전일재사용금액", max_length=12)
     min_tdy_reu_amt: str = Field(default="", description="미수불가금일재사용금액", max_length=12)
     entr: str = Field(default="", description="예수금", max_length=12)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_chart.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_chart.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Optional
 
 from cluefin_openapi.kiwoom._client import Client
 from cluefin_openapi.kiwoom._domestic_chart_types import (
@@ -168,6 +168,7 @@ class DomesticChart:
         stk_cd: str,
         tic_scope: str,
         upd_stkpc_tp: str = "0",
+        base_dt: Optional[str] = None,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[DomesticChartStockMinute]:
@@ -177,6 +178,7 @@ class DomesticChart:
             stk_cd (str): 종목코드 (KRX:039490,NXT:039490_NX,SOR:039490_AL)
             tic_scope (str): 틱범위 (1:1분, 3:3분, 5:5분, 10:10분, 15:15분, 30:30분, 45:45분, 60:60분)
             upd_stkpc_tp (str, optional): 수정주가구분. Defaults to "0".
+            base_dt (Optional[str], optional): 기준일자 (YYYYMMDD). Defaults to None.
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -196,6 +198,9 @@ class DomesticChart:
             "tic_scope": tic_scope,
             "upd_stkpc_tp": upd_stkpc_tp,
         }
+
+        if base_dt is not None:
+            body["base_dt"] = base_dt
 
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
@@ -405,6 +410,7 @@ class DomesticChart:
         self,
         inds_cd: str,
         tic_scope: str,
+        base_dt: Optional[str] = None,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[DomesticChartIndustryMinute]:
@@ -412,7 +418,8 @@ class DomesticChart:
 
         Args:
             inds_cd (str): 업종코드 (001:종합(KOSPI), 002:대형주, 003:중형주, 004:소형주, 101:종합(KOSDAQ), 201:KOSPI200, 302:KOSTAR, 701: KRX100)
-            tic_scope (str): 틱범위 (1:1틱, 3:3틱, 5:5틱, 10:10틱, 30:30틱)
+            tic_scope (str): 틱범위 (1:1분, 3:3분, 5:5분, 10:10분, 15:15분, 30:30분, 45:45분, 60:60분)
+            base_dt (Optional[str], optional): 기준일자 (YYYYMMDD). Defaults to None.
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -431,6 +438,10 @@ class DomesticChart:
             "inds_cd": inds_cd,
             "tic_scope": tic_scope,
         }
+
+        if base_dt is not None:
+            body["base_dt"] = base_dt
+
         response = self.client._post(self.path, headers, body)
         if response.status_code != 200:
             raise Exception(f"Error fetching industry minute chart: {response.text}")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_chart_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_chart_types.py
@@ -192,39 +192,14 @@ class DomesticChartStockTickItem(BaseModel):
         description="저가",
         max_length=20,
     )
-    upd_stkpc_tp: str = Field(
+    pred_pre: str = Field(
         default="",
-        description="수정주가구분",
+        description="전일대비",
         max_length=20,
     )
-    upd_rt: str = Field(
+    pred_pre_sig: str = Field(
         default="",
-        description="수정비율",
-        max_length=20,
-    )
-    bic_inds_tp: str = Field(
-        default="",
-        description="대업종구분",
-        max_length=20,
-    )
-    sm_inds_tp: str = Field(
-        default="",
-        description="소업종구분",
-        max_length=20,
-    )
-    stk_infr: str = Field(
-        default="",
-        description="종목정보",
-        max_length=20,
-    )
-    upd_stkpc_event: str = Field(
-        default="",
-        description="수정주가이벤트",
-        max_length=20,
-    )
-    pred_close_pric: str = Field(
-        default="",
-        description="전일종가",
+        description="전일대비 기호",
         max_length=20,
     )
 
@@ -276,39 +251,14 @@ class DomesticChartStockMinuteItem(BaseModel):
         description="저가",
         max_length=20,
     )
-    upd_stkpc_tp: str = Field(
+    pred_pre: str = Field(
         default="",
-        description="수정주가구분",
+        description="전일대비",
         max_length=20,
     )
-    upd_rt: str = Field(
+    pred_pre_sig: str = Field(
         default="",
-        description="수정비율",
-        max_length=20,
-    )
-    bic_inds_tp: str = Field(
-        default="",
-        description="대업종구분",
-        max_length=20,
-    )
-    sm_inds_tp: str = Field(
-        default="",
-        description="소업종구분",
-        max_length=20,
-    )
-    stk_infr: str = Field(
-        default="",
-        description="종목정보",
-        max_length=20,
-    )
-    upd_stkpc_event: str = Field(
-        default="",
-        description="수정주가이벤트",
-        max_length=20,
-    )
-    pred_close_pric: str = Field(
-        default="",
-        description="전일종가",
+        description="전일대비 기호",
         max_length=20,
     )
 
@@ -448,24 +398,14 @@ class DomesticChartIndustryTickItem(BaseModel):
         description="저가",
         max_length=20,
     )
-    bic_inds_tp: str = Field(
+    pred_pre: str = Field(
         default="",
-        description="대업종구분",
+        description="전일대비",
         max_length=20,
     )
-    sm_inds_tp: str = Field(
+    pred_pre_sig: str = Field(
         default="",
-        description="소업종구분",
-        max_length=20,
-    )
-    stk_infr: str = Field(
-        default="",
-        description="종목정보",
-        max_length=20,
-    )
-    pred_close_pric: str = Field(
-        default="",
-        description="전일종가",
+        description="전일대비 기호",
         max_length=20,
     )
 
@@ -516,24 +456,19 @@ class DomesticChartIndustryMinuteItem(BaseModel):
         description="저가",
         max_length=20,
     )
-    bic_inds_tp: str = Field(
+    acc_trde_qty: str = Field(
         default="",
-        description="대업종구분",
+        description="누적거래량",
         max_length=20,
     )
-    sm_inds_tp: str = Field(
+    pred_pre: str = Field(
         default="",
-        description="소업종구분",
+        description="전일대비",
         max_length=20,
     )
-    stk_infr: str = Field(
+    pred_pre_sig: str = Field(
         default="",
-        description="종목정보",
-        max_length=20,
-    )
-    pred_close_pric: str = Field(
-        default="",
-        description="전일종가",
+        description="전일대비 기호",
         max_length=20,
     )
 
@@ -586,26 +521,6 @@ class DomesticChartIndustryDailyItem(BaseModel):
     trde_prica: str = Field(
         default="",
         description="거래대금",
-        max_length=20,
-    )
-    bic_inds_tp: str = Field(
-        default="",
-        description="대업종구분",
-        max_length=20,
-    )
-    sm_inds_tp: str = Field(
-        default="",
-        description="소업종구분",
-        max_length=20,
-    )
-    stk_infr: str = Field(
-        default="",
-        description="종목정보",
-        max_length=20,
-    )
-    pred_close_pric: str = Field(
-        default="",
-        description="전일종가",
         max_length=20,
     )
 
@@ -661,26 +576,6 @@ class DomesticChartIndustryWeeklyItem(BaseModel):
         description="거래대금",
         max_length=20,
     )
-    bic_inds_tp: str = Field(
-        default="",
-        description="대업종구분",
-        max_length=20,
-    )
-    sm_inds_tp: str = Field(
-        default="",
-        description="소업종구분",
-        max_length=20,
-    )
-    stk_infr: str = Field(
-        default="",
-        description="종목정보",
-        max_length=20,
-    )
-    pred_close_pric: str = Field(
-        default="",
-        description="전일종가",
-        max_length=20,
-    )
 
 
 class DomesticChartIndustryWeekly(BaseModel, KiwoomHttpBody):
@@ -734,26 +629,6 @@ class DomesticChartIndustryMonthlyItem(BaseModel):
         description="거래대금",
         max_length=20,
     )
-    bic_inds_tp: str = Field(
-        default="",
-        description="대업종구분",
-        max_length=20,
-    )
-    sm_inds_tp: str = Field(
-        default="",
-        description="소업종구분",
-        max_length=20,
-    )
-    stk_infr: str = Field(
-        default="",
-        description="종목정보",
-        max_length=20,
-    )
-    pred_close_pric: str = Field(
-        default="",
-        description="전일종가",
-        max_length=20,
-    )
 
 
 class DomesticChartIndustryMonthly(BaseModel, KiwoomHttpBody):
@@ -805,26 +680,6 @@ class DomesticChartIndustryYearlyItem(BaseModel):
     trde_prica: str = Field(
         default="",
         description="거래대금",
-        max_length=20,
-    )
-    bic_inds_tp: str = Field(
-        default="",
-        description="대업종구분",
-        max_length=20,
-    )
-    sm_inds_tp: str = Field(
-        default="",
-        description="소업종구분",
-        max_length=20,
-    )
-    stk_infr: str = Field(
-        default="",
-        description="종목정보",
-        max_length=20,
-    )
-    pred_close_pric: str = Field(
-        default="",
-        description="전일종가",
         max_length=20,
     )
 

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_etf_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_etf_types.py
@@ -172,7 +172,6 @@ class DomesticEtfHourlyExecutionV2(BaseModel, KiwoomHttpBody):
 
 
 class DomesticEtfHourlyTrendV2Item(BaseModel):
-    cntr_tm: str = Field(default="", description="체결시간", max_length=20)
     cur_prc: str = Field(default="", description="현재가", max_length=20)
     pre_sig: str = Field(default="", description="대비기호", max_length=20)
     pred_pre: str = Field(default="", description="전일대비", max_length=20)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_market_condition.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_market_condition.py
@@ -22,7 +22,6 @@ from cluefin_openapi.kiwoom._domestic_market_condition_types import (
     DomesticMarketConditionStockPrice,
     DomesticMarketConditionStockQuote,
     DomesticMarketConditionStockQuoteByDate,
-    DomesticMarketConditionTopIntradayTradingByInvestor,
 )
 from cluefin_openapi.kiwoom._model import (
     KiwoomHttpHeader,
@@ -907,71 +906,3 @@ class DomesticMarketCondition:
             headers=headers,
             body=body,
         )
-
-    def get_top_intraday_trading_by_investor(
-        self,
-        trde_tp: Literal["1", "2"],
-        mrkt_tp: Literal["000", "001", "101"],
-        orgn_tp: Literal["9000", "9100", "1000", "3000", "5000", "4000", "2000", "6000", "7000", "7100", "9999"],
-        amt_qty_tp: Literal["1", "2"],
-        invsr: str = "0",
-        frgn_all: str = "0",
-        smtm_netprps_tp: str = "0",
-        stex_tp: Literal["1", "2"] = "1",
-        cont_yn: Literal["Y", "N"] = "N",
-        next_key: str = "",
-    ) -> KiwoomHttpResponse[DomesticMarketConditionTopIntradayTradingByInvestor]:
-        """장중투자자별매매상위요청
-
-        Args:
-            trde_tp (Literal["1", "2"]): 매매구분
-                - "1": 순매수
-                - "2": 순매도
-            mrkt_tp (Literal["000", "001", "101"]): 시장구분 (전체: '000', 코스피: '001', 코스닥: '101')
-            orgn_tp (Literal["9000", "9100", "1000", "3000", "5000", "4000", "2000", "6000", "7000", "7100", "9999"]): 기관구분
-                - "9000": 외국인
-                - "9100": 외국계
-                - "1000": 금융투자
-                - "3000": 투신
-                - "5000": 기타금융
-                - "4000": 은행
-                - "2000": 보험
-                - "6000": 연기금
-                - "7000": 국가
-                - "7100": 기타법인
-                - "9999": 기관계
-            amt_qty_tp (Literal["1", "2"]): 금액수량구분 (1:금액, 2:수량)
-            invsr (str, optional): 투자자구분. Defaults to "0".
-            frgn_all (str, optional): 외국인전체. Defaults to "0".
-            smtm_netprps_tp (str, optional): 순매수구분. Defaults to "0".
-            stex_tp (Literal["1", "2"], optional): 거래소구분. Defaults to "1".
-            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to 'N'.
-            next_key (str, optional): 다음 페이지 키. Defaults to "".
-
-        Returns:
-            KiwoomHttpResponse[DomesticMarketConditionTopIntradayTradingByInvestor]: 장중투자자별매매상위요청 결과
-        """
-        headers = {
-            "Content-Type": "application/json;charset=UTF-8",
-            "Accept": "application/json",
-            "Authorization": f"Bearer {self.client.token}",
-            "cont-yn": cont_yn,
-            "next-key": next_key,
-            "api-id": "ka10063",
-        }
-        body = {
-            "trde_tp": trde_tp,
-            "mrkt_tp": mrkt_tp,
-            "orgn_tp": orgn_tp,
-            "amt_qty_tp": amt_qty_tp,
-            "invsr": invsr,
-            "frgn_all": frgn_all,
-            "smtm_netprps_tp": smtm_netprps_tp,
-            "stex_tp": stex_tp,
-        }
-        response = self.client._post(self.path, headers, body)
-        if response.status_code != 200:
-            raise Exception(f"Error fetching top intraday trading by investor: {response.text}")
-        headers = KiwoomHttpHeader.model_validate(response.headers)
-        body = DomesticMarketConditionTopIntradayTradingByInvestor.model_validate(response.json())
-        return KiwoomHttpResponse(headers=headers, body=body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_market_condition_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_market_condition_types.py
@@ -369,6 +369,13 @@ class DomesticMarketConditionIntradayTradingByInvestorItem(BaseModel):
     pred_pre: str = Field(default="", description="전일대비", max_length=20)
     flu_rt: str = Field(default="", description="등락율", max_length=20)
     acc_trde_qty: str = Field(default="", description="누적거래량", max_length=20)
+    netprps_amt: str = Field(default="", description="순매수금액", max_length=20)
+    prev_netprps_amt: str = Field(default="", description="이전순매수금액", max_length=20)
+    buy_amt: str = Field(default="", description="매수금액", max_length=20)
+    netprps_amt_irds: str = Field(default="", description="순매수금액증감", max_length=20)
+    buy_amt_irds: str = Field(default="", description="매수금액증감", max_length=20)
+    sell_amt: str = Field(default="", description="매도금액", max_length=20)
+    sell_amt_irds: str = Field(default="", description="매도금액증감", max_length=20)
     netprps_qty: str = Field(default="", description="순매수수량", max_length=20)
     prev_pot_netprps_qty: str = Field(default="", description="이전시점순매수수량", max_length=20)
     netprps_irds: str = Field(default="", description="순매수증감", max_length=20)
@@ -669,20 +676,4 @@ class DomesticMarketConditionProgramTradingTrendByStockAndDate(BaseModel, Kiwoom
 
     stk_daly_prm_trde_trnsn: list[DomesticMarketConditionProgramTradingTrendByStockAndDateItem] = Field(
         default_factory=list, description="종목일별프로그램매매추이"
-    )
-
-
-class DomesticMarketConditionTopIntradayTradingByInvestorItem(BaseModel):
-    stk_cd: str = Field(default="", title="종목코드", max_length=20)
-    stk_nm: str = Field(default="", title="종목명", max_length=40)
-    sel_qty: str = Field(default="", title="매도량", max_length=20)
-    buy_qty: str = Field(default="", title="매수량", max_length=20)
-    netslmt: str = Field(default="", title="순매도", max_length=20)
-
-
-class DomesticMarketConditionTopIntradayTradingByInvestor(BaseModel, KiwoomHttpBody):
-    model_config = ConfigDict(title="장중투자자별매매상위요청 응답")
-
-    opmr_invsr_trde_upper: list[DomesticMarketConditionTopIntradayTradingByInvestorItem] = Field(
-        default_factory=list, title="장중투자자별매매상위"
     )

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_order_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_order_types.py
@@ -25,7 +25,6 @@ class DomesticOrderModify(BaseModel, KiwoomHttpBody):
 
     ord_no: str = Field(default="", title="주문번호", max_length=7)
     base_orig_ord_no: str = Field(default="", title="모주문번호", max_length=7, description="정정할 원주문번호")
-    stk_cd: str = Field(default="", title="종목코드", max_length=12)
     mdfy_qty: str = Field(default="", title="정정수량", max_length=12, description="정정할 수량")
     dmst_stex_tp: str = Field(default="", title="국내거래소구분", max_length=3, description="KRX, NXT, SOR 중 하나")
 

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_rank_info.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_rank_info.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Optional
 
 from cluefin_openapi.kiwoom._client import Client
 from cluefin_openapi.kiwoom._domestic_rank_info_types import (
@@ -16,6 +16,7 @@ from cluefin_openapi.kiwoom._domestic_rank_info_types import (
     DomesticRankInfoTopForeignAccountGroupTrading,
     DomesticRankInfoTopForeignerInstitutionTrading,
     DomesticRankInfoTopForeignerPeriodTrading,
+    DomesticRankInfoTopIntradayTradingByInvestor,
     DomesticRankInfoTopLimitExhaustionRateForeigner,
     DomesticRankInfoTopMarginRatio,
     DomesticRankInfoTopNetBuyTraderRanking,
@@ -1450,4 +1451,59 @@ class DomesticRankInfo:
             raise Exception(f"Error fetching top foreigner institution trading: {response.text}")
         headers = KiwoomHttpHeader.model_validate(response.headers)
         body = DomesticRankInfoTopForeignerInstitutionTrading.model_validate(response.json())
+        return KiwoomHttpResponse(headers=headers, body=body)
+
+    def get_top_intraday_trading_by_investor(
+        self,
+        trde_tp: Literal["1", "2"],
+        mrkt_tp: Literal["000", "001", "101"],
+        orgn_tp: Literal["9000", "9100", "1000", "3000", "5000", "4000", "2000", "6000", "7000", "7100", "9999"],
+        amt_qty_tp: Optional[Literal["1", "2"]] = None,
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[DomesticRankInfoTopIntradayTradingByInvestor]:
+        """장중투자자별매매상위요청 (ka10065)
+
+        Args:
+            trde_tp (Literal["1", "2"]): 매매구분 (1:순매수, 2:순매도)
+            mrkt_tp (Literal["000", "001", "101"]): 시장구분 (000:전체, 001:코스피, 101:코스닥)
+            orgn_tp (Literal[...]): 기관구분
+                - "9000": 외국인
+                - "9100": 외국계
+                - "1000": 금융투자
+                - "3000": 투신
+                - "5000": 기타금융
+                - "4000": 은행
+                - "2000": 보험
+                - "6000": 연기금
+                - "7000": 국가
+                - "7100": 기타법인
+                - "9999": 기관계
+            amt_qty_tp (Optional[Literal["1", "2"]], optional): 금액수량구분 (1:금액, 2:수량). Defaults to None.
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음 페이지 키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[DomesticRankInfoTopIntradayTradingByInvestor]: 장중투자자별매매상위 데이터
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "ka10065",
+        }
+        body = {
+            "trde_tp": trde_tp,
+            "mrkt_tp": mrkt_tp,
+            "orgn_tp": orgn_tp,
+        }
+        if amt_qty_tp is not None:
+            body["amt_qty_tp"] = amt_qty_tp
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching top intraday trading by investor: {response.text}")
+        headers = KiwoomHttpHeader.model_validate(response.headers)
+        body = DomesticRankInfoTopIntradayTradingByInvestor.model_validate(response.json())
         return KiwoomHttpResponse(headers=headers, body=body)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_rank_info_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_rank_info_types.py
@@ -64,7 +64,7 @@ class DomesticRankInfoRapidlyIncreasingTotalSellOrdersItem(BaseModel):
 class DomesticRankInfoRapidlyIncreasingTotalSellOrders(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="잔량율급증요청 응답")
 
-    req_rt_sdnin: list[DomesticRankInfoRapidlyIncreasingRemainingOrderQuantityItem] = Field(
+    req_rt_sdnin: list[DomesticRankInfoRapidlyIncreasingTotalSellOrdersItem] = Field(
         default_factory=list, title="잔량율급증요청"
     )
 
@@ -158,7 +158,7 @@ class DomesticRankInfoTopCurrentDayTradingVolumeItem(BaseModel):
     bf_mkrt_trde_qty: str = Field(default="", title="장전거래량", max_length=20)
     bf_mkrt_pred_rt: str = Field(default="", title="장전전일비", max_length=20)
     bf_mkrt_trde_rt: str = Field(default="", title="장전거래회전율", max_length=20)
-    bf_mkrt_pred_rt: str = Field(default="", title="장전거래금액", max_length=20)
+    bf_mkrt_trde_amt: str = Field(default="", title="장전거래금액", max_length=20)
 
 
 class DomesticRankInfoTopCurrentDayTradingVolume(BaseModel, KiwoomHttpBody):
@@ -353,6 +353,9 @@ class DomesticRankInfoTopSecuritiesFirmTradingItem(BaseModel):
     netprps: str = Field(default="", title="순매수", max_length=20)
     buy_trde_qty: str = Field(default="", title="매수거래량", max_length=20)
     sel_trde_qty: str = Field(default="", title="매도거래량", max_length=20)
+    netprps_amt: str = Field(default="", title="순매수금액", max_length=20)
+    buy_amt: str = Field(default="", title="매수금액", max_length=20)
+    sell_amt: str = Field(default="", title="매도금액", max_length=20)
 
 
 class DomesticRankInfoTopSecuritiesFirmTrading(BaseModel, KiwoomHttpBody):
@@ -464,7 +467,7 @@ class DomesticRankInfoSameNetBuySellRankingItem(BaseModel):
     rank: str = Field(default="", title="순위", max_length=20)
     stk_nm: str = Field(default="", title="종목명", max_length=40)
     cur_prc: str = Field(default="", title="현재가", max_length=20)
-    pred_pre_sig: str = Field(default="", title="전일대비기호", max_length=20)
+    pre_sig: str = Field(default="", title="대비기호", max_length=20)
     pred_pre: str = Field(default="", title="전일대비", max_length=20)
     flu_rt: str = Field(default="", title="등락률", max_length=20)
     acc_trde_qty: str = Field(default="", title="누적거래량", max_length=20)
@@ -474,9 +477,6 @@ class DomesticRankInfoSameNetBuySellRankingItem(BaseModel):
     for_nettrde_qty: str = Field(default="", title="외인순매매수량", max_length=20)
     for_nettrde_amt: str = Field(default="", title="외인순매매금액", max_length=20)
     for_nettrde_avg_pric: str = Field(default="", title="외인순매매평균가", max_length=20)
-    for_nettrde_qty: str = Field(default="", title="순매매수량", max_length=20)
-    for_nettrde_amt: str = Field(default="", title="순매매금액", max_length=20)
-    for_nettrde_avg_pric: str = Field(default="", title="순매매평균가", max_length=20)
     nettrde_qty: str = Field(default="", title="순매매수량", max_length=20)
     nettrde_amt: str = Field(default="", title="순매매금액", max_length=20)
 
@@ -537,4 +537,20 @@ class DomesticRankInfoTopForeignerInstitutionTrading(BaseModel, KiwoomHttpBody):
 
     frgnr_orgn_trde_upper: list[DomesticRankInfoTopForeignerInstitutionTradingItem] = Field(
         default_factory=list, title="외국인기관매매상위"
+    )
+
+
+class DomesticRankInfoTopIntradayTradingByInvestorItem(BaseModel):
+    stk_cd: str = Field(default="", title="종목코드", max_length=20)
+    stk_nm: str = Field(default="", title="종목명", max_length=40)
+    sel_qty: str = Field(default="", title="매도금액/매도량", max_length=20)
+    buy_qty: str = Field(default="", title="매수금액/매수량", max_length=20)
+    netslmt: str = Field(default="", title="순매수/순매도", max_length=20)
+
+
+class DomesticRankInfoTopIntradayTradingByInvestor(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="장중투자자별매매상위요청 응답")
+
+    opmr_invsr_trde_upper: list[DomesticRankInfoTopIntradayTradingByInvestorItem] = Field(
+        default_factory=list, title="장중투자자별매매상위"
     )

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_stock_info.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_stock_info.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Literal, Optional
 
 from cluefin_openapi.kiwoom._domestic_stock_info_types import (
     DomesticStockInfoBasic,
@@ -991,6 +991,7 @@ class DomesticStockInfo:
         stk_cd: str,
         tdy_pred: Literal["1", "2"],
         tic_min: str = "0",
+        tm: Optional[str] = None,
         cont_yn: Literal["Y", "N"] = "N",
         next_key: str = "",
     ) -> KiwoomHttpResponse[DomesticStockInfoDailyPreviousDayConclusion]:
@@ -999,7 +1000,8 @@ class DomesticStockInfo:
         Args:
             stk_cd (str): 종목코드 (KRX:039490,NXT:039490_NX,SOR:039490_AL)
             tdy_pred (Literal["1", "2"]): 당일전일 (1:당일, 2:전일)
-            tic_min (str, optional): 틱분구분. Defaults to "0".
+            tic_min (str, optional): 틱분구분 (0:틱, 1:분). Defaults to "0".
+            tm (Optional[str], optional): 조회시간 4자리 (예: 0900, 1430). 빈값 입력 시 현재시간. Defaults to None.
             cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
             next_key (str, optional): 다음키. Defaults to "".
 
@@ -1020,6 +1022,10 @@ class DomesticStockInfo:
             "tdy_pred": tdy_pred,
             "tic_min": tic_min,
         }
+
+        if tm is not None:
+            body["tm"] = tm
+
         response = self.client._post(self.path, headers, body)
 
         if response.status_code != 200:

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_stock_info_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_stock_info_types.py
@@ -178,7 +178,7 @@ class DomesticStockInfoDailyTradingDetailsItem(BaseModel):
     frgn: str = Field(default="", description="외국계", max_length=20)
     crd_remn_rt: str = Field(default="", description="신용잔고율", max_length=20)
     prm: str = Field(default="", description="프로그램", max_length=20)
-    bf_mkrt_trde_qty: str = Field(default="", description="장전거래대금", max_length=20)
+    bf_mkrt_trde_prica: str = Field(default="", description="장전거래대금", max_length=20)
     bf_mkrt_trde_prica_wght: str = Field(default="", description="장전거래대금비중", max_length=20)
     opmr_trde_prica: str = Field(default="", description="장중거래대금", max_length=20)
     opmr_trde_prica_wght: str = Field(default="", description="장중거래대금비중", max_length=20)
@@ -298,7 +298,7 @@ class DomesticStockInfoTradingVolumeRenewalItem(BaseModel):
 class DomesticStockInfoTradingVolumeRenewal(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="거래량갱신요청 응답")
 
-    trde_qty_updt: List[DomesticStockInfoPriceVolatilityItem] = Field(
+    trde_qty_updt: List[DomesticStockInfoTradingVolumeRenewalItem] = Field(
         default_factory=list, description="거래량 갱신", max_length=1000
     )
 
@@ -363,7 +363,7 @@ class DomesticStockInfoChangeRateFromOpenItem(BaseModel):
 class DomesticStockInfoChangeRateFromOpen(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="시가대비등락률요청 응답")
 
-    open_pric_pre_flu_rt: List[DomesticStockInfoHighPerItem] = Field(
+    open_pric_pre_flu_rt: List[DomesticStockInfoChangeRateFromOpenItem] = Field(
         default_factory=list, description="시가대비등락률", max_length=1000
     )
 
@@ -525,7 +525,7 @@ class DomesticStockInfoTotalInstitutionalInvestorByStockItem(BaseModel):
 class DomesticStockInfoTotalInstitutionalInvestorByStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="종목별투자자기관별합계요청 응답")
 
-    stk_invsr_orgn_tot: List[DomesticStockInfoInstitutionalInvestorByStockItem] = Field(
+    stk_invsr_orgn_tot: List[DomesticStockInfoTotalInstitutionalInvestorByStockItem] = Field(
         default_factory=list, description="종목별 투자자 기관 합계", max_length=1000
     )
 
@@ -548,7 +548,7 @@ class DomesticStockInfoDailyPreviousDayConclusionItem(BaseModel):
 class DomesticStockInfoDailyPreviousDayConclusion(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="당일전일체결요청 응답")
 
-    tdy_pred_cntr_qty: List[DomesticStockInfoDailyPreviousDayExecutionVolumeItem] = Field(
+    tdy_pred_cntr: List[DomesticStockInfoDailyPreviousDayConclusionItem] = Field(
         default_factory=list, description="당일 전일 체결", max_length=1000
     )
 
@@ -741,7 +741,7 @@ class DomesticStockInfoProgramTradingStatusByStockItem(BaseModel):
 class DomesticStockInfoProgramTradingStatusByStock(BaseModel, KiwoomHttpBody):
     model_config = ConfigDict(title="종목별프로그램매매현황요청 응답")
 
-    stk_prm_trde_prst: List[DomesticStockInfoTop50ProgramNetBuyItem] = Field(
+    stk_prm_trde_prst: List[DomesticStockInfoProgramTradingStatusByStockItem] = Field(
         default_factory=list, description="종목별 프로그램 매매 현황", max_length=1000
     )
     tot_1: str = Field(default="", description="매수체결수량합계", max_length=20)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_theme_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_domestic_theme_types.py
@@ -7,39 +7,41 @@ from cluefin_openapi.kiwoom._model import KiwoomHttpBody
 
 
 class DomesticThemeGroupItem(BaseModel):
-    thema_grp_cd: str = Field(default="", alias="테마그룹코드", max_length=20)
-    thema_nm: str = Field(default="", alias="테마명", max_length=20)
-    stk_num: str = Field(default="", alias="종목수", max_length=20)
-    flu_sig: str = Field(default="", alias="등락기호", max_length=20)
-    flu_rt: str = Field(default="", alias="등락율", max_length=20)
-    rising_stk_num: str = Field(default="", alias="상승종목수", max_length=20)
-    fall_stk_num: str = Field(default="", alias="하락종목수", max_length=20)
-    dt_prft_rt: str = Field(default="", alias="기간수익률", max_length=20)
-    main_stk: str = Field(default="", alias="주요종목", max_length=20)
+    thema_grp_cd: str = Field(default="", description="테마그룹코드", max_length=20)
+    thema_nm: str = Field(default="", description="테마명", max_length=20)
+    stk_num: str = Field(default="", description="종목수", max_length=20)
+    flu_sig: str = Field(default="", description="등락기호", max_length=20)
+    flu_rt: str = Field(default="", description="등락율", max_length=20)
+    rising_stk_num: str = Field(default="", description="상승종목수", max_length=20)
+    fall_stk_num: str = Field(default="", description="하락종목수", max_length=20)
+    dt_prft_rt: str = Field(default="", description="기간수익률", max_length=20)
+    main_stk: str = Field(default="", description="주요종목", max_length=20)
 
 
 class DomesticThemeGroup(BaseModel, KiwoomHttpBody):
-    thema_grp: List[DomesticThemeGroupItem] = Field(default_factory=list, alias="테마그룹별")
+    model_config = ConfigDict(title="테마그룹별요청 응답")
+
+    thema_grp: List[DomesticThemeGroupItem] = Field(default_factory=list, description="테마그룹별")
 
 
 class DomesticThemeGroupStocksItem(BaseModel):
-    stk_cd: str = Field(default="", alias="종목코드", max_length=20)
-    stk_nm: str = Field(default="", alias="종목명", max_length=40)
-    cur_prc: str = Field(default="", alias="현재가", max_length=20)
-    flu_sig: str = Field(default="", alias="등락기호", max_length=20)
-    pred_pre: str = Field(default="", alias="전일대비", max_length=20)
-    flu_rt: str = Field(default="", alias="등락율", max_length=20)
-    acc_trde_qty: str = Field(default="", alias="누적거래량", max_length=20)
-    sel_bid: str = Field(default="", alias="매도호가", max_length=20)
-    sel_req: str = Field(default="", alias="매도잔량", max_length=20)
-    buy_bid: str = Field(default="", alias="매수호가", max_length=20)
-    buy_req: str = Field(default="", alias="매수잔량", max_length=20)
-    dt_prft_rt_n: str = Field(default="", alias="기간수익률n", max_length=20)
+    stk_cd: str = Field(default="", description="종목코드", max_length=20)
+    stk_nm: str = Field(default="", description="종목명", max_length=40)
+    cur_prc: str = Field(default="", description="현재가", max_length=20)
+    flu_sig: str = Field(default="", description="등락기호", max_length=20)
+    pred_pre: str = Field(default="", description="전일대비", max_length=20)
+    flu_rt: str = Field(default="", description="등락율", max_length=20)
+    acc_trde_qty: str = Field(default="", description="누적거래량", max_length=20)
+    sel_bid: str = Field(default="", description="매도호가", max_length=20)
+    sel_req: str = Field(default="", description="매도잔량", max_length=20)
+    buy_bid: str = Field(default="", description="매수호가", max_length=20)
+    buy_req: str = Field(default="", description="매수잔량", max_length=20)
+    dt_prft_rt_n: str = Field(default="", description="기간수익률n", max_length=20)
 
 
 class DomesticThemeGroupStocks(BaseModel, KiwoomHttpBody):
-    model_config = ConfigDict(title="테마그룹별요청 응답")
+    model_config = ConfigDict(title="테마구성종목요청 응답")
 
-    flu_rt: str = Field(default="", alias="등락률", max_length=20)
-    dt_prft_rt: str = Field(default="", alias="기간수익률", max_length=20)
-    thema_comp_stk: List[DomesticThemeGroupStocksItem] = Field(default_factory=list, alias="테마구성종목")
+    flu_rt: str = Field(default="", description="등락률", max_length=20)
+    dt_prft_rt: str = Field(default="", description="기간수익률", max_length=20)
+    thema_comp_stk: List[DomesticThemeGroupStocksItem] = Field(default_factory=list, description="테마구성종목")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info.py
@@ -27,6 +27,7 @@ from cluefin_openapi.kiwoom._overseas_stock_info_types import (
     OverseasStockInfoSectorList,
     OverseasStockInfoStock,
     OverseasStockInfoStockList,
+    OverseasStockInfoStockMemo,
     OverseasStockInfoVolumeConcentrationEtf,
     OverseasStockInfoVolumeConcentrationStock,
     OverseasStockInfoVolumeRenewalEtf,
@@ -235,6 +236,43 @@ class OverseasStockInfo:
 
         res_headers = KiwoomHttpHeader.model_validate(response.headers)
         res_body = OverseasStockInfoIndexList.model_validate(response.json())
+        return KiwoomHttpResponse(headers=res_headers, body=res_body)
+
+    def get_stock_memo(
+        self,
+        input_list: list[dict[str, str]] | None = None,
+        cont_yn: Literal["Y", "N"] = "N",
+        next_key: str = "",
+    ) -> KiwoomHttpResponse[OverseasStockInfoStockMemo]:
+        """미국주식 종목메모 조회 (usa10103)
+
+        Args:
+            input_list (list[dict[str, str]] | None, optional): 요청종목코드리스트.
+                [{'stex_tp':'거래소구분','stk_cd':'종목코드'},...]. Defaults to None.
+            cont_yn (Literal["Y", "N"], optional): 연속조회 여부. Defaults to "N".
+            next_key (str, optional): 다음키. Defaults to "".
+
+        Returns:
+            KiwoomHttpResponse[OverseasStockInfoStockMemo]: 미국주식 종목메모 조회 응답
+        """
+        headers = {
+            "Content-Type": "application/json;charset=UTF-8",
+            "Accept": "application/json",
+            "Authorization": f"Bearer {self.client.token}",
+            "cont-yn": cont_yn,
+            "next-key": next_key,
+            "api-id": "usa10103",
+        }
+        body = {
+            "input_list": input_list if input_list is not None else [],
+        }
+
+        response = self.client._post(self.path, headers, body)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching stock memo: {response.text}")
+
+        res_headers = KiwoomHttpHeader.model_validate(response.headers)
+        res_body = OverseasStockInfoStockMemo.model_validate(response.json())
         return KiwoomHttpResponse(headers=res_headers, body=res_body)
 
     def get_etf_etn_list(

--- a/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kiwoom/_overseas_stock_info_types.py
@@ -80,6 +80,19 @@ class OverseasStockInfoIndexList(BaseModel, KiwoomHttpBody):
     )
 
 
+class OverseasStockInfoStockMemoItem(BaseModel):
+    stex_tp: str = Field(default="", description="거래소구분. NA: AMEX, ND: NASDAQ, NY: NYSE")
+    stk_cd: str = Field(default="", description="종목코드")
+    memo: str = Field(default="", description="메모내용")
+
+
+class OverseasStockInfoStockMemo(BaseModel, KiwoomHttpBody):
+    model_config = ConfigDict(title="미국주식 종목메모 조회 응답")
+
+    rtcd: str = Field(default="", description="처리결과")
+    result_list: list[OverseasStockInfoStockMemoItem] = Field(default_factory=list, description="결과리스트")
+
+
 class OverseasStockInfoEtfEtnListItem(BaseModel):
     stex_tp: str = Field(default="", description="거래소구분")
     code: str = Field(default="", description="종목코드")

--- a/packages/cluefin-openapi/tests/kiwoom/test_domestic_market_condition_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_domestic_market_condition_integration.py
@@ -22,7 +22,6 @@ from cluefin_openapi.kiwoom._domestic_market_condition_types import (
     DomesticMarketConditionStockPrice,
     DomesticMarketConditionStockQuote,
     DomesticMarketConditionStockQuoteByDate,
-    DomesticMarketConditionTopIntradayTradingByInvestor,
 )
 
 
@@ -215,15 +214,3 @@ def test_get_program_trading_trend_by_stock_and_date(client: Client):
     assert response is not None
     assert response.body is not None
     assert isinstance(response.body, DomesticMarketConditionProgramTradingTrendByStockAndDate)
-
-
-@pytest.mark.integration
-def test_get_top_intraday_trading_by_investor(client: Client):
-    response = client.market_conditions.get_top_intraday_trading_by_investor(
-        trde_tp="1",
-        mrkt_tp="000",
-        orgn_tp="9000",
-        amt_qty_tp="1",
-    )
-    assert response is not None
-    assert isinstance(response.body, DomesticMarketConditionTopIntradayTradingByInvestor)

--- a/packages/cluefin-openapi/tests/kiwoom/test_domestic_rank_info_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_domestic_rank_info_integration.py
@@ -16,6 +16,7 @@ from cluefin_openapi.kiwoom._domestic_rank_info_types import (
     DomesticRankInfoTopForeignAccountGroupTrading,
     DomesticRankInfoTopForeignerInstitutionTrading,
     DomesticRankInfoTopForeignerPeriodTrading,
+    DomesticRankInfoTopIntradayTradingByInvestor,
     DomesticRankInfoTopLimitExhaustionRateForeigner,
     DomesticRankInfoTopMarginRatio,
     DomesticRankInfoTopNetBuyTraderRanking,
@@ -295,3 +296,15 @@ def test_get_top_foreigner_institution_trading(client: Client):
     )
     assert response is not None
     assert isinstance(response.body, DomesticRankInfoTopForeignerInstitutionTrading)
+
+
+@pytest.mark.integration
+def test_get_top_intraday_trading_by_investor(client: Client):
+    response = client.rank_info.get_top_intraday_trading_by_investor(
+        trde_tp="1",
+        mrkt_tp="000",
+        orgn_tp="9000",
+        amt_qty_tp="1",
+    )
+    assert response is not None
+    assert isinstance(response.body, DomesticRankInfoTopIntradayTradingByInvestor)

--- a/packages/cluefin-openapi/tests/kiwoom/test_domestic_rank_info_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_domestic_rank_info_unit.py
@@ -176,6 +176,12 @@ CALL_KWARGS: Dict[str, Dict[str, str]] = {
         "qry_dt_tp": "0",
         "stex_tp": "1",
     },
+    "get_top_intraday_trading_by_investor": {
+        "trde_tp": "1",
+        "mrkt_tp": "000",
+        "orgn_tp": "9000",
+        "amt_qty_tp": "1",
+    },
 }
 
 

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_stock_info_integration.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_stock_info_integration.py
@@ -23,6 +23,7 @@ from cluefin_openapi.kiwoom._overseas_stock_info_types import (
     OverseasStockInfoSectorList,
     OverseasStockInfoStock,
     OverseasStockInfoStockList,
+    OverseasStockInfoStockMemo,
     OverseasStockInfoVolumeConcentrationEtf,
     OverseasStockInfoVolumeConcentrationStock,
     OverseasStockInfoVolumeRenewalEtf,
@@ -66,6 +67,16 @@ def test_get_stock(client: Client):
     assert response.headers is not None
     assert response.body is not None
     assert isinstance(response.body, OverseasStockInfoStock)
+
+
+@pytest.mark.integration
+def test_get_stock_memo(client: Client):
+    response = client.overseas_stock_info.get_stock_memo(input_list=[{"stex_tp": "ND", "stk_cd": "AAPL"}])
+
+    assert response is not None
+    assert response.headers is not None
+    assert response.body is not None
+    assert isinstance(response.body, OverseasStockInfoStockMemo)
 
 
 @pytest.mark.integration

--- a/packages/cluefin-openapi/tests/kiwoom/test_overseas_stock_info_unit.py
+++ b/packages/cluefin-openapi/tests/kiwoom/test_overseas_stock_info_unit.py
@@ -12,6 +12,7 @@ CALL_KWARGS = {
     "get_exchange_list": {"stk_cd": "AAPL"},
     "get_stock_list": {"stex_tp": "ND"},
     "get_stock": {"stk_cd": "AAPL", "stex_tp": "ND"},
+    "get_stock_memo": {"input_list": [{"stex_tp": "ND", "stk_cd": "AAPL"}]},
     "get_sector_list": {"gubun": "%"},
     "get_index_list": {"index_qry_tp": "NQ"},
     "get_etf_etn_list": {"stex_tp": "ND"},


### PR DESCRIPTION
## 관련 이슈

_(관련 이슈 없음)_

## 변경 사항

키움 공식 API 가이드(openapi.kiwoom.com)를 프로그래밍 방식으로 전수 수집해
국내·미국주식 구현과 1:1 대조했다. 응답 필드 오타·누락은 pydantic 기본값으로
조용히 흘러가 데이터가 비어 보이기 때문에, 어긋난 부분을 문서 기준으로 정정했다.

**국내주식 (`fix`)**

- 장중투자자별매매상위를 시세(ka10063)에서 순위정보(ka10065)로 이동 — 문서상
  소속 카테고리와 api-id가 달랐다. 문서에 없는 요청 파라미터 4개 제거
- 계좌: kt00001 예수금상세 d+2 정산 필드 6개 추가와 `crd_grnt_rt` alias 뒤집힘
  정정, kt00013 익일결제예정내역 응답을 문서의 결제 스키마로 전면 재정의,
  오타 필드명·array 키명 다수 정정
- 요청 파라미터 추가: kt00015 `qry_sort_tp`, 분봉차트(ka10080·ka20005)
  `base_dt`, 주식일별/전일체결(ka10084) `tm`
- 차트 틱/분봉 응답에서 문서에 없는 필드 7개 제거, rank_info/stock_info의
  중복 선언으로 덮어써지던 필드와 잘못된 Item 클래스 참조 수정, theme의
  한글 alias(실제 응답 키는 영문) 정정

**미국주식 (`feat`)**

- 문서 126개 API 중 유일하게 누락돼 있던 usa10103 미국주식 종목메모 조회
  (`OverseasStockInfo.get_stock_memo`) 구현 — 나머지 125개는 URL·요청·응답
  모두 문서와 일치함을 확인

## 변경 유형

- [x] 버그 수정 (`fix`)
- [x] 새로운 기능 추가 (`feat`)
- [ ] 기존 기능 개선 (`feat`)
- [ ] 리팩토링 (`refactor`)
- [x] 테스트 추가/수정 (`test`)
- [ ] 문서 수정 (`docs`)
- [ ] 의존성 업데이트 (`chore`)
- [ ] CI/CD (`ci`)

## 영향 범위

- [x] cluefin-openapi
- [ ] cluefin-ta
- [ ] cluefin-xbrl
- [ ] cluefin-cli
- [ ] cluefin-desk
- [ ] 루트 프로젝트 설정

## 테스트

kiwoom 단위 테스트 445건 전부 통과. 통합 테스트는 미국주식 종목정보
(`test_overseas_stock_info_integration.py`) 34건을 모의투자에서 전부 통과
확인했고(신규 usa10103 포함), 전체 통합 스위트는 이번에 돌리지 않았다 —
모의투자 미지원 TR 23건은 별도로 실호출해 기록된 skip 사유(RC9000·RC7006·
8104)가 그대로 재현됨을 확인했다.

- [x] 단위 테스트 통과 (`uv run pytest -m "not integration"`)
- [ ] 통합 테스트 통과 (`uv run pytest -m "integration"`)
- [ ] 테스트 불필요 (문서, 설정 변경 등)
