### PR TITLE
fix(kis): 공식 문서 대조로 국내·해외주식 API 스펙 불일치 30건 수정

### DIFF
--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/handlers/kis/domestic_market_analysis.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/handlers/kis/domestic_market_analysis.py
@@ -183,12 +183,20 @@ def handle_kis_watchlist_stocks_by_group(params: dict, session) -> dict:
     parameters={
         "type": "object",
         "properties": {
-            "user_id": {"type": "string", "description": "HTS user ID"},
-            "group_code": {"type": "string", "description": "Interest group code"},
-            "interest_type": {"type": "string", "description": "Interest type code (default 1)"},
-            "etc_cls_code": {"type": "string", "description": "FID etc classification code (default 4)"},
+            "market_code": {"type": "string", "description": "FID market division code (default V)"},
+            "screen_code": {"type": "string", "description": "FID screen division code (default 16449)"},
+            "stock_code": {
+                "type": "string",
+                "description": "Input code: 0000 all, 0001 KOSPI, 1001 KOSDAQ (default 0000)",
+            },
+            "div_cls_code": {"type": "string", "description": "0: sort by quantity, 1: sort by amount (default 0)"},
+            "rank_sort_code": {"type": "string", "description": "0: net buy top, 1: net sell top (default 0)"},
+            "etc_cls_code": {
+                "type": "string",
+                "description": "0: all, 1: foreign, 2: institution, 3: etc (default 0)",
+            },
         },
-        "required": ["user_id", "group_code"],
+        "required": [],
     },
     returns={"type": "object"},
     category="analysis",
@@ -197,14 +205,12 @@ def handle_kis_watchlist_stocks_by_group(params: dict, session) -> dict:
 def handle_kis_institutional_foreign_aggregate(params: dict, session) -> dict:
     kis = session.get_kis()
     response = kis.domestic_market_analysis.get_institutional_foreign_trading_aggregate(
-        type_=params.get("interest_type", "1"),
-        user_id=params["user_id"],
-        data_rank="",
-        inter_grp_code=params["group_code"],
-        inter_grp_name="",
-        hts_kor_isnm="",
-        cntg_cls_code="",
-        fid_etc_cls_code=params.get("etc_cls_code", "4"),
+        fid_cond_mrkt_div_code=params.get("market_code", "V"),
+        fid_cond_scr_div_code=params.get("screen_code", "16449"),
+        fid_input_iscd=params.get("stock_code", "0000"),
+        fid_div_cls_code=params.get("div_cls_code", "0"),
+        fid_rank_sort_cls_code=params.get("rank_sort_code", "0"),
+        fid_etc_cls_code=params.get("etc_cls_code", "0"),
     )
     return {"data": extract_output(response, "output")}
 

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/handlers/kis/domestic_ranking_analysis.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/handlers/kis/domestic_ranking_analysis.py
@@ -45,7 +45,6 @@ def handle_kis_trading_volume_rank(params: dict, session) -> dict:
         fid_input_price_1=params.get("price_min", ""),
         fid_input_price_2=params.get("price_max", ""),
         fid_vol_cnt=params.get("volume_min", ""),
-        fid_input_date_1=params.get("date", ""),
     )
     return {"data": extract_output(response, "output")}
 

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_account.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_account.py
@@ -481,51 +481,42 @@ class DomesticAccount:
 
     def get_buy_tradable_inquiry(
         self,
-        tr_id: Literal["TTTC0802R", "VTTC0802R"],
-        tr_cont: Literal["", "N"],
+        tr_id: Literal["TTTC8908R", "VTTC8908R"],
         cano: str,
         acnt_prdt_cd: str,
-        afhr_flpr_yn: Literal["N", "Y", "X"],
-        inqr_dvsn: Literal["01", "02"],
-        fund_sttl_icld_yn: Literal["N", "Y"],
-        prcs_dvsn: Literal["00", "01"],
-        ctx_area_fk100: str = "",
-        ctx_area_nk100: str = "",
+        pdno: str,
+        ord_unpr: str,
+        ord_dvsn: Literal["00", "01", "02", "03", "04", "05", "06", "07"],
+        cma_evlu_amt_icld_yn: Literal["Y", "N"],
+        ovrs_icld_yn: Literal["Y", "N"],
     ) -> KisHttpResponse[BuyTradableInquiry]:
         """
         매수가능조회
 
         Args:
             tr_id: TR ID
-            tr_cont: 연속 거래 여부, (공백 : 초기 조회, N : 다음 데이터 조회 (output header의 tr_cont가 M일 경우)
             cano: 종합계좌번호
             acnt_prdt_cd: 계좌상품코드
-            afhr_flpr_yn: 시간외단일가, 거래소여부
-            inqr_dvsn: 조회구분
-            fund_sttl_icld_yn: 펀드결제분포함여부
-            prcs_dvsn: 처리구분
-            ctx_area_fk100: 연속조회검색조건100, '공란 : 최초 조회시는 이전 조회 Output CTX_AREA_FK100 값 : 다음페이지 조회시(2번째부터)'
-            ctx_area_nk100: 연속조회키100, '공란 : 최초 조회시 이전 조회 Output CTX_AREA_NK100 값 : 다음페이지 조회시(2번째부터)'
+            pdno: 종목코드(6자리) , ETN의 경우 7자리 입력
+            ord_unpr: 주문단가, 주문단가 시장가 주문시, "0"으로 입력
+            ord_dvsn: 주문구분
+            cma_evlu_amt_icld_yn: CMA평가금액포함여부 (Y/N)
+            ovrs_icld_yn: 해외포함여부 (Y/N)
 
         Returns:
             KisHttpResponse[BuyTradableInquiry]: 매수가능조회 응답 객체
         """
         headers = {
             "tr_id": tr_id,
-            "tr_cont": tr_cont,
         }
         params = {
             "CANO": cano,
             "ACNT_PRDT_CD": acnt_prdt_cd,
-            "AFHR_FLPR_YN": afhr_flpr_yn,
-            "OFL_YN": "",
-            "INQR_DVSN": inqr_dvsn,
-            "UNPR_DVSN": "01",
-            "FUND_STTL_ICLD_YN": fund_sttl_icld_yn,
-            "FNCG_AMT_AUTO_RDPT_YN": "N",
-            "PRCS_DVSN": prcs_dvsn,
-            "CTX_AREA_FK100": ctx_area_fk100,
-            "CTX_AREA_NK100": ctx_area_nk100,
+            "PDNO": pdno,
+            "ORD_UNPR": ord_unpr,
+            "ORD_DVSN": ord_dvsn,
+            "CMA_EVLU_AMT_ICLD_YN": cma_evlu_amt_icld_yn,
+            "OVRS_ICLD_YN": ovrs_icld_yn,
         }
 
         response = self.client._get(
@@ -688,6 +679,7 @@ class DomesticAccount:
         tr_id: Literal["CTSC0009U", "CTSC0013U"],
         cano: str,
         acnt_prdt_cd: str,
+        pdno: str,
         rsvn_ord_seq: str,
         ord_qty: str,
         ord_unpr: str,
@@ -707,6 +699,7 @@ class DomesticAccount:
             tr_id: TR ID (예약취소): CTSC0009U, (예약정정): CTSC0013U
             cano: 종합계좌번호
             acnt_prdt_cd: 계좌상품코드
+            pdno: 종목코드(6자리)
             rsvn_ord_seq: 예약주문순번
             ord_qty: 주문수량
             ord_unpr: 주문단가, 주문단가 시장가 주문시, "0"으로 입력
@@ -728,6 +721,7 @@ class DomesticAccount:
         body = {
             "CANO": cano,
             "ACNT_PRDT_CD": acnt_prdt_cd,
+            "PDNO": pdno,
             "RSVN_ORD_SEQ": rsvn_ord_seq,
             "ORD_QTY": ord_qty,
             "ORD_UNPR": ord_unpr,
@@ -753,6 +747,7 @@ class DomesticAccount:
         rsvn_ord_ord_dt: str,
         rsvn_ord_end_dt: str,
         rsvn_ord_seq: str,
+        tmnl_mdia_kind_cd: str,
         cano: str,
         acnt_prdt_cd: str,
         prcs_dvsn_cd: Literal["0", "1", "2"],
@@ -770,6 +765,7 @@ class DomesticAccount:
             rsvn_ord_ord_dt: 예약주문시작일자, YYYYMMDD
             rsvn_ord_end_dt: 예약주문종료일자, YYYYMMDD
             rsvn_ord_seq: 예약주문순번
+            tmnl_mdia_kind_cd: 단말매체종류코드
             cano: 종합계좌번호
             acnt_prdt_cd: 계좌상품코드
             prcs_dvsn_cd: 처리구분코드 (0: 전체 1: 처리내역 2: 미처리내역)
@@ -790,6 +786,7 @@ class DomesticAccount:
             "RSVN_ORD_ORD_DT": rsvn_ord_ord_dt,
             "RSVN_ORD_END_DT": rsvn_ord_end_dt,
             "RSVN_ORD_SEQ": rsvn_ord_seq,
+            "TMNL_MDIA_KIND_CD": tmnl_mdia_kind_cd,
             "CANO": cano,
             "ACNT_PRDT_CD": acnt_prdt_cd,
             "PRCS_DVSN_CD": prcs_dvsn_cd,
@@ -945,7 +942,7 @@ class DomesticAccount:
         self,
         cano: str,
         acnt_prdt_cd: str = "29",
-        user_dvsn_cd: str = "00",
+        acca_dvsn_cd: str = "00",
     ) -> KisHttpResponse[PensionReserveDepositInquiry]:
         """
         퇴직연금 예수금조회
@@ -953,7 +950,7 @@ class DomesticAccount:
         Args:
             cano: 종합계좌번호
             acnt_prdt_cd: 계좌상품코드, 기본값 "29"
-            user_dvsn_cd: 사용자구분코드, 기본값 "00"
+            acca_dvsn_cd: 적립금구분코드, 기본값 "00"
 
         Returns:
             KisHttpResponse[PensionReserveDepositInquiry]: 퇴직연금 예수금조회 응답 객체
@@ -964,7 +961,7 @@ class DomesticAccount:
         params = {
             "CANO": cano,
             "ACNT_PRDT_CD": acnt_prdt_cd,
-            "USER_DVSN_CD": user_dvsn_cd,
+            "ACCA_DVSN_CD": acca_dvsn_cd,
         }
         response = self.client._get(
             "/uapi/domestic-stock/v1/trading/pension/inquire-deposit", headers=headers, params=params
@@ -981,7 +978,7 @@ class DomesticAccount:
         ctx_area_fk100: str,
         ctx_area_nk100: str,
         acnt_prdt_cd: str = "29",
-        user_dvsn_cd: str = "00",
+        acca_dvsn_cd: str = "00",
         inqr_dvsn: Literal["00"] = "00",
     ) -> KisHttpResponse[PensionBalanceInquiry]:
         """
@@ -992,7 +989,7 @@ class DomesticAccount:
             ctx_area_fk100: 연속조회검색조건100, '공란 : 최초 조회시는 이전 조회 Output CTX_AREA_FK100 값 : 다음페이지 조회시(2번째부터)'
             ctx_area_nk100: 연속조회키100, '공란 : 최초 조회시 이전 조회 Output CTX_AREA_NK100 값 : 다음페이지 조회시(2번째부터)'
             acnt_prdt_cd: 계좌상품코드, 기본값 "29"
-            user_dvsn_cd: 사용자구분코드, 기본값 "00"
+            acca_dvsn_cd: 적립금구분코드, 기본값 "00"
             inqr_dvsn: 조회구분, 기본값 "00"
 
         Returns:
@@ -1004,7 +1001,7 @@ class DomesticAccount:
         params = {
             "CANO": cano,
             "ACNT_PRDT_CD": acnt_prdt_cd,
-            "USER_DVSN_CD": user_dvsn_cd,
+            "ACCA_DVSN_CD": acca_dvsn_cd,
             "INQR_DVSN": inqr_dvsn,
             "CTX_AREA_FK100": ctx_area_fk100,
             "CTX_AREA_NK100": ctx_area_nk100,

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_account_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_account_types.py
@@ -217,86 +217,25 @@ class StockBalance(BaseModel, KisHttpBody):
     output2: Sequence[StockBalanceItem2] = Field(default_factory=list)
 
 
-class BuyTradableInquiryItem1(BaseModel):
-    pdno: str = Field(title="상품번호", description="종목번호(뒤 6자리만 해당)", max_length=12)
-    prdt_name: str = Field(title="상품명", description="종목명", max_length=60)
-    trad_dvsn_name: str = Field(title="매매구분명", description="매수매도구분", max_length=60)
-    bfdy_buy_qty: str = Field(title="전일매수수량", max_length=10)
-    bfdy_sll_qty: str = Field(title="전일매도수량", max_length=10)
-    thdt_buyqty: str = Field(title="금일매수수량", max_length=10)
-    thdt_sll_qty: str = Field(title="금일매도수량", max_length=10)
-    hldg_qty: str = Field(title="보유수량", max_length=19)
-    ord_psbl_qty: str = Field(title="주문가능수량", max_length=10)
-    pchs_avg_pric: str = Field(title="매입평균가격", description="매입금액 / 보유수량", max_length=22)
-    pchs_amt: str = Field(title="매입금액", max_length=19)
-    prpr: str = Field(title="현재가", max_length=19)
-    evlu_amt: str = Field(title="평가금액", max_length=19)
-    evlu_pfls_amt: str = Field(title="평가손익금액", description="평가금액 - 매입금액", max_length=19)
-    evlu_pfls_rt: str = Field(title="평가손익율", max_length=9)
-    evlu_erng_rt: str = Field(title="평가수익율", description="미사용항목(0으로 출력)", max_length=31)
-    loan_dt: str = Field(
-        title="대출일자", description="INQR_DVSN(조회구분)을 01(대출일별)로 설정해야 값이 나옴", max_length=8
-    )
-    loan_amt: str = Field(title="대출금액", max_length=19)
-    stln_slng_chgs: str = Field(title="대주매각대금", max_length=19)
-    expd_dt: str = Field(title="만기일자", max_length=8)
-    fltt_rt: str = Field(title="등락율", max_length=31)
-    bfdy_cprs_icdc: str = Field(title="전일대비증감", max_length=19)
-    item_mgna_rt_name: str = Field(title="종목증거금율명", max_length=20)
-    grta_rt_name: str = Field(title="보증금율명", max_length=20)
-    sbst_pric: str = Field(
-        title="대용가격", description="증권매매의 위탁보증금으로서 현금 대신에 사용되는 유가증권 가격", max_length=19
-    )
-    stck_loan_unpr: str = Field(title="주식대출단가", max_length=22)
-
-
-class BuyTradableInquiryItem2(BaseModel):
-    dnca_tot_amt: str = Field(title="예수금총금액", description="예수금", max_length=19)
-    nxdy_excc_amt: str = Field(title="익일정산금액", description="D+1 예수금", max_length=19)
-    prvs_rcdl_excc_amt: str = Field(title="가수도정산금액", description="D+2 예수금", max_length=19)
+class BuyTradableInquiryItem(BaseModel):
+    ord_psbl_cash: str = Field(title="주문가능현금", max_length=19)
+    ord_psbl_sbst: str = Field(title="주문가능대용", max_length=19)
+    ruse_psbl_amt: str = Field(title="재사용가능금액", max_length=19)
+    fund_rpch_chgs: str = Field(title="펀드환매대금", max_length=19)
+    psbl_qty_calc_unpr: str = Field(title="가능수량계산단가", max_length=19)
+    nrcvb_buy_amt: str = Field(title="미수없는매수금액", max_length=19)
+    nrcvb_buy_qty: str = Field(title="미수없는매수수량", max_length=10)
+    max_buy_amt: str = Field(title="최대매수금액", max_length=19)
+    max_buy_qty: str = Field(title="최대매수수량", max_length=10)
     cma_evlu_amt: str = Field(title="CMA평가금액", max_length=19)
-    bfdy_buy_amt: str = Field(title="전일매수금액", max_length=19)
-    thdt_buy_amt: str = Field(title="금일매수금액", max_length=19)
-    nxdy_auto_rdpt_amt: str = Field(title="익일자동상환금액", max_length=19)
-    bfdy_sll_amt: str = Field(title="전일매도금액", max_length=19)
-    thdt_sll_amt: str = Field(title="금일매도금액", max_length=19)
-    d2_auto_rdpt_amt: str = Field(title="D+2자동상환금액", max_length=19)
-    bfdy_tlex_amt: str = Field(title="전일제비용금액", max_length=19)
-    thdt_tlex_amt: str = Field(title="금일제비용금액", max_length=19)
-    tot_loan_amt: str = Field(title="총대출금액", max_length=19)
-    scts_evlu_amt: str = Field(title="유가평가금액", max_length=19)
-    tot_evlu_amt: str = Field(title="총평가금액", description="유가증권 평가금액 합계금액 + D+2 예수금", max_length=19)
-    nass_amt: str = Field(title="순자산금액", max_length=19)
-    fncg_gld_auto_rdpt_yn: str = Field(
-        title="융자금자동상환여부",
-        description="보유현금에 대한 융자금만 차감여부 신용융자 매수체결 시점에서는 융자비율을 매매대금 100%로 계산 하였다가 수도결제일에 보증금에 해당하는 금액을 고객의 현금으로 충당하여 융자금을 감소시키는 업무",
-        max_length=1,
-    )
-    pchs_amt_smtl_amt: str = Field(title="매입금액합계금액", max_length=19)
-    evlu_amt_smtl_amt: str = Field(title="평가금액합계금액", description="유가증권 평가금액 합계금액", max_length=19)
-    evlu_pfls_smtl_amt: str = Field(title="평가손익합계금액", max_length=19)
-    tot_stln_slng_chgs: str = Field(title="총대주매각대금", max_length=19)
-    bfdy_tot_asst_evlu_amt: str = Field(title="전일총자산평가금액", max_length=19)
-    asst_icdc_amt: str = Field(title="자산증감액", max_length=19)
-    asst_icdc_erng_rt: str = Field(title="자산증감수익율", description="데이터 미제공", max_length=31)
+    ovrs_re_use_amt_wcrc: str = Field(title="해외재사용금액원화", max_length=19)
+    ord_psbl_frcr_amt_wcrc: str = Field(title="주문가능외화금액원화", max_length=19)
 
 
 class BuyTradableInquiry(BaseModel, KisHttpBody):
     """매수가능조회 응답"""
 
-    ctx_area_fk100: str = Field(
-        title="연속조회검색조건100",
-        description="공란 : 최초 조회시는 이전 조회 Output CTX_AREA_FK100 값 : 다음페이지 조회시(2번째부터)",
-        max_length=100,
-    )
-    ctx_area_nk100: str = Field(
-        title="연속조회키100",
-        description="공란 : 최초 조회시 이전 조회 Output CTX_AREA_NK100 값 : 다음페이지 조회시(2번째부터)",
-        max_length=100,
-    )
-
-    output1: Sequence[BuyTradableInquiryItem1] = Field(default_factory=list)
-    output2: Sequence[BuyTradableInquiryItem2] = Field(default_factory=list)
+    output: BuyTradableInquiryItem
 
 
 class SellTradableInquiryItem(BaseModel):

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_basic_quote.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_basic_quote.py
@@ -17,6 +17,7 @@ from cluefin_openapi.kis._domestic_basic_quote_types import (
     DomesticStockCurrentPriceMember,
     DomesticStockCurrentPriceOvertimeConclusion,
     DomesticStockCurrentPriceTimeItemConclusion,
+    DomesticStockDailyMinuteChart,
     DomesticStockOvertimeAskingPrice,
     DomesticStockOvertimeCurrentPrice,
     DomesticStockPeriodQuote,
@@ -329,7 +330,7 @@ class DomesticBasicQuote:
         fid_input_date_1: str,
         fid_pw_data_incu_yn: Literal["N", "Y"],
         fid_fake_tick_incu_yn: Literal["", "N", "Y"] = "",
-    ) -> KisHttpResponse[DomesticStockTodayMinuteChart]:
+    ) -> KisHttpResponse[DomesticStockDailyMinuteChart]:
         """
         주식일별분봉조회
 
@@ -342,7 +343,7 @@ class DomesticBasicQuote:
             fid_fake_tick_incu_yn (str): 허봉 포함 여부, N:허봉미포함, Y:허봉포함, 공백 필수 입력
 
         Returns:
-            KisHttpResponse[DomesticStockTodayMinuteChart]: 주식일별분봉조회
+            KisHttpResponse[DomesticStockDailyMinuteChart]: 주식일별분봉조회
         """
         headers = {
             "tr_id": "FHKST03010230",
@@ -361,7 +362,7 @@ class DomesticBasicQuote:
         response_data = response.json()
         self._check_response_error(response_data)
         header = KisHttpHeader.model_validate(response.headers)
-        body = DomesticStockTodayMinuteChart.model_validate(response_data)
+        body = DomesticStockDailyMinuteChart.model_validate(response_data)
         return KisHttpResponse(header=header, body=body)
 
     def get_stock_current_price_time_item_conclusion(
@@ -471,7 +472,7 @@ class DomesticBasicQuote:
         Returns:
             KisHttpResponse[DomesticStockOvertimeCurrentPrice]: 국내주식 시간외현재가
         """
-        heders = {
+        headers = {
             "tr_id": "FHPST02300000",
         }
         params = {
@@ -479,7 +480,7 @@ class DomesticBasicQuote:
             "FID_INPUT_ISCD": fid_input_iscd,
         }
         response = self.client._get(
-            "/uapi/domestic-stock/v1/quotations/inquire-overtime-price", headers=heders, params=params
+            "/uapi/domestic-stock/v1/quotations/inquire-overtime-price", headers=headers, params=params
         )
         response_data = response.json()
         self._check_response_error(response_data)

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_basic_quote_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_basic_quote_types.py
@@ -1,6 +1,6 @@
 from typing import Any, Literal, Optional, Sequence
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator
 
 from cluefin_openapi.kis._model import KisHttpBody
 
@@ -458,8 +458,11 @@ class DomesticStockPeriodQuoteItem1(BaseModel):
     per: str = Field(title="PER", max_length=11)
     eps: str = Field(title="EPS", max_length=14)
     pbr: str = Field(title="PBR", max_length=11)
+    # 실서버는 오타 난 키("itewhol_loan_rmnd_ratem name")를 반환하고 공식 문서는 "itewhol_loan_rmnd_ratem"로 표기 — 둘 다 수용
     itewhol_loan_rmnd_rate: str = Field(
-        alias="itewhol_loan_rmnd_ratem name", title="전체 융자 잔고 비율", max_length=13
+        validation_alias=AliasChoices("itewhol_loan_rmnd_ratem name", "itewhol_loan_rmnd_ratem"),
+        title="전체 융자 잔고 비율",
+        max_length=13,
     )
 
 

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_market_analysis.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_market_analysis.py
@@ -441,46 +441,40 @@ class DomesticMarketAnalysis:
 
     def get_institutional_foreign_trading_aggregate(
         self,
-        type_: str,
-        user_id: str,
-        data_rank: str,
-        inter_grp_code: str,
-        inter_grp_name: str,
-        hts_kor_isnm: str,
-        cntg_cls_code: str,
+        fid_cond_mrkt_div_code: str,
+        fid_cond_scr_div_code: str,
+        fid_input_iscd: str,
+        fid_div_cls_code: str,
+        fid_rank_sort_cls_code: str,
         fid_etc_cls_code: str,
     ) -> KisHttpResponse[InstitutionalForeignTradingAggregate]:
         """
         국내기관_외국인 매매종목가집계
 
         Args:
-            type_ (str): 관심종목구분코드 (Unique key: 1)
-            user_id (str): 사용자 ID (HTS_ID 입력)
-            data_rank (str): 데이터 순위 (공백)
-            inter_grp_code (str): 관심 그룹 코드 (관심그룹 조회 결과의 그룹 값 입력)
-            inter_grp_name (str): 관심 그룹 명 (공백)
-            hts_kor_isnm (str): HTS 한글 종목명 (공백)
-            cntg_cls_code (str): 체결 구분 코드 (공백)
-            fid_etc_cls_code (str): 기타 구분 코드 (Unique key: 4)
+            fid_cond_mrkt_div_code (str): 조건 시장 분류 코드 (V)
+            fid_cond_scr_div_code (str): 조건 화면 분류 코드 (16449)
+            fid_input_iscd (str): 입력 종목코드 (0000:전체, 0001:코스피, 1001:코스닥, 이외 업종코드)
+            fid_div_cls_code (str): 분류 구분 코드 (0:수량정열, 1:금액정열)
+            fid_rank_sort_cls_code (str): 순위 정렬 구분 코드 (0:순매수상위, 1:순매도상위)
+            fid_etc_cls_code (str): 기타 구분 정렬 (0:전체, 1:외국인, 2:기관계, 3:기타)
 
         Returns:
             KisHttpResponse[InstitutionalForeignTradingAggregate]: 국내기관_외국인 매매종목가집계 응답 객체
         """
         headers = {
-            "tr_id": "HHKCM113004C6",
+            "tr_id": "FHPTJ04400000",
         }
         params = {
-            "TYPE": type_,
-            "USER_ID": user_id,
-            "DATA_RANK": data_rank,
-            "INTER_GRP_CODE": inter_grp_code,
-            "INTER_GRP_NAME": inter_grp_name,
-            "HTS_KOR_ISNM": hts_kor_isnm,
-            "CNTG_CLS_CODE": cntg_cls_code,
+            "FID_COND_MRKT_DIV_CODE": fid_cond_mrkt_div_code,
+            "FID_COND_SCR_DIV_CODE": fid_cond_scr_div_code,
+            "FID_INPUT_ISCD": fid_input_iscd,
+            "FID_DIV_CLS_CODE": fid_div_cls_code,
+            "FID_RANK_SORT_CLS_CODE": fid_rank_sort_cls_code,
             "FID_ETC_CLS_CODE": fid_etc_cls_code,
         }
         response = self.client._get(
-            "/uapi/domestic-stock/v1/quotations/intstock-stocklist-by-group", headers=headers, params=params
+            "/uapi/domestic-stock/v1/quotations/foreign-institution-total", headers=headers, params=params
         )
         response_data = response.json()
         self._check_response_error(response_data)
@@ -870,6 +864,7 @@ class DomesticMarketAnalysis:
         headers = {
             "tr_id": "FHKST03010800",
         }
+        # 공식 문서에는 _1 파라미터가 없지만 실서버는 누락 시 OPSQ2001(INPUT FIELD NOT FOUND)로 거절함
         params = {
             "FID_COND_MRKT_DIV_CODE": fid_cond_mrkt_div_code,
             "FID_INPUT_ISCD": fid_input_iscd,

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_market_analysis_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_market_analysis_types.py
@@ -169,7 +169,7 @@ class InstitutionalForeignTradingAggregateItem(BaseModel):
 class InstitutionalForeignTradingAggregate(BaseModel, KisHttpBody):
     """국내기관_외국인 매매종목가집계"""
 
-    output: InstitutionalForeignTradingAggregateItem = Field(title="응답상세")
+    output: Sequence[InstitutionalForeignTradingAggregateItem] = Field(default_factory=list)
 
 
 class ForeignBrokerageTradingAggregateItem(BaseModel):

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_ranking_analysis.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_ranking_analysis.py
@@ -52,7 +52,6 @@ class DomesticRankingAnalysis:
         fid_input_price_1: str,
         fid_input_price_2: str,
         fid_vol_cnt: str,
-        fid_input_date_1: str,
     ) -> KisHttpResponse[TradingVolumeRank]:
         """
         거래량순위
@@ -68,7 +67,6 @@ class DomesticRankingAnalysis:
             fid_input_price_1 (str): 입력 가격1 (가격~, 전체 조회시 공란)
             fid_input_price_2 (str): 입력 가격2 (~가격, 전체 조회시 공란)
             fid_vol_cnt (str): 거래량 수 (거래량~, 전체 조회시 공란)
-            fid_input_date_1 (str): 입력 날짜1 (공란 입력)
 
         Returns:
             TradingVolumeRank: 거래량순위 응답 객체
@@ -87,7 +85,6 @@ class DomesticRankingAnalysis:
             "FID_INPUT_PRICE_1": fid_input_price_1,
             "FID_INPUT_PRICE_2": fid_input_price_2,
             "FID_VOL_CNT": fid_vol_cnt,
-            "FID_INPUT_DATE_1": fid_input_date_1,
         }
         response = self.client._get("/uapi/domestic-stock/v1/quotations/volume-rank", headers=headers, params=params)
         response_data = response.json()

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_ranking_analysis_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_ranking_analysis_types.py
@@ -393,7 +393,7 @@ class StockDividendYieldTopItem(BaseModel):
 class StockDividendYieldTop(BaseModel, KisHttpBody):
     """국내주식 배당률 상위"""
 
-    output: Sequence[StockDividendYieldTopItem] = Field(default_factory=list)
+    output1: Sequence[StockDividendYieldTopItem] = Field(default_factory=list)
 
 
 class StockLargeExecutionCountTopItem(BaseModel):
@@ -416,7 +416,39 @@ class StockLargeExecutionCountTop(BaseModel, KisHttpBody):
     output: Sequence[StockLargeExecutionCountTopItem] = Field(default_factory=list)
 
 
-class StockCreditBalanceTopItem(BaseModel):
+class StockCreditBalanceTopItem1(BaseModel):
+    bstp_cls_code: str = Field(title="업종 구분 코드", max_length=10)
+    hts_kor_isnm: str = Field(title="HTS 한글 종목명", max_length=40)
+    stnd_date1: str = Field(title="기준 일자1", max_length=8)
+    stnd_date2: str = Field(title="기준 일자2", max_length=8)
+
+
+class StockCreditBalanceTopItem2(BaseModel):
+    mksc_shrn_iscd: str = Field(title="유가증권 단축 종목코드", max_length=9)
+    hts_kor_isnm: str = Field(title="HTS 한글 종목명", max_length=40)
+    stck_prpr: str = Field(title="주식 현재가", max_length=10)
+    prdy_vrss: str = Field(title="전일 대비", max_length=10)
+    prdy_vrss_sign: str = Field(title="전일 대비 부호", max_length=1)
+    prdy_ctrt: str = Field(title="전일 대비율", max_length=82)
+    acml_vol: str = Field(title="누적 거래량", max_length=18)
+    whol_loan_rmnd_stcn: str = Field(title="전체 융자 잔고 주수", max_length=18)
+    whol_loan_rmnd_amt: str = Field(title="전체 융자 잔고 금액", max_length=18)
+    whol_loan_rmnd_rate: str = Field(title="전체 융자 잔고 비율", max_length=62)
+    whol_stln_rmnd_stcn: str = Field(title="전체 대주 잔고 주수", max_length=18)
+    whol_stln_rmnd_amt: str = Field(title="전체 대주 잔고 금액", max_length=18)
+    whol_stln_rmnd_rate: str = Field(title="전체 대주 잔고 비율", max_length=62)
+    nday_vrss_loan_rmnd_inrt: str = Field(title="N일 대비 융자 잔고 증가율", max_length=84)
+    nday_vrss_stln_rmnd_inrt: str = Field(title="N일 대비 대주 잔고 증가율", max_length=84)
+
+
+class StockCreditBalanceTop(BaseModel, KisHttpBody):
+    """국내주식 신용잔고 상위"""
+
+    output1: Sequence[StockCreditBalanceTopItem1] = Field(default_factory=list)
+    output2: Sequence[StockCreditBalanceTopItem2] = Field(default_factory=list)
+
+
+class StockShortSellingTopItem(BaseModel):
     mksc_shrn_iscd: str = Field(title="유가증권 단축 종목코드", max_length=9)
     hts_kor_isnm: str = Field(title="HTS 한글 종목명", max_length=40)
     stck_prpr: str = Field(title="주식 현재가", max_length=10)
@@ -434,49 +466,10 @@ class StockCreditBalanceTopItem(BaseModel):
     avrg_prc: str = Field(title="평균가격", max_length=11)
 
 
-class StockCreditBalanceTop(BaseModel, KisHttpBody):
-    """국내주식 신용잔고 상위"""
-
-    output: Sequence[StockCreditBalanceTopItem] = Field(default_factory=list)
-
-
-class StockShortSellingTopItem1(BaseModel):
-    ovtm_untp_uplm_issu_cnt: str = Field(title="시간외 단일가 상한 종목 수", max_length=7)
-    ovtm_untp_ascn_issu_cnt: str = Field(title="시간외 단일가 상승 종목 수", max_length=7)
-    ovtm_untp_stnr_issu_cnt: str = Field(title="시간외 단일가 보합 종목 수", max_length=7)
-    ovtm_untp_lslm_issu_cnt: str = Field(title="시간외 단일가 하한 종목 수", max_length=7)
-    ovtm_untp_down_issu_cnt: str = Field(title="시간외 단일가 하락 종목 수", max_length=7)
-    ovtm_untp_acml_vol: str = Field(title="시간외 단일가 누적 거래량", max_length=19)
-    ovtm_untp_acml_tr_pbmn: str = Field(title="시간외 단일가 누적 거래대금", max_length=19)
-    ovtm_untp_exch_vol: str = Field(title="시간외 단일가 거래소 거래량", max_length=18)
-    ovtm_untp_exch_tr_pbmn: str = Field(title="시간외 단일가 거래소 거래대금", max_length=18)
-    ovtm_untp_kosdaq_vol: str = Field(title="시간외 단일가 KOSDAQ 거래량", max_length=18)
-    ovtm_untp_kosdaq_tr_pbmn: str = Field(title="시간외 단일가 KOSDAQ 거래대금", max_length=18)
-
-
-class StockShortSellingTopItem2(BaseModel):
-    mksc_shrn_iscd: str = Field(title="유가증권 단축 종목코드", max_length=9)
-    hts_kor_isnm: str = Field(title="HTS 한글 종목명", max_length=40)
-    ovtm_untp_prpr: str = Field(title="시간외 단일가 현재가", max_length=10)
-    ovtm_untp_prdy_vrss: str = Field(title="시간외 단일가 전일 대비", max_length=10)
-    ovtm_untp_prdy_vrss_sign: str = Field(title="시간외 단일가 전일 대비 부호", max_length=1)
-    ovtm_untp_prdy_ctrt: str = Field(title="시간외 단일가 전일 대비율", max_length=82)
-    ovtm_untp_askp1: str = Field(title="시간외 단일가 매도호가1", max_length=10)
-    ovtm_untp_seln_rsqn: str = Field(title="시간외 단일가 매도 잔량", max_length=12)
-    ovtm_untp_bidp1: str = Field(title="시간외 단일가 매수호가1", max_length=10)
-    ovtm_untp_shnu_rsqn: str = Field(title="시간외 단일가 매수 잔량", max_length=12)
-    ovtm_untp_vol: str = Field(title="시간외 단일가 거래량", max_length=18)
-    ovtm_vrss_acml_vol_rlim: str = Field(title="시간외 대비 누적 거래량 비중", max_length=52)
-    stck_prpr: str = Field(title="주식 현재가", max_length=10)
-    acml_vol: str = Field(title="누적 거래량", max_length=18)
-    bidp: str = Field(title="매수호가", max_length=10)
-    askp: str = Field(title="매도호가", max_length=10)
-
-
 class StockShortSellingTop(BaseModel, KisHttpBody):
     """국내주식 공매도 상위종목"""
 
-    output: Sequence[StockCreditBalanceTopItem] = Field(default_factory=list)
+    output: Sequence[StockShortSellingTopItem] = Field(default_factory=list)
 
 
 class StockAfterHoursFluctuationRankItem1(BaseModel):

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_realtime_quote.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_realtime_quote.py
@@ -190,32 +190,31 @@ class DomesticRealtimeQuote:
         The API may send batched updates (multiple records concatenated).
         This method parses ALL records and returns them as a list.
 
-        Note: The API may return extra fields beyond the documented 59 fields.
-        This parser will use the first 59 fields per record and ignore any extras.
+        Note: The API may return extra fields beyond the documented 62 fields.
+        This parser will use the first 62 fields per record and ignore any extras.
         This provides forward compatibility with future API schema changes.
 
         Args:
             data: List of string values from WebSocket message.
-                  - Single record: 59+ fields
-                  - Batched: N×59+ fields
-                  - With schema changes: 62+ per record (forward compatible)
+                  - Single record: 62+ fields
+                  - Batched: N×62+ fields
 
         Returns:
             List of parsed DomesticRealtimeOrderbookItem models.
             Always returns a list, even for single records.
 
         Raises:
-            ValueError: If data has insufficient fields (< 59)
+            ValueError: If data has insufficient fields (< 62)
 
         Example:
             ```python
-            # Single record with extra fields
-            data = [...] * 62  # 62 fields (59 used, 3 ignored)
+            # Single record
+            data = [...] * 62  # 62 fields
             items = parse_orderbook_data(data)
             assert len(items) == 1
 
             # Batched records
-            data = [...] * (10 * 59)  # 590 fields = 10 records
+            data = [...] * (10 * 62)  # 620 fields = 10 records
             items = parse_orderbook_data(data)
             assert len(items) == 10
             ```

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_realtime_quote_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_realtime_quote_types.py
@@ -103,7 +103,7 @@ class DomesticRealtimeOrderbookItem(BaseModel):
     """국내주식 실시간호가 (KRX) - H0STASP0.
 
     WebSocket 메시지의 데이터 부분을 파싱한 모델입니다.
-    데이터는 "^" 구분자로 59개 필드가 구분되어 전달됩니다.
+    데이터는 "^" 구분자로 62개 필드가 구분되어 전달됩니다.
     """
 
     mksc_shrn_iscd: str = Field(title="유가증권 단축 종목코드")
@@ -165,6 +165,10 @@ class DomesticRealtimeOrderbookItem(BaseModel):
     ovtm_total_askp_icdc: str = Field(title="시간외 총 매도호가 증감")
     ovtm_total_bidp_icdc: str = Field(title="시간외 총 매수호가 증감")
     stck_deal_cls_code: str = Field(title="주식 매매 구분 코드")
+    # 아래 3개는 중간가 도입으로 추가된 필드 — 구형(59필드) 전문도 파싱되도록 기본값 유지
+    mid_prc: str = Field(default="", title="중간가")
+    midp_total_rsqn: str = Field(default="", title="중간가잔량합계수량")
+    midp_cls_code: str = Field(default="", title="중간가 매수매도 구분")
 
 
 # 필드 순서 리스트 (WebSocket 데이터 파싱용) - 체결가
@@ -278,6 +282,9 @@ ORDERBOOK_FIELD_NAMES: list[str] = [
     "ovtm_total_askp_icdc",
     "ovtm_total_bidp_icdc",
     "stck_deal_cls_code",
+    "mid_prc",
+    "midp_total_rsqn",
+    "midp_cls_code",
 ]
 
 # 필드 순서 리스트 (WebSocket 데이터 파싱용) - 실시간체결통보

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_stock_info_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_domestic_stock_info_types.py
@@ -457,7 +457,7 @@ class KsdPaidInCapitalIncreaseScheduleItem(BaseModel):
 class KsdPaidInCapitalIncreaseSchedule(BaseModel, KisHttpBody):
     """예탁원정보(유상증자일정)"""
 
-    output1: Sequence[KsdPaidInCapitalIncreaseScheduleItem] = Field(default_factory=list)
+    output: Sequence[KsdPaidInCapitalIncreaseScheduleItem] = Field(default_factory=list)
 
 
 class KsdStockDividendScheduleItem(BaseModel):

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_overseas_account.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_overseas_account.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from cluefin_openapi.kis._http_client import HttpClient
 from cluefin_openapi.kis._model import KisHttpHeader, KisHttpResponse
 from cluefin_openapi.kis._overseas_account_types import (
@@ -38,6 +40,32 @@ class OverseasAccount:
 
     def request_stock_order(
         self,
+        tr_id: Literal[
+            "TTTT1002U",
+            "TTTT1006U",
+            "TTTS1002U",
+            "TTTS1001U",
+            "TTTS0202U",
+            "TTTS1005U",
+            "TTTS0305U",
+            "TTTS0304U",
+            "TTTS0308U",
+            "TTTS0307U",
+            "TTTS0311U",
+            "TTTS0310U",
+            "VTTT1002U",
+            "VTTT1001U",
+            "VTTS1002U",
+            "VTTS1001U",
+            "VTTS0202U",
+            "VTTS1005U",
+            "VTTS0305U",
+            "VTTS0304U",
+            "VTTS0308U",
+            "VTTS0307U",
+            "VTTS0311U",
+            "VTTS0310U",
+        ],
         cano: str,
         acnt_prdt_cd: str,
         ovrs_excg_cd: str,
@@ -45,6 +73,7 @@ class OverseasAccount:
         ord_qty: str,
         ovrs_ord_unpr: str,
         ord_dvsn: str,
+        ord_svr_dvsn_cd: str = "0",
         start_time: str = "",
         end_time: str = "",
         algo_ord_tmd_dvsn_cd: str = "",
@@ -52,6 +81,10 @@ class OverseasAccount:
         """해외주식 주문
 
         Args:
+            tr_id: TR ID (미국매수: TTTT1002U, 미국매도: TTTT1006U, 홍콩매수: TTTS1002U, 홍콩매도: TTTS1001U,
+                상해매수: TTTS0202U, 상해매도: TTTS1005U, 심천매수: TTTS0305U, 심천매도: TTTS0304U,
+                일본매수: TTTS0308U, 일본매도: TTTS0307U, 베트남매수: TTTS0311U, 베트남매도: TTTS0310U.
+                모의투자는 V로 시작하는 동일 코드(단, 미국매도는 VTTT1001U))
             cano (str): 종합계좌번호 (8자리)
             acnt_prdt_cd (str): 계좌상품코드 (2자리)
             ovrs_excg_cd (str): 해외거래소코드 (NASD: 나스닥, NYSE: 뉴욕, AMEX: 아멕스, SEHK: 홍콩, SHAA: 중국상해, SZAA: 중국심천, TKSE: 일본, HASE: 베트남 하노이, VNSE: 베트남 호치민)
@@ -59,6 +92,7 @@ class OverseasAccount:
             ord_qty (str): 주문수량
             ovrs_ord_unpr (str): 해외주문단가
             ord_dvsn (str): 주문구분 (00: 지정가, 31: MOO, 32: LOO, 33: MOC, 34: LOC, 35: TWAP, 36: VWAP)
+            ord_svr_dvsn_cd (str): 주문서버구분코드 (기본값 "0")
             start_time (str): 시작시간 (HHMMSS, TWAP/VWAP 주문유형인 경우 사용)
             end_time (str): 종료시간 (HHMMSS, TWAP/VWAP 주문유형인 경우 사용)
             algo_ord_tmd_dvsn_cd (str): 알고리즘주문시간구분코드 (00: 분할주문 시간 직접입력, 02: 정규장 종료시까지)
@@ -67,7 +101,7 @@ class OverseasAccount:
             KisHttpResponse[StockQuoteCurrent]: 해외주식 주문 응답 객체
         """
         headers = {
-            "tr_id": "TTTT1002U",
+            "tr_id": tr_id,
         }
         body = {
             "CANO": cano,
@@ -77,6 +111,7 @@ class OverseasAccount:
             "ORD_QTY": ord_qty,
             "OVRS_ORD_UNPR": ovrs_ord_unpr,
             "ORD_DVSN": ord_dvsn,
+            "ORD_SVR_DVSN_CD": ord_svr_dvsn_cd,
             "START_TIME": start_time,
             "END_TIME": end_time,
             "ALGO_ORD_TMD_DVSN_CD": algo_ord_tmd_dvsn_cd,
@@ -90,6 +125,7 @@ class OverseasAccount:
 
     def request_stock_quote_correction(
         self,
+        tr_id: Literal["TTTT1004U", "VTTT1004U"],
         cano: str,
         acnt_prdt_cd: str,
         ovrs_excg_cd: str,
@@ -104,6 +140,7 @@ class OverseasAccount:
         """해외주식 정정취소주문
 
         Args:
+            tr_id: TR ID (미국 정정·취소: TTTT1004U, 모의투자: VTTT1004U)
             cano (str): 종합계좌번호 (8자리)
             acnt_prdt_cd (str): 계좌상품코드 (2자리)
             ovrs_excg_cd (str): 해외거래소코드 (NASD: 나스닥, NYSE: 뉴욕, AMEX: 아멕스, SEHK: 홍콩, SHAA: 중국상해, SZAA: 중국심천, TKSE: 일본, HASE: 베트남 하노이, VNSE: 베트남 호치민)
@@ -119,7 +156,7 @@ class OverseasAccount:
             StockQuoteCorrection: 해외주식 정정취소주문 응답 객체
         """
         headers = {
-            "tr_id": "TTTT1004U",
+            "tr_id": tr_id,
         }
         body = {
             "CANO": cano,
@@ -146,6 +183,7 @@ class OverseasAccount:
 
     def request_stock_reserve_quote(
         self,
+        tr_id: Literal["TTTT3014U", "TTTT3016U", "TTTS3013U", "VTTT3014U", "VTTT3016U", "VTTS3013U"],
         cano: str,
         acnt_prdt_cd: str,
         pdno: str,
@@ -164,6 +202,8 @@ class OverseasAccount:
         """해외주식 예약주문접수
 
         Args:
+            tr_id: TR ID (미국예약매수: TTTT3014U, 미국예약매도: TTTT3016U, 중국/홍콩/일본/베트남 예약주문: TTTS3013U,
+                모의투자: VTTT3014U/VTTT3016U/VTTS3013U)
             cano (str): 종합계좌번호 (8자리)
             acnt_prdt_cd (str): 계좌상품코드 (2자리)
             pdno (str): 상품번호
@@ -183,7 +223,7 @@ class OverseasAccount:
             StockReserveQuote: 해외주식 예약주문접수 응답 객체
         """
         headers = {
-            "tr_id": "TTTT3014U",
+            "tr_id": tr_id,
         }
         body = {
             "CANO": cano,
@@ -210,6 +250,7 @@ class OverseasAccount:
 
     def request_stock_reserve_quote_correction(
         self,
+        tr_id: Literal["TTTT3017U", "VTTT3017U"],
         cano: str,
         acnt_prdt_cd: str,
         rsyn_ord_rcit_dt: str,
@@ -218,6 +259,7 @@ class OverseasAccount:
         """해외주식 예약주문접수취소
 
         Args:
+            tr_id: TR ID (미국 예약주문 취소접수: TTTT3017U, 모의투자: VTTT3017U. 아시아 국가는 미제공)
             cano (str): 종합계좌번호 (8자리)
             acnt_prdt_cd (str): 계좌상품코드 (2자리)
             rsyn_ord_rcit_dt (str): 해외주문접수일자
@@ -227,7 +269,7 @@ class OverseasAccount:
             StockReserveQuoteCorrection: 해외주식 예약주문접수취소 응답 객체
         """
         headers = {
-            "tr_id": "TTTT3017U",
+            "tr_id": tr_id,
         }
         body = {
             "CANO": cano,
@@ -248,6 +290,7 @@ class OverseasAccount:
 
     def get_buy_tradable_amount(
         self,
+        tr_id: Literal["TTTS3007R", "VTTS3007R"],
         cano: str,
         acnt_prdt_cd: str,
         ovrs_excg_cd: str,
@@ -257,6 +300,7 @@ class OverseasAccount:
         """해외주식 매수가능금액조회
 
         Args:
+            tr_id: TR ID (실전: TTTS3007R, 모의투자: VTTS3007R)
             cano (str): 종합계좌번호 (8자리)
             acnt_prdt_cd (str): 계좌상품코드 (2자리)
             ovrs_excg_cd (str): 해외거래소코드 (NASD: 나스닥, NYSE: 뉴욕, AMEX: 아멕스, SEHK: 홍콩, SHAA: 중국상해, SZAA: 중국심천, TKSE: 일본, HASE: 하노이거래소, VNSE: 호치민거래소)
@@ -267,7 +311,7 @@ class OverseasAccount:
             BuyTradableAmount: 해외주식 매수가능금액조회 응답 객체
         """
         headers = {
-            "tr_id": "TTTS3007R",
+            "tr_id": tr_id,
         }
         params = {
             "CANO": cano,
@@ -333,6 +377,7 @@ class OverseasAccount:
 
     def get_stock_balance(
         self,
+        tr_id: Literal["TTTS3012R", "VTTS3012R"],
         cano: str,
         acnt_prdt_cd: str,
         ovrs_excg_cd: str,
@@ -343,6 +388,7 @@ class OverseasAccount:
         """해외주식 잔고
 
         Args:
+            tr_id: TR ID (실전: TTTS3012R, 모의투자: VTTS3012R)
             cano (str): 종합계좌번호 (8자리)
             acnt_prdt_cd (str): 계좌상품코드 (2자리)
             ovrs_excg_cd (str): 해외거래소코드 (NASD: 미국전체, NAS: 나스닥, NYSE: 뉴욕, AMEX: 아멕스, SEHK: 홍콩, SHAA: 중국상해, SZAA: 중국심천, TKSE: 일본, HASE: 베트남 하노이, VNSE: 베트남 호치민)
@@ -354,7 +400,7 @@ class OverseasAccount:
             StockBalance: 해외주식 잔고 응답 객체
         """
         headers = {
-            "tr_id": "TTTS3012R",
+            "tr_id": tr_id,
         }
         params = {
             "CANO": cano,
@@ -377,6 +423,7 @@ class OverseasAccount:
 
     def get_stock_conclusion_history(
         self,
+        tr_id: Literal["TTTS3035R", "VTTS3035R"],
         cano: str,
         acnt_prdt_cd: str,
         pdno: str,
@@ -395,6 +442,7 @@ class OverseasAccount:
         """해외주식 주문체결내역
 
         Args:
+            tr_id: TR ID (실전: TTTS3035R, 모의투자: VTTS3035R)
             cano (str): 종합계좌번호 (8자리)
             acnt_prdt_cd (str): 계좌상품코드 (2자리)
             pdno (str): 상품번호 (전종목일 경우 "%", 모의투자계좌의 경우 ""만 가능)
@@ -414,7 +462,7 @@ class OverseasAccount:
             StockConclusionHistory: 해외주식 주문체결내역 응답 객체
         """
         headers = {
-            "tr_id": "TTTS3035R",
+            "tr_id": tr_id,
         }
         params = {
             "CANO": cano,
@@ -445,6 +493,7 @@ class OverseasAccount:
 
     def get_current_balance_by_conclusion(
         self,
+        tr_id: Literal["CTRP6504R", "VTRP6504R"],
         cano: str,
         acnt_prdt_cd: str,
         wcrc_frcr_dvsn_cd: str,
@@ -455,6 +504,7 @@ class OverseasAccount:
         """해외주식 체결기준현재잔고
 
         Args:
+            tr_id: TR ID (실전: CTRP6504R, 모의투자: VTRP6504R)
             cano (str): 종합계좌번호 (8자리)
             acnt_prdt_cd (str): 계좌상품코드 (2자리)
             wcrc_frcr_dvsn_cd (str): 원화외화구분코드 (01: 원화, 02: 외화)
@@ -466,7 +516,7 @@ class OverseasAccount:
             CurrentBalanceByConclusion: 해외주식 체결기준현재잔고 응답 객체
         """
         headers = {
-            "tr_id": "CTRP6504R",
+            "tr_id": tr_id,
         }
         params = {
             "CANO": cano,
@@ -489,6 +539,7 @@ class OverseasAccount:
 
     def get_reserve_orders(
         self,
+        tr_id: Literal["TTTT3039R", "TTTS3014R"],
         cano: str,
         acnt_prdt_cd: str,
         inqr_strt_dt: str,
@@ -502,6 +553,7 @@ class OverseasAccount:
         """해외주식 예약주문조회
 
         Args:
+            tr_id: TR ID (미국: TTTT3039R, 일본/중국/홍콩/베트남: TTTS3014R. 모의투자 미지원)
             cano (str): 종합계좌번호 (8자리)
             acnt_prdt_cd (str): 계좌상품코드 (2자리)
             inqr_strt_dt (str): 조회시작일자 (YYYYMMDD)
@@ -516,7 +568,7 @@ class OverseasAccount:
             ReserveOrders: 해외주식 예약주문조회 응답 객체
         """
         headers = {
-            "tr_id": "TTTT3039R",
+            "tr_id": tr_id,
         }
         params = {
             "CANO": cano,
@@ -730,6 +782,7 @@ class OverseasAccount:
 
     def request_order_after_day_time(
         self,
+        tr_id: Literal["TTTS6036U", "TTTS6037U"],
         cano: str,
         acnt_prdt_cd: str,
         ovrs_excg_cd: str,
@@ -744,6 +797,7 @@ class OverseasAccount:
         """해외주식 미국주간주문
 
         Args:
+            tr_id: TR ID (주간매수: TTTS6036U, 주간매도: TTTS6037U. 모의투자 미지원)
             cano (str): 종합계좌번호 (8자리)
             acnt_prdt_cd (str): 계좌상품코드 (2자리)
             ovrs_excg_cd (str): 해외거래소코드 (NASD: 나스닥, NYSE: 뉴욕, AMEX: 아멕스)
@@ -759,7 +813,7 @@ class OverseasAccount:
             OrderAfterDayTime: 해외주식 미국주간주문 응답 객체
         """
         headers = {
-            "tr_id": "TTTS6036U",
+            "tr_id": tr_id,
         }
         body = {
             "CANO": cano,
@@ -847,7 +901,7 @@ class OverseasAccount:
         self,
         trad_dt: str,
         cano: str,
-        acno_prdt_cd: str,
+        acnt_prdt_cd: str,
         ctx_area_nk200: str = "",
         ctx_area_fk200: str = "",
     ) -> KisHttpResponse[LimitOrderNumber]:
@@ -856,7 +910,7 @@ class OverseasAccount:
         Args:
             trad_dt (str): 거래일자 (YYYYMMDD)
             cano (str): 계좌번호 (종합계좌번호 8자리)
-            acno_prdt_cd (str): 계좌상품코드 (2자리, 주식계좌는 01)
+            acnt_prdt_cd (str): 계좌상품코드 (2자리, 주식계좌는 01)
             ctx_area_nk200 (str): 연속조회키200 (최초 조회시 공란)
             ctx_area_fk200 (str): 연속조회조건200 (최초 조회시 공란)
 
@@ -869,7 +923,7 @@ class OverseasAccount:
         params = {
             "TRAD_DT": trad_dt,
             "CANO": cano,
-            "ACNO_PRDT_CD": acno_prdt_cd,
+            "ACNT_PRDT_CD": acnt_prdt_cd,
             "CTX_AREA_NK200": ctx_area_nk200,
             "CTX_AREA_FK200": ctx_area_fk200,
         }

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_overseas_account_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_overseas_account_types.py
@@ -7,10 +7,15 @@ from cluefin_openapi.kis._model import KisHttpBody
 
 class StockQuoteCurrentItem(BaseModel):
     krx_fwdg_ord_orgno: str = Field(
-        title="한국거래소전송주문조직번호", max_length=5, description="주문시 한국투자증권 시스템에서 지정된 영업점코드"
+        title="한국거래소전송주문조직번호",
+        max_length=5,
+        alias="KRX_FWDG_ORD_ORGNO",
+        description="주문시 한국투자증권 시스템에서 지정된 영업점코드",
     )
-    odno: str = Field(title="주문번호", max_length=10, description="주문시 한국투자증권 시스템에서 채번된 주문번호")
-    ord_tmd: str = Field(title="주문시각", max_length=6, description="주문시각(시분초HHMMSS)")
+    odno: str = Field(
+        title="주문번호", max_length=10, alias="ODNO", description="주문시 한국투자증권 시스템에서 채번된 주문번호"
+    )
+    ord_tmd: str = Field(title="주문시각", max_length=6, alias="ORD_TMD", description="주문시각(시분초HHMMSS)")
 
 
 class StockQuoteCurrent(BaseModel, KisHttpBody):
@@ -39,19 +44,22 @@ class StockQuoteCorrection(BaseModel, KisHttpBody):
 
 
 class StockReserveQuoteItem(BaseModel):
-    odno: str = Field(
+    odno: Optional[str] = Field(
+        default=None,
         title="한국거래소전송주문조직번호",
         max_length=10,
         alias="ODNO",
         description="tr_id가 TTTT3016U(미국 예약 매도 주문) / TTTT3014U(미국 예약 매수 주문)인 경우만 출력",
     )
-    rsvn_ord_rcit_dt: str = Field(
+    rsvn_ord_rcit_dt: Optional[str] = Field(
+        default=None,
         title="예약주문접수일자",
         max_length=8,
         alias="RSVN_ORD_RCIT_DT",
         description="tr_id가 TTTS3013U(중국/홍콩/일본/베트남 예약 주문)인 경우만 출력",
     )
-    ovrs_rsvn_odno: str = Field(
+    ovrs_rsvn_odno: Optional[str] = Field(
+        default=None,
         title="해외예약주문번호",
         max_length=10,
         alias="OVRS_RSVN_ODNO",
@@ -361,6 +369,9 @@ class CurrentBalanceByConclusionItem2(BaseModel):
     frcr_evlu_amt2: str = Field(title="출금가능원화금액", max_length=29, description="출금가능한 원화금액")
     acpl_cstd_crcy_yn: str = Field(title="현지보관통화여부", max_length=1)
     nxdy_frcr_drwg_psbl_amt: str = Field(title="익일외화출금가능금액", max_length=31)
+
+
+class CurrentBalanceByConclusionItem3(BaseModel):
     pchs_amt_smtl: str = Field(
         title="매입금액합계", max_length=19, description="해외유가증권 매수금액의 원화 환산 금액"
     )
@@ -395,6 +406,7 @@ class CurrentBalanceByConclusion(BaseModel, KisHttpBody):
 
     output1: Sequence[CurrentBalanceByConclusionItem1] = Field(default_factory=list)
     output2: Sequence[CurrentBalanceByConclusionItem2] = Field(default_factory=list)
+    output3: CurrentBalanceByConclusionItem3 = Field(title="응답상세3")
 
 
 class ReserveOrdersItem(BaseModel):
@@ -405,7 +417,7 @@ class ReserveOrdersItem(BaseModel):
     ord_gno_brno: Optional[str] = Field(title="주문채번지점번호", max_length=5)
     odno: Optional[str] = Field(title="주문번호", max_length=10)
     sll_buy_dvsn_cd: Optional[str] = Field(title="매도매수구분코드", max_length=2)
-    sll_buy_dvsn_name: Optional[str] = Field(title="매도매수구분명", max_length=4)
+    sll_buy_dvsn_cd_name: Optional[str] = Field(title="매도매수구분명", max_length=4)
     ovrs_rsvn_ord_stat_cd: Optional[str] = Field(title="해외예약주문상태코드", max_length=2)
     ovrs_rsvn_ord_stat_cd_name: Optional[str] = Field(title="해외예약주문상태코드명", max_length=60)
     pdno: Optional[str] = Field(title="상품번호", max_length=12)
@@ -433,7 +445,7 @@ class ReserveOrders(BaseModel, KisHttpBody):
 
     ctx_area_fk200: str = Field(title="연속조회검색조건200", max_length=200)
     ctx_area_nk200: str = Field(title="연속조회키200", max_length=200)
-    output: ReserveOrdersItem = Field(title="응답상세")
+    output: Sequence[ReserveOrdersItem] = Field(default_factory=list)
 
 
 class BalanceBySettlementItem1(BaseModel):
@@ -469,6 +481,9 @@ class BalanceBySettlementItem2(BaseModel):
     frcr_dncl_amt_2: str = Field(title="외화예수금액2", max_length=236)
     frst_bltn_exrt: str = Field(title="최초고시환율", max_length=238)
     frcr_evlu_amt2: str = Field(title="외화평가금액2", max_length=236)
+
+
+class BalanceBySettlementItem3(BaseModel):
     pchs_amt_smtl_amt: str = Field(title="매입금액합계금액", max_length=19)
     tot_evlu_pfls_amt: str = Field(title="총평가손익금액", max_length=238)
     evlu_erng_rt1: str = Field(title="평가수익율1", max_length=201)
@@ -485,6 +500,7 @@ class BalanceBySettlement(BaseModel, KisHttpBody):
 
     output1: Sequence[BalanceBySettlementItem1] = Field(default_factory=list)
     output2: Sequence[BalanceBySettlementItem2] = Field(default_factory=list)
+    output3: BalanceBySettlementItem3 = Field(title="응답상세3")
 
 
 class DailyTransactionHistoryItem(BaseModel):
@@ -511,7 +527,9 @@ class DailyTransactionHistoryItem(BaseModel):
     erlm_exrt: str = Field(title="등록환율", max_length=238)
     loan_dvsn_cd: str = Field(title="대출구분코드", max_length=2)
     loan_dvsn_name: str = Field(title="대출구분명", max_length=60)
-    output2: str = Field(title="응답상세")
+
+
+class DailyTransactionHistoryItem2(BaseModel):
     frcr_buy_amt_smtl: str = Field(title="외화매수금액합계", max_length=236)
     frcr_sll_amt_smtl: str = Field(title="외화매도금액합계", max_length=236)
     dmst_fee_smtl: str = Field(title="국내수수료합계", max_length=256)
@@ -521,9 +539,10 @@ class DailyTransactionHistoryItem(BaseModel):
 class DailyTransactionHistory(BaseModel, KisHttpBody):
     """해외주식 일별거래내역"""
 
-    ctx_area_fk200: str = Field(title="연속조회검색조건200", max_length=200)
-    ctx_area_nk200: str = Field(title="연속조회키200", max_length=200)
-    output: Sequence[DailyTransactionHistoryItem] = Field(default_factory=list)
+    ctx_area_fk100: str = Field(title="연속조회검색조건100", max_length=100)
+    ctx_area_nk100: str = Field(title="연속조회키100", max_length=100)
+    output1: Sequence[DailyTransactionHistoryItem] = Field(default_factory=list)
+    output2: DailyTransactionHistoryItem2 = Field(title="응답상세2")
 
 
 class PeriodProfitLossItem1(BaseModel):
@@ -577,7 +596,7 @@ class PeriodProfitLossItem2(BaseModel):
 class PeriodProfitLoss(BaseModel, KisHttpBody):
     """해외주식 기간손익"""
 
-    output: Sequence[PeriodProfitLossItem1] = Field(default_factory=list)
+    output1: Sequence[PeriodProfitLossItem1] = Field(default_factory=list)
     output2: PeriodProfitLossItem2 = Field(title="응답상세2")
 
 
@@ -603,10 +622,15 @@ class MarginAggregate(BaseModel, KisHttpBody):
 
 class OrderAfterDayTimeItem(BaseModel):
     krx_fwdg_ord_orgno: str = Field(
-        title="한국거래소전송주문조직번호", max_length=5, description="주문시 한국투자증권 시스템에서 지정된 영업점코드"
+        title="한국거래소전송주문조직번호",
+        max_length=5,
+        alias="KRX_FWDG_ORD_ORGNO",
+        description="주문시 한국투자증권 시스템에서 지정된 영업점코드",
     )
-    odno: str = Field(title="주문번호", max_length=10, description="주문시 한국투자증권 시스템에서 채번된 주문번호")
-    ord_tmd: str = Field(title="주문시각", max_length=6, description="주문시각(시분초HHMMSS)")
+    odno: str = Field(
+        title="주문번호", max_length=10, alias="ODNO", description="주문시 한국투자증권 시스템에서 채번된 주문번호"
+    )
+    ord_tmd: str = Field(title="주문시각", max_length=6, alias="ORD_TMD", description="주문시각(시분초HHMMSS)")
 
 
 class OrderAfterDayTime(BaseModel, KisHttpBody):
@@ -617,10 +641,15 @@ class OrderAfterDayTime(BaseModel, KisHttpBody):
 
 class CorrectAfterDayTimeItem(BaseModel):
     krx_fwdg_ord_orgno: str = Field(
-        title="한국거래소전송주문조직번호", max_length=5, description="주문시 한국투자증권 시스템에서 지정된 영업점코드"
+        title="한국거래소전송주문조직번호",
+        max_length=5,
+        alias="KRX_FWDG_ORD_ORGNO",
+        description="주문시 한국투자증권 시스템에서 지정된 영업점코드",
     )
-    odno: str = Field(title="주문번호", max_length=10, description="주문시 한국투자증권 시스템에서 채번된 주문번호")
-    ord_tmd: str = Field(title="주문시각", max_length=6, description="주문시각(시분초HHMMSS)")
+    odno: str = Field(
+        title="주문번호", max_length=10, alias="ODNO", description="주문시 한국투자증권 시스템에서 채번된 주문번호"
+    )
+    ord_tmd: str = Field(title="주문시각", max_length=6, alias="ORD_TMD", description="주문시각(시분초HHMMSS)")
 
 
 class CorrectAfterDayTime(BaseModel, KisHttpBody):
@@ -639,16 +668,13 @@ class LimitOrderNumberItem(BaseModel):
     splt_buy_attr_name: str = Field(title="분할매수속성명", max_length=60)
     ft_ccld_qty: str = Field(title="FT체결수량", max_length=4)
     ord_gno_brno: Optional[str] = Field(title="주문채번지점번호", max_length=5)
-    rt_cd: str = Field(title="성공 실패 여부", max_length=1, description="0 : 성공 0 이외의 값 : 실패")
-    msg_cd: str = Field(title="응답코드", max_length=8)
-    msg1: str = Field(title="응답메세지", max_length=80)
-    ctx_area_fk200: str = Field(title="연속조회검색조건200", max_length=200)
-    ctx_area_nk200: str = Field(title="연속조회키200", max_length=200)
 
 
 class LimitOrderNumber(BaseModel, KisHttpBody):
     """해외주식 지정가주문번호조회"""
 
+    ctx_area_fk200: str = Field(title="연속조회검색조건200", max_length=200)
+    ctx_area_nk200: str = Field(title="연속조회키200", max_length=200)
     output: Sequence[LimitOrderNumberItem] = Field(default_factory=list)
 
 
@@ -682,4 +708,4 @@ class LimitOrderExecutionHistory(BaseModel, KisHttpBody):
     """해외주식 지정가체결내역조회"""
 
     output1: Sequence[LimitOrderConclusionHistoryItem1] = Field(default_factory=list)
-    output2: Sequence[LimitOrderConclusionHistoryItem2] = Field(alias="output3", default_factory=list)
+    output2: LimitOrderConclusionHistoryItem2 = Field(title="응답상세2")

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_overseas_market_analysis.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_overseas_market_analysis.py
@@ -37,7 +37,7 @@ class OverseasMarketAnalysis:
         self,
         excd: str,
         gubn: str,
-        mixn: str,
+        minx: str,
         vol_rang: str,
     ) -> KisHttpResponse[StockPriceFluctuation]:
         """
@@ -46,7 +46,7 @@ class OverseasMarketAnalysis:
         Args:
             excd (str): 거래소코드 (NYS: 뉴욕, NAS: 나스닥, AMS: 아멕스, HKS: 홍콩, SHS: 상해, SZS: 심천, HSX: 호치민, HNX: 하노이, TSE: 도쿄)
             gubn (str): 급등/급락구분 (0: 급락, 1: 급등)
-            mixn (str): N분전콤보값 (0: 1분전, 1: 2분전, 2: 3분전, 3: 5분전, 4: 10분전, 5: 15분전, 6: 20분전, 7: 30분전, 8: 60분전, 9: 120분전)
+            minx (str): N분전콤보값 (0: 1분전, 1: 2분전, 2: 3분전, 3: 5분전, 4: 10분전, 5: 15분전, 6: 20분전, 7: 30분전, 8: 60분전, 9: 120분전)
             vol_rang (str): 거래량조건 (0: 전체, 1: 1백주이상, 2: 1천주이상, 3: 1만주이상, 4: 10만주이상, 5: 100만주이상, 6: 1000만주이상)
 
         Returns:
@@ -60,10 +60,10 @@ class OverseasMarketAnalysis:
             "AUTH": "",
             "EXCD": excd,
             "GUBN": gubn,
-            "MIXN": mixn,
+            "MINX": minx,
             "VOL_RANG": vol_rang,
         }
-        response = self.client._get("/uapi/overseas-stock/v1/ranking/price-fluctuation", headers=headers, params=params)
+        response = self.client._get("/uapi/overseas-stock/v1/ranking/price-fluct", headers=headers, params=params)
         response_data = response.json()
         self._check_response_error(response_data)
         header = KisHttpHeader.model_validate(response.headers)
@@ -75,9 +75,8 @@ class OverseasMarketAnalysis:
         keyb: str,
         auth: str,
         excd: str,
-        mixn: str,
+        minx: str,
         vol_rang: str,
-        minx: str | None = None,
     ) -> KisHttpResponse[StockVolumeSurge]:
         """
         해외주식 거래량급증
@@ -86,9 +85,8 @@ class OverseasMarketAnalysis:
             keyb (str): NEXT KEY BUFF (공백)
             auth (str): 사용자권한정보 (공백)
             excd (str): 거래소코드 (NYS: 뉴욕, NAS: 나스닥, AMS: 아멕스, HKS: 홍콩, SHS: 상해, SZS: 심천, HSX: 호치민, HNX: 하노이, TSE: 도쿄)
-            mixn (str): N분전콤보값 (0: 1분전, 1: 2분전, 2: 3분전, 3: 5분전, 4: 10분전, 5: 15분전, 6: 20분전, 7: 30분전, 8: 60분전, 9: 120분전)
+            minx (str): N분전콤보값 (0: 1분전, 1: 2분전, 2: 3분전, 3: 5분전, 4: 10분전, 5: 15분전, 6: 20분전, 7: 30분전, 8: 60분전, 9: 120분전)
             vol_rang (str): 거래량조건 (0: 전체, 1: 1백주이상, 2: 1천주이상, 3: 1만주이상, 4: 10만주이상, 5: 100만주이상, 6: 1000만주이상)
-            minx (str | None): 분 기준(MINX). 미지정 시 mixn 값을 사용
 
         Returns:
             StockVolumeSurge: 해외주식 거래량급증 응답 객체
@@ -100,8 +98,7 @@ class OverseasMarketAnalysis:
             "KEYB": keyb,
             "AUTH": auth,
             "EXCD": excd,
-            "MIXN": mixn,
-            "MINX": mixn if minx is None else minx,
+            "MINX": minx,
             "VOL_RANG": vol_rang,
         }
         response = self.client._get("/uapi/overseas-stock/v1/ranking/volume-surge", headers=headers, params=params)
@@ -126,7 +123,7 @@ class OverseasMarketAnalysis:
             keyb (str): NEXT KEY BUFF (공백)
             auth (str): 사용자권한정보 (공백)
             excd (str): 거래소코드 (NYS: 뉴욕, NAS: 나스닥, AMS: 아멕스, HKS: 홍콩, SHS: 상해, SZS: 심천, HSX: 호치민, HNX: 하노이, TSE: 도쿄)
-            nday (str): N일자값 (0: 1분전, 1: 2분전, 2: 3분전, 3: 5분전, 4: 10분전, 5: 15분전, 6: 20분전, 7: 30분전, 8: 60분전, 9: 120분전)
+            nday (str): N일자값 (0: 당일, 1: 2일, 2: 3일, 3: 5일, 4: 10일, 5: 20일전, 6: 30일, 7: 60일, 8: 120일, 9: 1년)
             vol_rang (str): 거래량조건 (0: 전체, 1: 1백주이상, 2: 1천주이상, 3: 1만주이상, 4: 10만주이상, 5: 100만주이상, 6: 1000만주이상)
 
         Returns:

--- a/packages/cluefin-openapi/src/cluefin_openapi/kis/_overseas_market_analysis_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/kis/_overseas_market_analysis_types.py
@@ -1,6 +1,6 @@
 from typing import Sequence
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 
 from cluefin_openapi.kis._model import KisHttpBody
 
@@ -79,7 +79,8 @@ class StockBuyExecutionStrengthTopItem2(BaseModel):
     rsym: str = Field(title="실시간조회심볼", max_length=16)
     excd: str = Field(title="거래소코드", max_length=4)
     symb: str = Field(title="종목코드", max_length=16)
-    name: str = Field(title="종목명", max_length=48)
+    # 공식 문서는 knam/enam으로 표기하지만 실서버 응답 키는 name/ename — 둘 다 수용
+    name: str = Field(validation_alias=AliasChoices("name", "knam"), title="종목명", max_length=48)
     last: str = Field(title="현재가", max_length=12)
     sign: str = Field(title="기호", max_length=1)
     diff: str = Field(title="대비", max_length=12)
@@ -89,7 +90,7 @@ class StockBuyExecutionStrengthTopItem2(BaseModel):
     pbid: str = Field(title="매수호가", max_length=12)
     tpow: str = Field(title="당일체결강도", max_length=10)
     powx: str = Field(title="체결강도", max_length=10)
-    ename: str = Field(title="영문종목명", max_length=48)
+    ename: str = Field(validation_alias=AliasChoices("ename", "enam"), title="영문종목명", max_length=48)
     e_ordyn: str = Field(title="매매가능", max_length=2)
 
 

--- a/packages/cluefin-openapi/tests/kis/domestic_account_cases.json
+++ b/packages/cluefin-openapi/tests/kis/domestic_account_cases.json
@@ -303,33 +303,26 @@
         "endpoint": "/uapi/domestic-stock/v1/trading/inquire-psbl-order",
         "method": "GET",
         "call_kwargs": {
-            "tr_id": "TTTC0802R",
-            "tr_cont": "",
+            "tr_id": "TTTC8908R",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
-            "afhr_flpr_yn": "N",
-            "inqr_dvsn": "01",
-            "fund_sttl_icld_yn": "N",
-            "prcs_dvsn": "00",
-            "ctx_area_fk100": "",
-            "ctx_area_nk100": ""
+            "pdno": "005930",
+            "ord_unpr": "70000",
+            "ord_dvsn": "00",
+            "cma_evlu_amt_icld_yn": "N",
+            "ovrs_icld_yn": "N"
         },
         "expected_headers": {
-            "tr_id": "TTTC0802R",
-            "tr_cont": ""
+            "tr_id": "TTTC8908R"
         },
         "expected_body": {
             "CANO": "12345678",
             "ACNT_PRDT_CD": "01",
-            "AFHR_FLPR_YN": "N",
-            "OFL_YN": "",
-            "INQR_DVSN": "01",
-            "UNPR_DVSN": "01",
-            "FUND_STTL_ICLD_YN": "N",
-            "FNCG_AMT_AUTO_RDPT_YN": "N",
-            "PRCS_DVSN": "00",
-            "CTX_AREA_FK100": "",
-            "CTX_AREA_NK100": ""
+            "PDNO": "005930",
+            "ORD_UNPR": "70000",
+            "ORD_DVSN": "00",
+            "CMA_EVLU_AMT_ICLD_YN": "N",
+            "OVRS_ICLD_YN": "N"
         },
         "response_payload": {
             "rt_cd": "0",
@@ -345,7 +338,6 @@
                 "max_buy_qty": "71",
                 "cma_evlu_amt": "0",
                 "ovrs_re_use_amt_wcrc": "0",
-                "ord_psbl_frcr_amt": "0",
                 "ord_psbl_frcr_amt_wcrc": "0"
             }
         }
@@ -587,6 +579,7 @@
             "tr_id": "CTSC0013U",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
+            "pdno": "005930",
             "rsvn_ord_seq": "0000001234",
             "ord_qty": "50",
             "ord_unpr": "75000",
@@ -605,6 +598,7 @@
         "expected_body": {
             "CANO": "12345678",
             "ACNT_PRDT_CD": "01",
+            "PDNO": "005930",
             "RSVN_ORD_SEQ": "0000001234",
             "ORD_QTY": "50",
             "ORD_UNPR": "75000",
@@ -636,6 +630,7 @@
             "rsvn_ord_ord_dt": "20250101",
             "rsvn_ord_end_dt": "20251231",
             "rsvn_ord_seq": "",
+            "tmnl_mdia_kind_cd": "10",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "prcs_dvsn_cd": "0",
@@ -653,6 +648,7 @@
             "RSVN_ORD_ORD_DT": "20250101",
             "RSVN_ORD_END_DT": "20251231",
             "RSVN_ORD_SEQ": "",
+            "TMNL_MDIA_KIND_CD": "10",
             "CANO": "12345678",
             "ACNT_PRDT_CD": "01",
             "PRCS_DVSN_CD": "0",
@@ -825,7 +821,7 @@
         "call_kwargs": {
             "cano": "12345678",
             "acnt_prdt_cd": "29",
-            "user_dvsn_cd": "00"
+            "acca_dvsn_cd": "00"
         },
         "expected_headers": {
             "tr_id": "TTTC0506R"
@@ -833,7 +829,7 @@
         "expected_body": {
             "CANO": "12345678",
             "ACNT_PRDT_CD": "29",
-            "USER_DVSN_CD": "00"
+            "ACCA_DVSN_CD": "00"
         },
         "response_payload": {
             "rt_cd": "0",
@@ -853,7 +849,7 @@
             "ctx_area_fk100": "",
             "ctx_area_nk100": "",
             "acnt_prdt_cd": "29",
-            "user_dvsn_cd": "00",
+            "acca_dvsn_cd": "00",
             "inqr_dvsn": "00"
         },
         "expected_headers": {
@@ -862,7 +858,7 @@
         "expected_body": {
             "CANO": "12345678",
             "ACNT_PRDT_CD": "29",
-            "USER_DVSN_CD": "00",
+            "ACCA_DVSN_CD": "00",
             "INQR_DVSN": "00",
             "CTX_AREA_FK100": "",
             "CTX_AREA_NK100": ""

--- a/packages/cluefin-openapi/tests/kis/domestic_basic_quote_cases.json
+++ b/packages/cluefin-openapi/tests/kis/domestic_basic_quote_cases.json
@@ -463,7 +463,7 @@
     },
     {
         "method_name": "get_stock_daily_minute_chart",
-        "response_model_attr": "DomesticStockTodayMinuteChart",
+        "response_model_attr": "DomesticStockDailyMinuteChart",
         "endpoint": "/uapi/domestic-stock/v1/quotations/inquire-time-dailychartprice",
         "method": "GET",
         "call_kwargs": {

--- a/packages/cluefin-openapi/tests/kis/domestic_market_analysis_cases.json
+++ b/packages/cluefin-openapi/tests/kis/domestic_market_analysis_cases.json
@@ -238,6 +238,47 @@
         }
     },
     {
+        "method_name": "get_buy_sell_volume_by_stock_daily",
+        "response_model_attr": "BuySellVolumeByStockDaily",
+        "endpoint": "/uapi/domestic-stock/v1/quotations/inquire-daily-trade-volume",
+        "method": "GET",
+        "call_kwargs": {
+            "fid_cond_mrkt_div_code": "J",
+            "fid_input_iscd": "005930",
+            "fid_input_date_1": "20250101",
+            "fid_input_date_2": "20250115",
+            "fid_period_div_code": "D"
+        },
+        "expected_headers": {
+            "tr_id": "FHKST03010800"
+        },
+        "expected_body": {
+            "FID_COND_MRKT_DIV_CODE": "J",
+            "FID_INPUT_ISCD": "005930",
+            "FID_INPUT_DATE_1": "20250101",
+            "FID_INPUT_DATE_2": "20250115",
+            "FID_PERIOD_DIV_CODE": "D",
+            "FID_COND_MRKT_DIV_CODE_1": "J",
+            "FID_INPUT_ISCD_1": "005930"
+        },
+        "response_payload": {
+            "rt_cd": "0",
+            "output1": [
+                {
+                    "shnu_cnqn_smtn": "10000",
+                    "seln_cnqn_smtn": "9000"
+                }
+            ],
+            "output2": [
+                {
+                    "stck_bsop_date": "20250115",
+                    "total_seln_qty": "9000",
+                    "total_shnu_qty": "10000"
+                }
+            ]
+        }
+    },
+    {
         "method_name": "get_program_trading_trend_by_stock_intraday",
         "response_model_attr": "ProgramTradingTrendByStockIntraday",
         "endpoint": "/uapi/domestic-stock/v1/quotations/program-trade-by-stock",

--- a/packages/cluefin-openapi/tests/kis/domestic_ranking_analysis_cases.json
+++ b/packages/cluefin-openapi/tests/kis/domestic_ranking_analysis_cases.json
@@ -14,8 +14,7 @@
             "fid_trgt_exls_cls_code": "0000000000",
             "fid_input_price_1": "",
             "fid_input_price_2": "",
-            "fid_vol_cnt": "",
-            "fid_input_date_1": ""
+            "fid_vol_cnt": ""
         },
         "expected_headers": {
             "tr_id": "FHPST01710000"
@@ -30,8 +29,7 @@
             "FID_TRGT_EXLS_CLS_CODE": "0000000000",
             "FID_INPUT_PRICE_1": "",
             "FID_INPUT_PRICE_2": "",
-            "FID_VOL_CNT": "",
-            "FID_INPUT_DATE_1": ""
+            "FID_VOL_CNT": ""
         },
         "response_payload": {
             "rt_cd": "0",
@@ -454,6 +452,163 @@
                 {
                     "mrkt_div_cls_code": "J",
                     "mksc_shrn_iscd": "005930"
+                }
+            ]
+        }
+    },
+    {
+        "method_name": "get_stock_dividend_yield_top",
+        "response_model_attr": "StockDividendYieldTop",
+        "endpoint": "/uapi/domestic-stock/v1/ranking/dividend-rate",
+        "method": "GET",
+        "call_kwargs": {
+            "cts_area": "",
+            "gb1": "0",
+            "upjong": "0001",
+            "gb2": "0",
+            "gb3": "1",
+            "f_dt": "20240101",
+            "t_dt": "20241231",
+            "gb4": "0"
+        },
+        "expected_headers": {
+            "tr_id": "HHKDB13470100"
+        },
+        "expected_body": {
+            "CTS_AREA": "",
+            "GB1": "0",
+            "UPJONG": "0001",
+            "GB2": "0",
+            "GB3": "1",
+            "F_DT": "20240101",
+            "T_DT": "20241231",
+            "GB4": "0"
+        },
+        "response_payload": {
+            "rt_cd": "0",
+            "msg_cd": "MCA00000",
+            "msg1": "정상처리 되었습니다.",
+            "output1": [
+                {
+                    "rank": "1",
+                    "sht_cd": "005930",
+                    "isin_name": "삼성전자",
+                    "record_date": "20241231",
+                    "per_sto_divi_amt": "361",
+                    "divi_rate": "2.5",
+                    "divi_kind": "1"
+                }
+            ]
+        }
+    },
+    {
+        "method_name": "get_stock_credit_balance_top",
+        "response_model_attr": "StockCreditBalanceTop",
+        "endpoint": "/uapi/domestic-stock/v1/ranking/credit-balance",
+        "method": "GET",
+        "call_kwargs": {
+            "fid_cond_scr_div_code": "11701",
+            "fid_input_iscd": "0000",
+            "fid_option": "2",
+            "fid_cond_mrkt_div_code": "J",
+            "fid_rank_sort_cls_code": "0"
+        },
+        "expected_headers": {
+            "tr_id": "FHKST17010000"
+        },
+        "expected_body": {
+            "FID_COND_SCR_DIV_CODE": "11701",
+            "FID_INPUT_ISCD": "0000",
+            "FID_OPTION": "2",
+            "FID_COND_MRKT_DIV_CODE": "J",
+            "FID_RANK_SORT_CLS_CODE": "0"
+        },
+        "response_payload": {
+            "rt_cd": "0",
+            "msg_cd": "MCA00000",
+            "msg1": "정상처리 되었습니다.",
+            "output1": [
+                {
+                    "bstp_cls_code": "001",
+                    "hts_kor_isnm": "종합",
+                    "stnd_date1": "20241231",
+                    "stnd_date2": "20241230"
+                }
+            ],
+            "output2": [
+                {
+                    "mksc_shrn_iscd": "005930",
+                    "hts_kor_isnm": "삼성전자",
+                    "stck_prpr": "70000",
+                    "prdy_vrss": "1000",
+                    "prdy_vrss_sign": "2",
+                    "prdy_ctrt": "1.43",
+                    "acml_vol": "10000000",
+                    "whol_loan_rmnd_stcn": "1000000",
+                    "whol_loan_rmnd_amt": "70000000000",
+                    "whol_loan_rmnd_rate": "1.5",
+                    "whol_stln_rmnd_stcn": "500000",
+                    "whol_stln_rmnd_amt": "35000000000",
+                    "whol_stln_rmnd_rate": "0.8",
+                    "nday_vrss_loan_rmnd_inrt": "2.1",
+                    "nday_vrss_stln_rmnd_inrt": "1.1"
+                }
+            ]
+        }
+    },
+    {
+        "method_name": "get_stock_short_selling_top",
+        "response_model_attr": "StockShortSellingTop",
+        "endpoint": "/uapi/domestic-stock/v1/ranking/short-sale",
+        "method": "GET",
+        "call_kwargs": {
+            "fid_aply_rang_vol": "",
+            "fid_cond_mrkt_div_code": "J",
+            "fid_cond_scr_div_code": "20482",
+            "fid_input_iscd": "0000",
+            "fid_period_div_code": "D",
+            "fid_input_cnt_1": "0",
+            "fid_trgt_exls_cls_code": "",
+            "fid_trgt_cls_code": "",
+            "fid_aply_rang_prc_1": "",
+            "fid_aply_rang_prc_2": ""
+        },
+        "expected_headers": {
+            "tr_id": "FHPST04820000"
+        },
+        "expected_body": {
+            "FID_APLY_RANG_VOL": "",
+            "FID_COND_MRKT_DIV_CODE": "J",
+            "FID_COND_SCR_DIV_CODE": "20482",
+            "FID_INPUT_ISCD": "0000",
+            "FID_PERIOD_DIV_CODE": "D",
+            "FID_INPUT_CNT_1": "0",
+            "FID_TRGT_EXLS_CLS_CODE": "",
+            "FID_TRGT_CLS_CODE": "",
+            "FID_APLY_RANG_PRC_1": "",
+            "FID_APLY_RANG_PRC_2": ""
+        },
+        "response_payload": {
+            "rt_cd": "0",
+            "msg_cd": "MCA00000",
+            "msg1": "정상처리 되었습니다.",
+            "output": [
+                {
+                    "mksc_shrn_iscd": "005930",
+                    "hts_kor_isnm": "삼성전자",
+                    "stck_prpr": "70000",
+                    "prdy_vrss": "1000",
+                    "prdy_vrss_sign": "2",
+                    "prdy_ctrt": "1.43",
+                    "acml_vol": "10000000",
+                    "acml_tr_pbmn": "700000000000",
+                    "ssts_cntg_qty": "50000",
+                    "ssts_vol_rlim": "0.5",
+                    "ssts_tr_pbmn": "3500000000",
+                    "ssts_tr_pbmn_rlim": "0.5",
+                    "stnd_date1": "20241231",
+                    "stnd_date2": "20241230",
+                    "avrg_prc": "69500"
                 }
             ]
         }

--- a/packages/cluefin-openapi/tests/kis/overseas_account_cases.json
+++ b/packages/cluefin-openapi/tests/kis/overseas_account_cases.json
@@ -5,6 +5,7 @@
         "endpoint": "/uapi/overseas-stock/v1/trading/order",
         "method": "POST",
         "call_kwargs": {
+            "tr_id": "TTTT1002U",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "ovrs_excg_cd": "NASD",
@@ -24,6 +25,7 @@
             "ORD_QTY": "10",
             "OVRS_ORD_UNPR": "150.50",
             "ORD_DVSN": "00",
+            "ORD_SVR_DVSN_CD": "0",
             "START_TIME": "",
             "END_TIME": "",
             "ALGO_ORD_TMD_DVSN_CD": ""
@@ -43,6 +45,7 @@
         "endpoint": "/uapi/overseas-stock/v1/trading/order-rvsecncl",
         "method": "POST",
         "call_kwargs": {
+            "tr_id": "TTTT1004U",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "ovrs_excg_cd": "NASD",
@@ -81,6 +84,7 @@
         "endpoint": "/uapi/overseas-stock/v1/trading/order-resv",
         "method": "POST",
         "call_kwargs": {
+            "tr_id": "TTTT3014U",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "pdno": "JPY00001",
@@ -122,6 +126,7 @@
         "endpoint": "/uapi/overseas-stock/v1/trading/order-resv-ccnl",
         "method": "POST",
         "call_kwargs": {
+            "tr_id": "TTTT3017U",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "rsyn_ord_rcit_dt": "20240101",
@@ -149,6 +154,7 @@
         "endpoint": "/uapi/overseas-stock/v1/trading/inquire-psamount",
         "method": "GET",
         "call_kwargs": {
+            "tr_id": "TTTS3007R",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "ovrs_excg_cd": "NASD",
@@ -215,6 +221,7 @@
         "endpoint": "/uapi/overseas-stock/v1/trading/inquire-balance",
         "method": "GET",
         "call_kwargs": {
+            "tr_id": "TTTS3012R",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "ovrs_excg_cd": "NASD",
@@ -255,6 +262,7 @@
         "endpoint": "/uapi/overseas-stock/v1/trading/inquire-ccnl",
         "method": "GET",
         "call_kwargs": {
+            "tr_id": "TTTS3035R",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "pdno": "%",
@@ -305,6 +313,7 @@
         "endpoint": "/uapi/overseas-stock/v1/trading/inquire-present-balance",
         "method": "GET",
         "call_kwargs": {
+            "tr_id": "CTRP6504R",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "wcrc_frcr_dvsn_cd": "01",
@@ -338,7 +347,10 @@
                     "tot_evlu_amt": "1505000",
                     "deposit": "500000"
                 }
-            ]
+            ],
+            "output3": {
+                "tot_asst_amt": "1505000"
+            }
         }
     },
     {
@@ -347,6 +359,7 @@
         "endpoint": "/uapi/overseas-stock/v1/trading/order-resv-list",
         "method": "GET",
         "call_kwargs": {
+            "tr_id": "TTTT3039R",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "inqr_strt_dt": "20240101",
@@ -371,11 +384,13 @@
         },
         "response_payload": {
             "rt_cd": "0",
-            "output": {
-                "rsvn_odno": "RES001",
-                "pdno": "AAPL",
-                "ft_ord_qty": "100"
-            },
+            "output": [
+                {
+                    "rsvn_odno": "RES001",
+                    "pdno": "AAPL",
+                    "ft_ord_qty": "100"
+                }
+            ],
             "ctx_area_fk200": "0",
             "ctx_area_nk200": ""
         }
@@ -416,7 +431,10 @@
                     "tot_deposit": "500000",
                     "tot_evlu_amt": "1505000"
                 }
-            ]
+            ],
+            "output3": {
+                "tot_dncl_amt": "500000"
+            }
         }
     },
     {
@@ -451,7 +469,7 @@
         },
         "response_payload": {
             "rt_cd": "0",
-            "output": [
+            "output1": [
                 {
                     "trad_dt": "20240115",
                     "pdno": "AAPL",
@@ -460,6 +478,10 @@
                     "trad_amt": "1505000"
                 }
             ],
+            "output2": {
+                "frcr_buy_amt_smtl": "1505000",
+                "frcr_sll_amt_smtl": "0"
+            },
             "ctx_area_fk100": "0",
             "ctx_area_nk100": ""
         }
@@ -498,7 +520,7 @@
         },
         "response_payload": {
             "rt_cd": "0",
-            "output": [
+            "output1": [
                 {
                     "pdno": "AAPL",
                     "pft_loss_amt": "50000",
@@ -545,6 +567,7 @@
         "endpoint": "/uapi/overseas-stock/v1/trading/daytime-order",
         "method": "POST",
         "call_kwargs": {
+            "tr_id": "TTTS6036U",
             "cano": "12345678",
             "acnt_prdt_cd": "01",
             "ovrs_excg_cd": "NYSE",
@@ -622,7 +645,7 @@
         "call_kwargs": {
             "trad_dt": "20240115",
             "cano": "12345678",
-            "acno_prdt_cd": "01"
+            "acnt_prdt_cd": "01"
         },
         "expected_headers": {
             "tr_id": "TTTS6058R"
@@ -630,7 +653,7 @@
         "expected_body": {
             "TRAD_DT": "20240115",
             "CANO": "12345678",
-            "ACNO_PRDT_CD": "01",
+            "ACNT_PRDT_CD": "01",
             "CTX_AREA_NK200": "",
             "CTX_AREA_FK200": ""
         },
@@ -681,12 +704,10 @@
                     "ccld_amt": "7525000"
                 }
             ],
-            "output2": [
-                {
-                    "tot_ccld_qty": "50",
-                    "tot_ccld_amt": "7525000"
-                }
-            ],
+            "output2": {
+                "tot_ccld_qty": "50",
+                "tot_ccld_amt": "7525000"
+            },
             "ctx_area_nk200": "",
             "ctx_area_fk200": "0"
         }

--- a/packages/cluefin-openapi/tests/kis/overseas_market_analysis_cases.json
+++ b/packages/cluefin-openapi/tests/kis/overseas_market_analysis_cases.json
@@ -2,12 +2,12 @@
     {
         "method_name": "get_stock_price_fluctuation",
         "response_model_attr": "StockPriceFluctuation",
-        "endpoint": "/uapi/overseas-stock/v1/ranking/price-fluctuation",
+        "endpoint": "/uapi/overseas-stock/v1/ranking/price-fluct",
         "method": "GET",
         "call_kwargs": {
             "excd": "NAS",
             "gubn": "1",
-            "mixn": "3",
+            "minx": "3",
             "vol_rang": "0"
         },
         "expected_headers": {
@@ -18,7 +18,7 @@
             "AUTH": "",
             "EXCD": "NAS",
             "GUBN": "1",
-            "MIXN": "3",
+            "MINX": "3",
             "VOL_RANG": "0"
         },
         "response_payload": {
@@ -44,7 +44,7 @@
             "keyb": "",
             "auth": "",
             "excd": "NYS",
-            "mixn": "4",
+            "minx": "4",
             "vol_rang": "1"
         },
         "expected_headers": {
@@ -54,7 +54,6 @@
             "KEYB": "",
             "AUTH": "",
             "EXCD": "NYS",
-            "MIXN": "4",
             "MINX": "4",
             "VOL_RANG": "1"
         },
@@ -95,13 +94,28 @@
         },
         "response_payload": {
             "rt_cd": "0",
-            "output": [
+            "output1": {
+                "zdiv": "4",
+                "stat": "장중",
+                "nrec": "2"
+            },
+            "output2": [
                 {
-                    "rsym": "MSFT",
+                    "rsym": "DNASMSFT",
+                    "excd": "NAS",
                     "symb": "MSFT",
-                    "rsym_name": "Microsoft Corp",
-                    "last": "380.25",
-                    "rate": "125.5"
+                    "name": "마이크로소프트",
+                    "last": "380.2500",
+                    "sign": "2",
+                    "diff": "1.2500",
+                    "rate": "0.33",
+                    "tvol": "1234567",
+                    "pask": "380.3000",
+                    "pbid": "380.2000",
+                    "tpow": "120.5",
+                    "powx": "118.2",
+                    "ename": "MICROSOFT CORP",
+                    "e_ordyn": "○"
                 }
             ]
         }

--- a/packages/cluefin-openapi/tests/kis/test_domestic_ranking_analysis_integration.py
+++ b/packages/cluefin-openapi/tests/kis/test_domestic_ranking_analysis_integration.py
@@ -26,7 +26,6 @@ def test_get_trading_volume_rank(client: HttpClient):
             fid_input_price_1="",  # 가격~
             fid_input_price_2="",  # ~가격
             fid_vol_cnt="",  # 거래량~
-            fid_input_date_1="",  # 공란 입력
         )
 
         # Verify response type

--- a/packages/cluefin-openapi/tests/kis/test_domestic_ranking_analysis_unit.py
+++ b/packages/cluefin-openapi/tests/kis/test_domestic_ranking_analysis_unit.py
@@ -11,11 +11,14 @@ from cluefin_openapi.kis import _domestic_ranking_analysis as ranking_analysis_m
 from cluefin_openapi.kis._domestic_ranking_analysis import DomesticRankingAnalysis
 from cluefin_openapi.kis._domestic_ranking_analysis_types import (
     HtsInquiryTop20,
+    StockCreditBalanceTop,
+    StockDividendYieldTop,
     StockFinanceRatioRank,
     StockFluctuationRank,
     StockHogaQuantityRank,
     StockMarketCapTop,
     StockProfitabilityIndicatorRank,
+    StockShortSellingTop,
     StockTimeHogaRank,
     TradingVolumeRank,
 )
@@ -30,6 +33,9 @@ RESPONSE_MODELS = {
     "StockFinanceRatioRank": StockFinanceRatioRank,
     "StockTimeHogaRank": StockTimeHogaRank,
     "HtsInquiryTop20": HtsInquiryTop20,
+    "StockDividendYieldTop": StockDividendYieldTop,
+    "StockCreditBalanceTop": StockCreditBalanceTop,
+    "StockShortSellingTop": StockShortSellingTop,
 }
 
 
@@ -224,7 +230,6 @@ def test_get_trading_volume_rank_detailed():
         fid_input_price_1="",
         fid_input_price_2="",
         fid_vol_cnt="",
-        fid_input_date_1="",
     )
 
     # Verify
@@ -244,7 +249,6 @@ def test_get_trading_volume_rank_detailed():
             "FID_INPUT_PRICE_1": "",
             "FID_INPUT_PRICE_2": "",
             "FID_VOL_CNT": "",
-            "FID_INPUT_DATE_1": "",
         },
     )
 

--- a/packages/cluefin-openapi/tests/kis/test_domestic_realtime_quote_unit.py
+++ b/packages/cluefin-openapi/tests/kis/test_domestic_realtime_quote_unit.py
@@ -277,7 +277,7 @@ class TestExecutionFieldNames:
 
 @pytest.fixture
 def sample_orderbook_data() -> list[str]:
-    """Generate sample orderbook data (59 fields)."""
+    """Generate sample orderbook data (62 fields)."""
     return [
         "005930",  # mksc_shrn_iscd
         "093000",  # bsop_hour
@@ -338,6 +338,9 @@ def sample_orderbook_data() -> list[str]:
         "100",  # ovtm_total_askp_icdc
         "-200",  # ovtm_total_bidp_icdc
         "00",  # stck_deal_cls_code
+        "70050",  # mid_prc
+        "12345",  # midp_total_rsqn
+        "0",  # midp_cls_code
     ]
 
 
@@ -400,17 +403,17 @@ class TestParseOrderbookData:
         with pytest.raises(ValueError) as exc_info:
             DomesticRealtimeQuote.parse_orderbook_data(short_data)
 
-        assert "Expected at least 59 fields, got 3" in str(exc_info.value)
+        assert "Expected at least 62 fields, got 3" in str(exc_info.value)
 
     def test_parse_orderbook_data_empty_list_raises_error(self):
         """Test that empty list raises ValueError."""
         with pytest.raises(ValueError) as exc_info:
             DomesticRealtimeQuote.parse_orderbook_data([])
 
-        assert "Expected at least 59 fields, got 0" in str(exc_info.value)
+        assert "Expected at least 62 fields, got 0" in str(exc_info.value)
 
     def test_parse_orderbook_data_batched_10_records(self, sample_orderbook_data):
-        """Test parsing 10 batched orderbook records (10 × 59 = 590 fields)."""
+        """Test parsing 10 batched orderbook records (10 × 62 = 620 fields)."""
         batched_data = []
         for i in range(10):
             record = sample_orderbook_data.copy()
@@ -427,23 +430,24 @@ class TestParseOrderbookData:
             assert item.askp1 == str(70100 + i * 10)
 
     def test_parse_orderbook_data_single_record_with_extra_fields(self, sample_orderbook_data):
-        """Test single record with 62 fields (59 + 3 extra) - forward compatibility."""
-        # Simulate API returning 62 fields (actual case mentioned in docs)
+        """Test single record with 65 fields (62 + 3 extra) - forward compatibility."""
+        # Simulate API returning extra fields beyond the documented 62
         data = sample_orderbook_data + ["extra1", "extra2", "extra3"]
 
         result = DomesticRealtimeQuote.parse_orderbook_data(data)
 
         assert isinstance(result, list)
         assert len(result) == 1
-        # Extra fields should be ignored, first 59 used
+        # Extra fields should be ignored, first 62 used
         assert result[0].mksc_shrn_iscd == "005930"
         assert result[0].stck_deal_cls_code == "00"
+        assert result[0].midp_cls_code == "0"
 
     def test_parse_orderbook_data_batched_with_extra_fields_per_record(self):
-        """Test batched records where each has extra fields."""
-        # 5 records × 62 fields per record (59 + 3 extras) = 310 total
-        # Should parse floor(310 / 59) = 5 complete records
-        data = ["value"] * (5 * 62)
+        """Test batched records with trailing extra fields."""
+        # 5 records × 62 fields + 3 trailing extras = 313 total
+        # Should parse floor(313 / 62) = 5 complete records
+        data = ["value"] * (5 * 62 + 3)
 
         result = DomesticRealtimeQuote.parse_orderbook_data(data)
 
@@ -456,9 +460,9 @@ class TestDomesticRealtimeOrderbookItem:
     """Test DomesticRealtimeOrderbookItem Pydantic model."""
 
     def test_model_field_count(self):
-        """Test that model has exactly 59 fields."""
-        assert len(ORDERBOOK_FIELD_NAMES) == 59
-        assert len(DomesticRealtimeOrderbookItem.model_fields) == 59
+        """Test that model has exactly 62 fields."""
+        assert len(ORDERBOOK_FIELD_NAMES) == 62
+        assert len(DomesticRealtimeOrderbookItem.model_fields) == 62
 
     def test_model_validation_from_dict(self, sample_orderbook_data):
         """Test model can be created from dictionary."""
@@ -478,16 +482,16 @@ class TestDomesticRealtimeOrderbookItem:
         assert item.mksc_shrn_iscd == "005930"
 
         # Last field
-        assert ORDERBOOK_FIELD_NAMES[58] == "stck_deal_cls_code"
-        assert item.stck_deal_cls_code == "00"
+        assert ORDERBOOK_FIELD_NAMES[61] == "midp_cls_code"
+        assert item.midp_cls_code == "0"
 
 
 class TestOrderbookFieldNames:
     """Test ORDERBOOK_FIELD_NAMES constant."""
 
     def test_field_names_count(self):
-        """Test that field names list has 59 entries."""
-        assert len(ORDERBOOK_FIELD_NAMES) == 59
+        """Test that field names list has 62 entries."""
+        assert len(ORDERBOOK_FIELD_NAMES) == 62
 
     def test_field_names_all_strings(self):
         """Test that all field names are strings."""

--- a/packages/cluefin-openapi/tests/kis/test_kis_domestic_stock_info_integration.py
+++ b/packages/cluefin-openapi/tests/kis/test_kis_domestic_stock_info_integration.py
@@ -298,7 +298,8 @@ def test_get_ksd_paid_in_capital_increase_schedule(client: HttpClient, date_rang
     )
 
     assert response is not None
-    assert hasattr(response.body, "output1")
+    # 이 API만 예외적으로 응답 컨테이너가 output1이 아닌 output
+    assert hasattr(response.body, "output")
 
 
 @pytest.mark.integration

--- a/packages/cluefin-openapi/tests/kis/test_overseas_market_analysis_integration.py
+++ b/packages/cluefin-openapi/tests/kis/test_overseas_market_analysis_integration.py
@@ -93,7 +93,7 @@ def test_get_stock_volume_surge_nasdaq(client: HttpClient, common_params):
         keyb=common_params["keyb"],
         auth=common_params["auth"],
         excd="NAS",  # NASDAQ
-        mixn="3",  # 5 minutes ago
+        minx="3",  # 5 minutes ago
         vol_rang=common_params["vol_rang"],
     )
 
@@ -108,7 +108,7 @@ def test_get_stock_volume_surge_tse(client: HttpClient, common_params):
         keyb=common_params["keyb"],
         auth=common_params["auth"],
         excd="TSE",  # Tokyo
-        mixn="4",  # 10 minutes ago
+        minx="4",  # 10 minutes ago
         vol_rang="2",  # 1000+ shares
     )
 
@@ -624,12 +624,10 @@ def test_market_cap_rank_multiple_exchanges(client: HttpClient, exchange_code, e
 def test_invalid_exchange_code(client: HttpClient):
     """Test handling of invalid exchange code."""
     try:
-        response = client.overseas_market_analysis.get_stock_price_rise_fall(
-            keyb="",
-            auth="",
+        response = client.overseas_market_analysis.get_stock_price_fluctuation(
             excd="INVALID",  # Invalid exchange code
             gubn="1",
-            mixn="3",
+            minx="3",
             vol_rang="0",
         )
         # If no exception, check for error in response


### PR DESCRIPTION
## 관련 이슈

_(관련 이슈 없음)_

## 변경 사항

KIS 클라이언트가 실제 API 명세와 다르게 구현된 곳이 많아(잘못된 tr_id, 오타 난
파라미터, 실응답과 다른 응답 모델) 일부 메서드는 호출 자체가 불가능한 상태였다.
KIS 개발자 포털 공개 문서 API에서 국내주식 135개·해외주식 50개 명세를 덤프해
국내 7개·해외 4개 클래스의 전 메서드와 대조하고, 코드가 틀린 30건을 수정했다.

**국내주식 (12건)** — 커밋 4c8323d
- 매수가능조회: tr_id 오류(TTTC0802R→TTTC8908R) + 잔고조회 파라미터를 복붙한
  요청 바디 전면 교체, 응답 모델 재정의
- 기관/외국인 매매종목가집계: 관심종목 API를 잘못 호출하던 것을
  foreign-institution-total(FHPTJ04400000)로 교체 (CLI 핸들러 포함)
- 예약주문 필수 필드 누락(PDNO, TMNL_MDIA_KIND_CD), 퇴직연금 파라미터 오류
  (USER_DVSN_CD→ACCA_DVSN_CD), 시간외현재가 `headers=heders` 오타(NameError) 등
- 실시간호가(H0STASP0) 파싱을 59→62필드로 확장(중간가 3필드) — 배치 수신 시
  레코드 경계가 밀리던 문제 해소
- 배당률·신용잔고·공매도 상위, 유상증자일정 등 응답 컨테이너/모델 구조 교정

**해외주식 (18건)** — 커밋 40a1094
- 주문류 8개 메서드의 tr_id가 미국·실전 값으로 하드코딩 → tr_id를 Literal
  인자로 받도록 변경(매수/매도×6거래소×실전/모의). 주문에 필수 필드
  ORD_SVR_DVSN_CD 추가, 바디 키 오타 ACNO_PRDT_CD→ACNT_PRDT_CD 수정
- 응답 모델 구조 오류 정리: output2/output3 병합, 실제 키(output1)와 다른
  필드명, envelope 필드가 item에 섞인 것 등 6건
- 가격급등락 URL 오타(price-fluctuation→price-fluct), MIXN→MINX 파라미터 오타

**문서 쪽이 틀린 것은 코드 유지** (통합 테스트로 실증):
inquire-daily-trade-volume의 문서에 없는 필수 `*_1` 파라미터, 실서버가 오타 난
키를 반환하는 2건(`itewhol_loan_rmnd_ratem name`, 체결강도상위의 name/ename)은
AliasChoices로 문서·실서버 키를 모두 수용했다.

## 변경 유형

- [x] 버그 수정 (`fix`)
- [ ] 새로운 기능 추가 (`feat`)
- [ ] 기존 기능 개선 (`feat`)
- [ ] 리팩토링 (`refactor`)
- [ ] 테스트 추가/수정 (`test`)
- [ ] 문서 수정 (`docs`)
- [ ] 의존성 업데이트 (`chore`)
- [ ] CI/CD (`ci`)

## 영향 범위

- [x] cluefin-openapi
- [ ] cluefin-ta
- [ ] cluefin-xbrl
- [x] cluefin-cli
- [ ] cluefin-desk
- [ ] 루트 프로젝트 설정

## 테스트

- KIS 단위 518개·CLI 274개 통과
- 통합 테스트는 변경 범위인 KIS만 실행: 국내 106통과+3skip(HTS ID 필요,
  기존과 동일), 해외 54개 통과(미국장 개장 중 실데이터로 검증).
  kiwoom·realtime 마커는 이번 변경과 무관해 실행하지 않음
- foreign-institution-total·해외 주문류는 모의투자 미지원이라 dev 키로
  실호출 검증 불가 — 실계좌로 장중 1회 확인 권장

- [x] 단위 테스트 통과 (`uv run pytest -m "not integration"`)
- [ ] 통합 테스트 통과 (`uv run pytest -m "integration"`) ← KIS 범위만 실행(위 참고)
- [ ] 테스트 불필요 (문서, 설정 변경 등)

## 체크리스트

- [x] `uv run ruff format . && uv run ruff check . --fix` 실행
- [x] 커밋 메시지가 컨벤션을 따름 (`type(scope): 설명`)
- [x] `.env`, 시크릿, 인증 정보 미포함
- [ ] 관련 문서 업데이트 완료 (해당 시) ← 해당 문서 없음

## 참고 사항 (선택)

**Breaking change**: `OverseasAccount.request_stock_order` 등 해외 주문류
8개 메서드가 tr_id를 첫 번째 필수 인자로 받도록 시그니처가 변경됨.
`DomesticMarketAnalysis.get_institutional_foreign_trading_aggregate`와
`get_buy_sell_volume_by_stock_daily`, `OverseasMarketAnalysis`의
`get_stock_volume_surge`(mixn→minx)도 시그니처가 바뀜.
