### PR TITLE
feat(openapi-ts): NH투자증권 PLUG 클라이언트 이식 — REST 51종·WebSocket (v0.4.0)

### DIFF
--- a/packages/cluefin-openapi-ts/AGENTS.md
+++ b/packages/cluefin-openapi-ts/AGENTS.md
@@ -4,10 +4,16 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 
 ## Scope boundary (easy to get wrong)
 
-- The Kiwoom side implements **domestic endpoints only**. Kiwoom US-stock REST and all
-  Kiwoom WebSocket support are Python-only (sibling `cluefin-openapi`) and out of scope
-  here. The `src/kis/overseas-*` files are **KIS** overseas-stock APIs and *are* in
-  scope — don't confuse the two.
+- "해외/overseas" means three different things here, and only one of them is out of scope:
+  - `src/kis/overseas-*` — **KIS** overseas stock. In scope.
+  - `src/nhplug/overseas-stock-*` — **NH PLUG gbstock** (`/gbstock/...`). In scope, REST +
+    WebSocket. The class/file names say "overseas", the paths and the vendor docs say
+    "gbstock" — same thing.
+  - **Kiwoom** US stock. Out of scope: the Kiwoom side implements domestic endpoints only,
+    and Kiwoom US-stock REST plus all Kiwoom WebSocket support are Python-only (sibling
+    `cluefin-openapi`).
+- NH PLUG's other asset classes (krfuture·gbfuture·krbond·krgold) have public specs but are
+  not ported here — only common·krstock·gbstock are.
 
 ## Coupling to the Python sibling
 
@@ -20,8 +26,20 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 - The KIS token cache JSON (`<repo>/data/.kis_token_cache.json`) is **shared with the
   Python package** — same file, same snake_case format — because KIS allows only 1
   token generation per minute. Don't change the format on one side only.
+- The nhplug token cache file is **also shared with Python**, but is scoped by **app_key
+  only** (`nhplugTokenCacheFileName`), not by env — one NH token is issued on the live
+  domain and used for both live and mock calls. The KIS store is env-scoped. Don't
+  "unify" the two schemes; changing either breaks cache sharing with Python.
 - Endpoint-count tests hardcode totals (`tests/core/endpoint-count.test.ts`, KIS
   contract tests); bump them whenever metadata changes.
+- `dist/types/index.d.ts` is **string-templated by hand**, not emitted by `tsc`. Domain
+  classes come from metadata, but everything else (auth, token cache, socket client,
+  standalone consts) has to be typed out literally in `scripts/generate-types.mjs` — it
+  silently under-declares otherwise. `tests/nhplug/dts-drift.test.ts` guards the nhplug
+  surface by diffing the generator output against the runtime exports of
+  `src/nhplug/index.ts`; there is no equivalent guard for KIS/Kiwoom, and the KIS side is
+  in fact still missing `KisSocketClient`, `KisSocketClientOptions`, `FileTokenCacheStore`
+  and the KIS realtime-quote helpers.
 
 ## Tooling surprises
 
@@ -31,6 +49,17 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
   responses. A new field must be handled with this asymmetry in mind.
 - KIS `custtype` is hardcoded to `'P'` (personal) in the HTTP and socket clients —
   corporate-account calls aren't possible without changing that.
+- `CamelizeKeys` in `src/core/types.ts` deliberately wraps its key mapping in
+  `Uncapitalize` because the runtime `toCamelCase` lowercases the first character. This is
+  invisible for KIS/Kiwoom (lowercase snake_case wire keys) and only shows up on NH PLUG's
+  capitalized envelope keys (`Output_0` → `output0`). Dropping it silently desyncs the
+  declared response types from the values actually returned.
+- nhplug treats **both** `00000` and `XA102` as success (`SUCCESS_RSP_CODES`) — the mock
+  server answers some successful inquiries with `XA102`, so a 00000-only check reports
+  false failures. Keep the list identical to Python's `_model.SUCCESS_RSP_CODES`.
+- An nhplug HTTP 200 can still carry a failing `rsp_cd`; the failure check lives in
+  `NhplugClient.invokeEndpoint` after the HTTP layer, so HTTP-level retry/rate-limit logic
+  never sees those errors.
 
 ## Integration tests
 
@@ -43,5 +72,8 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 ## Stale docs
 
 - `docs/api-coverage-gap.md` is a snapshot: its "미구현" rows for KIS realtime quotes
-  are outdated (those files exist now). The README's KIS quick-start calls
-  `auth.generateToken()`, but the real method is `generate()` — don't copy it verbatim.
+  are outdated (those files exist now), and it predates NH PLUG entirely.
+- (The README's KIS quick-start used to call a non-existent `auth.generateToken()`; it now
+  correctly says `generate()`. Note that Kiwoom really does use `generateToken()`/
+  `revokeToken()` while KIS and NH PLUG use `generate()`/`revoke()` — the asymmetry is
+  real, not a typo.)

--- a/packages/cluefin-openapi-ts/README.md
+++ b/packages/cluefin-openapi-ts/README.md
@@ -7,10 +7,11 @@
 > 지연되거나 충분히 이루어지지 않았을 수 있습니다. 웹소켓 기능을 사용하거나 수정할 때는
 > 이 점을 감안하고, 가능하면 장중에 직접 동작을 확인해 주세요.
 
-한국투자증권(KIS)·키움증권 OpenAPI TypeScript 클라이언트.
+한국투자증권(KIS)·키움증권·NH투자증권(PLUG) OpenAPI TypeScript 클라이언트.
 
 - **KIS**: 국내/해외주식·장내채권 REST API + 실시간 WebSocket 시세, 토큰 파일 캐시
 - **키움**: 국내주식 REST API (해외주식·WebSocket은 파이썬 패키지 `cluefin-openapi` 전용)
+- **NH PLUG**: 공통 2 + 국내주식 31 + 해외주식 18 = REST 51개 엔드포인트 + 실시간 WebSocket 시세
 - 요청/응답 Zod 검증, 응답 키 자동 camelCase 변환, 재시도·rate limit 내장
 
 ## 설치
@@ -30,9 +31,14 @@ KIS_ENV=dev                    # dev(모의투자) | prod(실전)
 KIWOOM_APP_KEY=your_app_key
 KIWOOM_SECRET_KEY=your_secret_key
 KIWOOM_ENV=dev                 # dev(모의투자) | prod(실전)
+
+NHPLUG_APP_KEY=your_app_key
+NHPLUG_SECRET_KEY=your_secret_key
+NHPLUG_ENV=dev                 # dev(모의투자, moapi) | prod(운영, 실주문)
 ```
 
-API 키 발급: [KIS](https://apiportal.koreainvestment.com/) / [키움](https://apiportal.kiwoom.com/)
+API 키 발급: [KIS](https://apiportal.koreainvestment.com/) / [키움](https://apiportal.kiwoom.com/) /
+[NH PLUG](https://www.nhplug.com/)
 
 ## 빠른 시작
 
@@ -87,6 +93,98 @@ const client = new KiwoomClient({ token, env: 'dev' });
 const res = await client.domesticStockInfo.getStockInfo({ stkCd: '005930' });
 console.log(res.body);
 ```
+
+### NH투자증권 (PLUG)
+
+```ts
+import { NhplugAuth, NhplugClient } from 'cluefin-openapi';
+
+// 토큰 발급(`/oauth2/token`)은 **운영 도메인 전용**이고, 발급된 토큰 하나로 운영·모의투자를
+// 모두 호출한다. 그래서 `NhplugAuth`는 `env`를 받지 않는다.
+const auth = new NhplugAuth({ appKey, secretKey });
+const { accessToken } = await auth.generate();
+
+// env: 'dev'(기본값) = 모의투자(moapi.nhplug.com), 'prod' = 운영(api.nhplug.com, 실제 주문 체결)
+const client = new NhplugClient({ token: accessToken, appKey, secretKey, env: 'dev' });
+
+// 1) 계좌 목록을 먼저 조회한다. 이후 조회/주문 API는 모두 `actNo`를 요구한다.
+const accounts = await client.common.getAccountList({});
+const actNo = accounts.body.output0?.[0]?.acctNo;
+
+// 2) 국내주식 현재가 (marketCd: KRX | NXT | UNT(통합시세))
+const price = await client.krstockQuote.currentPrice({ marketCd: 'KRX', iemCd: '005930' });
+
+// 3) 국내주식 잔고
+const balance = await client.krstockInquiry.balance({
+  actNo,
+  bncBseCd: '1', // 주식관련 총 평가(체결기준)
+  ltgAotDitCd: '9', // 전체
+  aetBse: '1', // 순자산
+  qutDitCd: 'UNT', // 통합시세
+});
+```
+
+입력 파라미터는 camelCase(`iemCd`)로 넘기면 와이어 포맷(`iem_cd`)으로 변환되고, 요청 본문은
+`Input_0` 봉투로 감싸집니다. 응답은 `Output_0` → `output0`처럼 camelCase로 변환됩니다.
+연속조회는 이전 응답 헤더의 `cts` 값을 다음 요청 입력의 `cts`로 그대로 넘기면 됩니다.
+
+#### 꼭 알아둘 것
+
+- **`env`를 틀리면 실계좌에 주문이 나갑니다.** `'prod'`는 운영(실제 체결), `'dev'`는
+  모의투자입니다. 기본값은 `'dev'`.
+- **계좌 목록(`common.getAccountList`)을 먼저 호출하세요.** 조회·주문 API는 모두 `actNo`가
+  필요하고, 계좌구분(`acctType`)이 환경과 맞아야 합니다 —
+  `01`(자계좌)·`02`(주문대리인계좌)는 **운영 전용**, `03`(모의투자계좌)은 **모의투자 전용**입니다.
+- **해외주식 시세 4종(`overseasStockQuote.*`)은 운영 도메인 전용**입니다. 모의투자에서 호출하면
+  종목코드와 무관하게 `IGW40019 "종목코드(iem_cd)를 확인해주세요"`로 거절되는데, 이는 잘못된
+  종목코드가 아니라 "모의투자 미제공"이라는 뜻입니다.
+- HTTP 200이어도 본문 `rsp_cd`가 실패일 수 있어 클라이언트가 이를 검사합니다. 성공 코드는
+  `00000`과 `XA102`(모의투자 조회 완료) 두 가지입니다 (`NHPLUG_SUCCESS_RSP_CODES`).
+
+#### 토큰 캐시
+
+토큰 발급은 서버에서 초당 1회로 제한되고, 불필요한 재발급은 계좌 보안 알림을 유발합니다.
+기본은 메모리 캐시이며 `NhplugFileTokenCacheStore`를 쓰면 프로세스를 재시작해도 재사용됩니다.
+파일 포맷은 파이썬 패키지(`cluefin_openapi.nhplug`)와 동일합니다. 캐시 파일 이름은 env가 아니라
+app key로만 구분됩니다 — 토큰 하나를 운영·모의투자가 공유하기 때문입니다.
+
+```ts
+import { NhplugAuth, NhplugFileTokenCacheStore, nhplugTokenCacheFileName } from 'cluefin-openapi';
+
+const auth = new NhplugAuth({
+  appKey,
+  secretKey,
+  tokenCacheStore: new NhplugFileTokenCacheStore(`./data/${nhplugTokenCacheFileName(appKey)}`),
+});
+```
+
+### 실시간 시세 (NH PLUG WebSocket)
+
+REST와 같은 access token을 그대로 씁니다(approval key 없음). 구독 대상은 REST 경로가 아니라
+웹소켓 전용 채널 코드(`tr_cd`)이며, 서버 푸시는 평문 JSON이라 `event.body`로 바로 읽습니다.
+
+```ts
+import { NhplugAuth, NhplugSocketClient } from 'cluefin-openapi';
+
+const auth = new NhplugAuth({ appKey, secretKey });
+const { accessToken } = await auth.generate();
+
+// market: 'kr'(국내, 기본) | 'gb'(해외) — 운영에서만 주소가 갈리고 모의투자는 단일 주소입니다.
+const socket = new NhplugSocketClient({ token: accessToken, env: 'dev', market: 'kr' });
+
+socket.on('connected', async () => {
+  await socket.subscribe('mc', '005930'); // 국내 통합시세 체결가
+});
+
+socket.on('data', (event) => {
+  console.log(event.trId, event.body); // { header: { tr_cd, tr_key }, body: {...} } 의 body
+});
+
+socket.connect();
+```
+
+채널 코드는 대소문자로 갈립니다(해외 실시간 `RC` / 지연 `rc`). 세션을 정리할 때는
+`client.common.closeWebsocketSession({})`를 호출하세요.
 
 ### 실시간 시세 (KIS WebSocket)
 
@@ -159,9 +257,21 @@ prod 전용)를 지원하며, 해외주식·장내채권도 같은 패턴으로 
 | `domesticSector` | 국내주식 섹터 |
 | `domesticTheme` | 국내주식 테마 |
 
+### NH PLUG REST (`NhplugClient`의 getter)
+
+| 모듈 | 설명 | 엔드포인트 |
+|------|------|------|
+| `common` | 공통 (계좌목록·웹소켓 세션해제) | 2 |
+| `krstockOrder` | 국내주식 주문 | 8 |
+| `krstockInquiry` | 국내주식 조회 | 12 |
+| `krstockQuote` | 국내주식 시세 | 11 |
+| `overseasStockOrder` | 해외주식(gbstock) 주문 | 6 |
+| `overseasStockInquiry` | 해외주식(gbstock) 조회 | 8 |
+| `overseasStockQuote` | 해외주식(gbstock) 시세 (**운영 전용**) | 4 |
+
 ## 에러 처리
 
-KIS/키움 각각 전용 에러 클래스 제공 (`ApiError` 상속):
+KIS/키움/NH PLUG 각각 전용 에러 클래스 제공 (`ApiError` 상속):
 
 `Authentication` · `Authorization` · `Validation` · `Server` · `Network` · `Timeout` · `RateLimit`
 

--- a/packages/cluefin-openapi-ts/package-lock.json
+++ b/packages/cluefin-openapi-ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cluefin-openapi",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cluefin-openapi",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "ws": "^8.19.0",

--- a/packages/cluefin-openapi-ts/package.json
+++ b/packages/cluefin-openapi-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cluefin-openapi",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "TypeScript OpenAPI client for KIS and Kiwoom",
   "license": "MIT",
   "author": "kgcrom",

--- a/packages/cluefin-openapi-ts/scripts/generate-metadata.mjs
+++ b/packages/cluefin-openapi-ts/scripts/generate-metadata.mjs
@@ -354,6 +354,33 @@ const buildKiwoomMetadata = (sourceRelativePath, symbolName) => {
   });
 };
 
+const buildNhplugMetadata = (sourceRelativePath, symbolName) => {
+  const sourcePath = resolveWithinRoot(workspaceRoot, sourceRelativePath);
+  const source = fs.readFileSync(sourcePath, 'utf8');
+  const methods = extractMethods(source);
+
+  return methods.map((method) => {
+    // 키움은 클래스 레벨 self.path 하나를 쓰지만, NH PLUG 는 호출마다 경로를 넘긴다.
+    const endpointPath = (method.block.match(/client\.post\(\s*["']([^"']+)["']/) || [])[1] ?? '';
+    const signatureParams = parseSignatureParams(method.signature);
+    const bodyEntries = parseDictFromBlock(method.block, 'body').concat(parseDictAssignments(method.block, 'body'));
+    const { mappings, syntheticParams } = resolveDictEntries(bodyEntries, signatureParams, method.methodName);
+
+    if (!endpointPath) {
+      console.warn(`  [warn] ${symbolName}.${method.methodName}: could not extract endpoint path`);
+    }
+
+    return {
+      methodName: method.methodName,
+      path: endpointPath,
+      bodyMap: applyOverrides(symbolName, method.methodName, Object.fromEntries(mappings)),
+      // 연속조회는 시그니처에 cts kwarg 가 있는지로 판단한다 (헤더는 클라이언트가 조립).
+      supportsCts: /\bcts\b/.test(method.signature),
+      params: stripInternalFields(signatureParams).concat(syntheticParams),
+    };
+  });
+};
+
 const toPascalCase = (camel) => camel.charAt(0).toUpperCase() + camel.slice(1);
 
 const writeTs = (targetRelativePath, symbolName, importPath, data) => {
@@ -490,14 +517,65 @@ const tasks = [
     symbolName: 'domesticOrderEndpoints',
     kind: 'kiwoom',
   },
+  {
+    sourcePath: 'packages/cluefin-openapi/src/cluefin_openapi/nhplug/_common.py',
+    targetPath: 'packages/cluefin-openapi-ts/src/nhplug/metadata/common.ts',
+    symbolName: 'commonEndpoints',
+    kind: 'nhplug',
+  },
+  {
+    sourcePath: 'packages/cluefin-openapi/src/cluefin_openapi/nhplug/_krstock_order.py',
+    targetPath: 'packages/cluefin-openapi-ts/src/nhplug/metadata/krstock-order.ts',
+    symbolName: 'krstockOrderEndpoints',
+    kind: 'nhplug',
+  },
+  {
+    sourcePath: 'packages/cluefin-openapi/src/cluefin_openapi/nhplug/_krstock_inquiry.py',
+    targetPath: 'packages/cluefin-openapi-ts/src/nhplug/metadata/krstock-inquiry.ts',
+    symbolName: 'krstockInquiryEndpoints',
+    kind: 'nhplug',
+  },
+  {
+    sourcePath: 'packages/cluefin-openapi/src/cluefin_openapi/nhplug/_krstock_quote.py',
+    targetPath: 'packages/cluefin-openapi-ts/src/nhplug/metadata/krstock-quote.ts',
+    symbolName: 'krstockQuoteEndpoints',
+    kind: 'nhplug',
+  },
+  {
+    sourcePath: 'packages/cluefin-openapi/src/cluefin_openapi/nhplug/_overseas_stock_order.py',
+    targetPath: 'packages/cluefin-openapi-ts/src/nhplug/metadata/overseas-stock-order.ts',
+    symbolName: 'overseasStockOrderEndpoints',
+    kind: 'nhplug',
+  },
+  {
+    sourcePath: 'packages/cluefin-openapi/src/cluefin_openapi/nhplug/_overseas_stock_inquiry.py',
+    targetPath: 'packages/cluefin-openapi-ts/src/nhplug/metadata/overseas-stock-inquiry.ts',
+    symbolName: 'overseasStockInquiryEndpoints',
+    kind: 'nhplug',
+  },
+  {
+    sourcePath: 'packages/cluefin-openapi/src/cluefin_openapi/nhplug/_overseas_stock_quote.py',
+    targetPath: 'packages/cluefin-openapi-ts/src/nhplug/metadata/overseas-stock-quote.ts',
+    symbolName: 'overseasStockQuoteEndpoints',
+    kind: 'nhplug',
+  },
 ];
 
+const builders = {
+  kis: buildKisMetadata,
+  kiwoom: buildKiwoomMetadata,
+  nhplug: buildNhplugMetadata,
+};
+
+const importTypes = {
+  kis: 'KisEndpointDefinition',
+  kiwoom: 'KiwoomEndpointDefinition',
+  nhplug: 'NhplugEndpointDefinition',
+};
+
 for (const task of tasks) {
-  const data =
-    task.kind === 'kis'
-      ? buildKisMetadata(task.sourcePath, task.symbolName)
-      : buildKiwoomMetadata(task.sourcePath, task.symbolName);
-  const importType = task.kind === 'kis' ? 'KisEndpointDefinition' : 'KiwoomEndpointDefinition';
+  const data = builders[task.kind](task.sourcePath, task.symbolName);
+  const importType = importTypes[task.kind];
   writeTs(task.targetPath, task.symbolName, importType, data);
   console.log(`${task.symbolName}: ${data.length}`);
 }

--- a/packages/cluefin-openapi-ts/scripts/generate-types.mjs
+++ b/packages/cluefin-openapi-ts/scripts/generate-types.mjs
@@ -104,6 +104,40 @@ const kiwoomDomains = [
   { className: 'KiwoomDomesticTheme', metadataPath: 'src/kiwoom/metadata/domestic-theme.ts', prop: 'domesticTheme' },
 ];
 
+const nhplugDomains = [
+  { className: 'NhplugCommon', metadataPath: 'src/nhplug/metadata/common.ts', prop: 'common' },
+  {
+    className: 'NhplugKrstockOrder',
+    metadataPath: 'src/nhplug/metadata/krstock-order.ts',
+    prop: 'krstockOrder',
+  },
+  {
+    className: 'NhplugKrstockInquiry',
+    metadataPath: 'src/nhplug/metadata/krstock-inquiry.ts',
+    prop: 'krstockInquiry',
+  },
+  {
+    className: 'NhplugKrstockQuote',
+    metadataPath: 'src/nhplug/metadata/krstock-quote.ts',
+    prop: 'krstockQuote',
+  },
+  {
+    className: 'NhplugOverseasStockOrder',
+    metadataPath: 'src/nhplug/metadata/overseas-stock-order.ts',
+    prop: 'overseasStockOrder',
+  },
+  {
+    className: 'NhplugOverseasStockInquiry',
+    metadataPath: 'src/nhplug/metadata/overseas-stock-inquiry.ts',
+    prop: 'overseasStockInquiry',
+  },
+  {
+    className: 'NhplugOverseasStockQuote',
+    metadataPath: 'src/nhplug/metadata/overseas-stock-quote.ts',
+    prop: 'overseasStockQuote',
+  },
+];
+
 const kisDomainDecls = kisDomains
   .map((d) => renderDomainClass(d.className, extractMethodNames(d.metadataPath)))
   .join('\n\n');
@@ -112,8 +146,13 @@ const kiwoomDomainDecls = kiwoomDomains
   .map((d) => renderDomainClass(d.className, extractMethodNames(d.metadataPath)))
   .join('\n\n');
 
+const nhplugDomainDecls = nhplugDomains
+  .map((d) => renderDomainClass(d.className, extractMethodNames(d.metadataPath)))
+  .join('\n\n');
+
 const kisClientProps = kisDomains.map((d) => `  readonly ${d.prop}: ${d.className};`).join('\n');
 const kiwoomClientProps = kiwoomDomains.map((d) => `  readonly ${d.prop}: ${d.className};`).join('\n');
+const nhplugClientProps = nhplugDomains.map((d) => `  readonly ${d.prop}: ${d.className};`).join('\n');
 
 const content = `export type ApiEnv = 'dev' | 'prod';
 
@@ -148,6 +187,14 @@ export interface KiwoomEndpointDefinition {
   apiId: string;
   bodyMap: Record<string, string>;
   headerParamMap: Record<string, string>;
+  params: EndpointParamDefinition[];
+}
+
+export interface NhplugEndpointDefinition {
+  methodName: string;
+  path: string;
+  bodyMap: Record<string, string>;
+  supportsCts: boolean;
   params: EndpointParamDefinition[];
 }
 
@@ -190,6 +237,15 @@ export class KiwoomServerError extends ApiServerError {}
 export class KiwoomNetworkError extends ApiNetworkError {}
 export class KiwoomTimeoutError extends ApiTimeoutError {}
 export class KiwoomRateLimitError extends ApiRateLimitError {}
+
+export class NhplugApiError extends ApiError {}
+export class NhplugAuthenticationError extends ApiAuthenticationError {}
+export class NhplugAuthorizationError extends ApiAuthorizationError {}
+export class NhplugValidationError extends ApiValidationError {}
+export class NhplugServerError extends ApiServerError {}
+export class NhplugNetworkError extends ApiNetworkError {}
+export class NhplugTimeoutError extends ApiTimeoutError {}
+export class NhplugRateLimitError extends ApiRateLimitError {}
 
 export interface TokenCacheEntry {
   accessToken: string;
@@ -292,6 +348,26 @@ ${kiwoomDomainDecls}
 export class KiwoomClient {
   constructor(options: KiwoomClientOptions);
 ${kiwoomClientProps}
+}
+
+export interface NhplugClientOptions {
+  token: string;
+  appKey: string;
+  secretKey: string;
+  env?: ApiEnv;
+  debug?: boolean;
+  timeoutMs?: number;
+  maxRetries?: number;
+  rateLimitRequestsPerSecond?: number;
+  rateLimitBurst?: number;
+  fetchImpl?: typeof fetch;
+}
+
+${nhplugDomainDecls}
+
+export class NhplugClient {
+  constructor(options: NhplugClientOptions);
+${nhplugClientProps}
 }
 `;
 

--- a/packages/cluefin-openapi-ts/scripts/generate-types.mjs
+++ b/packages/cluefin-openapi-ts/scripts/generate-types.mjs
@@ -8,8 +8,6 @@ const packageRoot = path.resolve(scriptDir, '..');
 const typesDir = path.join(packageRoot, 'dist', 'types');
 const typesPath = path.join(typesDir, 'index.d.ts');
 
-fs.mkdirSync(typesDir, { recursive: true });
-
 const extractMethodNames = (metadataRelPath) => {
   const fullPath = path.join(packageRoot, metadataRelPath);
   const source = fs.readFileSync(fullPath, 'utf8');
@@ -164,6 +162,85 @@ export interface ApiResponse<TBody = Record<string, unknown>> {
 export interface RateLimitOptions {
   requestsPerSecond: number;
   burst: number;
+}
+
+export interface Logger {
+  debug(message: string, context?: Record<string, unknown>): void;
+  warn(message: string, context?: Record<string, unknown>): void;
+  error(message: string, context?: Record<string, unknown>): void;
+}
+
+export const consoleLogger: Logger;
+export const silentLogger: Logger;
+
+export type SubscriptionType = '1' | '2';
+export type MessageType = 'PINGPONG' | 'DATA' | 'SYSTEM';
+export type WebSocketEventType =
+  | 'data'
+  | 'connected'
+  | 'disconnected'
+  | 'error'
+  | 'subscribed'
+  | 'unsubscribed'
+  | 'system';
+
+export interface WebSocketMessage {
+  messageType: MessageType;
+  trId?: string | undefined;
+  trKey?: string | undefined;
+  data?: string[] | undefined;
+  body?: Record<string, unknown> | undefined;
+  raw: string;
+  encrypted: boolean;
+}
+
+export interface WebSocketEvent {
+  eventType: WebSocketEventType;
+  trId?: string;
+  trKey?: string;
+  data?: { values: string[]; encrypted: boolean };
+  body?: Record<string, unknown>;
+  error?: Error;
+  raw?: string;
+}
+
+export interface BaseWebSocketClientOptions {
+  url: string;
+  rateLimitBurst: number;
+  rateLimitRequestsPerSecond: number;
+}
+
+export interface BaseWebSocketClientEvents {
+  data: [event: WebSocketEvent];
+  connected: [event: WebSocketEvent];
+  disconnected: [event: WebSocketEvent];
+  error: [event: WebSocketEvent];
+  subscribed: [event: WebSocketEvent];
+  unsubscribed: [event: WebSocketEvent];
+  system: [event: WebSocketEvent];
+}
+
+export class BaseWebSocketClient {
+  constructor(options: BaseWebSocketClientOptions);
+  readonly connected: boolean;
+  readonly subscriptions: Map<string, string>;
+  connect(): void;
+  close(): void;
+  subscribe(trId: string, trKey: string): Promise<void>;
+  unsubscribe(trId: string, trKey: string): Promise<void>;
+  parseMessage(raw: string): WebSocketMessage;
+  on<K extends keyof BaseWebSocketClientEvents>(
+    eventType: K,
+    listener: (...args: BaseWebSocketClientEvents[K]) => void,
+  ): this;
+  once<K extends keyof BaseWebSocketClientEvents>(
+    eventType: K,
+    listener: (...args: BaseWebSocketClientEvents[K]) => void,
+  ): this;
+  off<K extends keyof BaseWebSocketClientEvents>(
+    eventType: K,
+    listener: (...args: BaseWebSocketClientEvents[K]) => void,
+  ): this;
 }
 
 export interface EndpointParamDefinition {
@@ -350,6 +427,69 @@ export class KiwoomClient {
 ${kiwoomClientProps}
 }
 
+export const NHPLUG_AUTH_BASE_URL: string;
+
+export interface NhplugTokenCacheEntry {
+  accessToken: string;
+  scope: string;
+  tokenType: string;
+  expiresIn: number;
+  cachedAt: string;
+}
+
+export interface NhplugTokenCacheStore {
+  get(): Promise<NhplugTokenCacheEntry | null>;
+  set(entry: NhplugTokenCacheEntry): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export class NhplugMemoryTokenCacheStore implements NhplugTokenCacheStore {
+  get(): Promise<NhplugTokenCacheEntry | null>;
+  set(entry: NhplugTokenCacheEntry): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export class NhplugFileTokenCacheStore implements NhplugTokenCacheStore {
+  constructor(filePath: string);
+  get(): Promise<NhplugTokenCacheEntry | null>;
+  set(entry: NhplugTokenCacheEntry): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export function nhplugTokenCacheFileName(appKey?: string): string;
+
+export interface NhplugAuthOptions {
+  appKey: string;
+  secretKey: string;
+  tokenCacheStore?: NhplugTokenCacheStore;
+  fetchImpl?: typeof fetch;
+}
+
+export interface NhplugTokenResponse {
+  accessToken: string;
+  scope: string;
+  tokenType: string;
+  expiresIn: number;
+}
+
+export interface NhplugTokenRevokeResponse {
+  code?: string | number | undefined;
+  message?: string | undefined;
+  errorCode?: string | undefined;
+  errorDescription?: string | undefined;
+}
+
+export class NhplugAuth {
+  constructor(options: NhplugAuthOptions);
+  generate(): Promise<NhplugTokenResponse>;
+  revoke(
+    token?: string,
+    tokenTypeHint?: 'access_token' | 'refresh_token',
+  ): Promise<NhplugTokenRevokeResponse>;
+}
+
+export const NHPLUG_SUCCESS_RSP_CODES: readonly string[];
+
 export interface NhplugClientOptions {
   token: string;
   appKey: string;
@@ -361,6 +501,11 @@ export interface NhplugClientOptions {
   rateLimitRequestsPerSecond?: number;
   rateLimitBurst?: number;
   fetchImpl?: typeof fetch;
+  logger?: Logger;
+}
+
+export declare class NhplugDomainBase {
+  constructor(client: NhplugClient, endpoints: readonly NhplugEndpointDefinition[]);
 }
 
 ${nhplugDomainDecls}
@@ -368,8 +513,34 @@ ${nhplugDomainDecls}
 export class NhplugClient {
   constructor(options: NhplugClientOptions);
 ${nhplugClientProps}
+  invokeEndpoint(definition: NhplugEndpointDefinition, input: Record<string, unknown>): Promise<ApiResponse>;
+}
+
+export type NhplugMarket = 'kr' | 'gb';
+
+export interface NhplugSocketClientOptions {
+  token: string;
+  env?: ApiEnv;
+  market?: NhplugMarket;
+  rateLimitRequestsPerSecond?: number;
+  rateLimitBurst?: number;
+}
+
+export function getNhplugSocketUrl(env: ApiEnv, market: NhplugMarket): string;
+
+export class NhplugSocketClient extends BaseWebSocketClient {
+  constructor(options: NhplugSocketClientOptions);
+  readonly env: ApiEnv;
+  readonly market: NhplugMarket;
 }
 `;
 
-fs.writeFileSync(typesPath, content, 'utf8');
-console.log(`Wrote ${path.relative(packageRoot, typesPath)}`);
+/** 생성될 `dist/types/index.d.ts` 본문. 드리프트 테스트가 빌드 없이 검사할 수 있도록 export 한다. */
+export const typesContent = content;
+
+// 스크립트로 직접 실행될 때만 파일을 쓴다 (테스트에서 import 해도 dist 를 건드리지 않도록).
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  fs.mkdirSync(typesDir, { recursive: true });
+  fs.writeFileSync(typesPath, content, 'utf8');
+  console.log(`Wrote ${path.relative(packageRoot, typesPath)}`);
+}

--- a/packages/cluefin-openapi-ts/src/core/errors.ts
+++ b/packages/cluefin-openapi-ts/src/core/errors.ts
@@ -56,3 +56,12 @@ export class KiwoomServerError extends ApiServerError {}
 export class KiwoomNetworkError extends ApiNetworkError {}
 export class KiwoomTimeoutError extends ApiTimeoutError {}
 export class KiwoomRateLimitError extends ApiRateLimitError {}
+
+export class NhplugApiError extends ApiError {}
+export class NhplugAuthenticationError extends ApiAuthenticationError {}
+export class NhplugAuthorizationError extends ApiAuthorizationError {}
+export class NhplugValidationError extends ApiValidationError {}
+export class NhplugServerError extends ApiServerError {}
+export class NhplugNetworkError extends ApiNetworkError {}
+export class NhplugTimeoutError extends ApiTimeoutError {}
+export class NhplugRateLimitError extends ApiRateLimitError {}

--- a/packages/cluefin-openapi-ts/src/core/types.ts
+++ b/packages/cluefin-openapi-ts/src/core/types.ts
@@ -6,10 +6,13 @@ type CamelCase<S extends string> = S extends `${infer P}_${infer Q}${infer R}`
   ? `${P}${Uppercase<Q>}${CamelCase<R>}`
   : S;
 
+// 런타임 `toCamelCase` 는 변환 후 첫 글자를 낮춘다(`Output_0` → `output0`). 타입 쪽도
+// `Uncapitalize` 로 같은 규칙을 적용해야 한다 — 와이어 키가 대문자로 시작하는 NH PLUG
+// 봉투에서만 드러나는 차이이고, 소문자 snake_case 를 쓰는 KIS·키움에는 영향이 없다.
 export type CamelizeKeys<T> = T extends (infer U)[]
   ? CamelizeKeys<U>[]
   : T extends Record<string, unknown>
-    ? { [K in keyof T as K extends string ? CamelCase<K> : K]: CamelizeKeys<T[K]> }
+    ? { [K in keyof T as K extends string ? Uncapitalize<CamelCase<K>> : K]: CamelizeKeys<T[K]> }
     : T;
 
 export interface ApiResponse<TBody = Record<string, unknown>> {
@@ -58,6 +61,14 @@ export interface KiwoomEndpointDefinition extends EndpointBaseDefinition {
   apiId: string;
   bodyMap: Record<string, string>;
   headerParamMap: Record<string, string>;
+  responseSchema?: z.ZodTypeAny;
+}
+
+export interface NhplugEndpointDefinition extends EndpointBaseDefinition {
+  path: string;
+  bodyMap: Record<string, string>;
+  /** 연속조회(페이지네이션) 지원 여부. true 인 경우에만 `cts`/`cts_flag` 요청 헤더를 붙인다. */
+  supportsCts: boolean;
   responseSchema?: z.ZodTypeAny;
 }
 

--- a/packages/cluefin-openapi-ts/src/core/validation.ts
+++ b/packages/cluefin-openapi-ts/src/core/validation.ts
@@ -36,3 +36,14 @@ export const kiwoomEnvelopeSchema = z
     return_msg: z.string().optional(),
   })
   .passthrough();
+
+// NH PLUG 응답 봉투. 스펙(자산군 openapi.json)은 `message` 블록을 명세하지만 실서버는
+// null 을 내려주고 `rsp_cd`/`rsp_msg` 로 응답하므로 셋 다 optional 로 둔다.
+// `Output_0`, `Output_1`… 블록은 API 마다 객체/배열이 달라 passthrough 로 통과시킨다.
+export const nhplugEnvelopeSchema = z
+  .object({
+    rsp_cd: z.string().optional(),
+    rsp_msg: z.string().optional(),
+    message: z.unknown().optional(),
+  })
+  .passthrough();

--- a/packages/cluefin-openapi-ts/src/core/websocket.ts
+++ b/packages/cluefin-openapi-ts/src/core/websocket.ts
@@ -4,12 +4,22 @@ import { TokenBucket } from './rate-limiter';
 
 export type SubscriptionType = '1' | '2';
 export type MessageType = 'PINGPONG' | 'DATA' | 'SYSTEM';
-export type WebSocketEventType = 'data' | 'connected' | 'disconnected' | 'error' | 'subscribed' | 'unsubscribed';
+export type WebSocketEventType =
+  | 'data'
+  | 'connected'
+  | 'disconnected'
+  | 'error'
+  | 'subscribed'
+  | 'unsubscribed'
+  | 'system';
 
 export interface WebSocketMessage {
   messageType: MessageType;
   trId?: string | undefined;
+  trKey?: string | undefined;
   data?: string[] | undefined;
+  /** JSON 푸시를 쓰는 벤더(NH PLUG)용 파싱된 body. 파이프 포맷(KIS)에서는 비어 있다. */
+  body?: Record<string, unknown> | undefined;
   raw: string;
   encrypted: boolean;
 }
@@ -19,6 +29,8 @@ export interface WebSocketEvent {
   trId?: string;
   trKey?: string;
   data?: { values: string[]; encrypted: boolean };
+  /** JSON 푸시를 쓰는 벤더(NH PLUG)용 응답 body. */
+  body?: Record<string, unknown>;
   error?: Error;
   raw?: string;
 }
@@ -36,6 +48,7 @@ export interface BaseWebSocketClientEvents {
   error: [event: WebSocketEvent];
   subscribed: [event: WebSocketEvent];
   unsubscribed: [event: WebSocketEvent];
+  system: [event: WebSocketEvent];
 }
 
 export class BaseWebSocketClient extends EventEmitter {
@@ -131,7 +144,7 @@ export class BaseWebSocketClient extends EventEmitter {
     throw new Error('buildSubscriptionMessage must be implemented by subclass');
   }
 
-  private handleMessage(raw: string): void {
+  protected handleMessage(raw: string): void {
     const message = this.parseMessage(raw);
 
     if (message.messageType === 'PINGPONG') {
@@ -169,7 +182,7 @@ export class BaseWebSocketClient extends EventEmitter {
     return { messageType: 'SYSTEM', raw, encrypted: false };
   }
 
-  private emitEvent(event: WebSocketEvent): void {
+  protected emitEvent(event: WebSocketEvent): void {
     this.emit(event.eventType, event);
   }
 }

--- a/packages/cluefin-openapi-ts/src/index.ts
+++ b/packages/cluefin-openapi-ts/src/index.ts
@@ -23,6 +23,14 @@ export {
   KiwoomServerError,
   KiwoomTimeoutError,
   KiwoomValidationError,
+  NhplugApiError,
+  NhplugAuthenticationError,
+  NhplugAuthorizationError,
+  NhplugNetworkError,
+  NhplugRateLimitError,
+  NhplugServerError,
+  NhplugTimeoutError,
+  NhplugValidationError,
 } from './core/errors';
 export type { Logger } from './core/logger';
 export { consoleLogger, silentLogger } from './core/logger';
@@ -32,6 +40,7 @@ export type {
   EndpointParamDefinition,
   KisEndpointDefinition,
   KiwoomEndpointDefinition,
+  NhplugEndpointDefinition,
   RateLimitOptions,
 } from './core/types';
 export type {
@@ -47,3 +56,4 @@ export { BaseWebSocketClient } from './core/websocket';
 
 export * from './kis';
 export * from './kiwoom';
+export * from './nhplug';

--- a/packages/cluefin-openapi-ts/src/nhplug/auth.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/auth.ts
@@ -1,0 +1,185 @@
+import { z } from 'zod';
+import {
+  NhplugApiError,
+  NhplugAuthenticationError,
+  NhplugNetworkError,
+  NhplugServerError,
+  NhplugValidationError,
+} from '../core/errors';
+import { MemoryTokenCacheStore, type TokenCacheEntry, type TokenCacheStore } from './token-cache';
+
+const tokenResponseSchema = z.object({
+  access_token: z.string(),
+  scope: z.string(),
+  token_type: z.string(),
+  expires_in: z.union([z.string(), z.number()]),
+});
+
+const tokenRevokeResponseSchema = z
+  .object({
+    code: z.union([z.string(), z.number()]).optional(),
+    message: z.string().optional(),
+    error_code: z.string().optional(),
+    error_description: z.string().optional(),
+  })
+  .passthrough();
+
+// 접근토큰 발급/폐기는 운영 도메인 전용(모의투자 미제공). 발급받은 토큰은
+// 운영·모의투자 호출 모두에 사용하므로 NhplugAuth 는 env 를 받지 않는다.
+export const NHPLUG_AUTH_BASE_URL = 'https://api.nhplug.com:8443';
+
+export interface NhplugAuthOptions {
+  appKey: string;
+  secretKey: string;
+  tokenCacheStore?: TokenCacheStore;
+  fetchImpl?: typeof fetch;
+}
+
+export interface NhplugTokenResponse {
+  accessToken: string;
+  scope: string;
+  tokenType: string;
+  expiresIn: number;
+}
+
+export interface NhplugTokenRevokeResponse {
+  code?: string | number | undefined;
+  message?: string | undefined;
+  errorCode?: string | undefined;
+  errorDescription?: string | undefined;
+}
+
+const nowIso = (): string => new Date().toISOString();
+
+// 캐시 만료 버퍼 1시간. 토큰 응답에 절대 만료시각이 없으므로 cachedAt + expiresIn 으로 계산한다.
+const EXPIRY_BUFFER_MS = 60 * 60 * 1000;
+
+const isTokenValid = (entry: TokenCacheEntry): boolean => {
+  const cachedAt = new Date(entry.cachedAt).getTime();
+  if (Number.isNaN(cachedAt)) {
+    return false;
+  }
+  const expiry = cachedAt + entry.expiresIn * 1000;
+  return Date.now() < expiry - EXPIRY_BUFFER_MS;
+};
+
+const formEncode = (data: Record<string, string>): string => new URLSearchParams(data).toString();
+
+export class NhplugAuth {
+  private readonly tokenCacheStore: TokenCacheStore;
+  private readonly fetchImpl: typeof fetch;
+
+  public constructor(private readonly options: NhplugAuthOptions) {
+    this.tokenCacheStore = options.tokenCacheStore ?? new MemoryTokenCacheStore();
+    this.fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  }
+
+  /**
+   * Get a cached token, or issue a new one when it is missing/expiring.
+   *
+   * 접근토큰발급은 서버에서 초당 1회로 제한되며 불필요한 재발급은 계좌 보안 알림을
+   * 유발한다 — 캐시 경로를 우회하지 말 것.
+   */
+  public async generate(): Promise<NhplugTokenResponse> {
+    const cached = await this.tokenCacheStore.get();
+    if (cached && isTokenValid(cached)) {
+      return {
+        accessToken: cached.accessToken,
+        scope: cached.scope,
+        tokenType: cached.tokenType,
+        expiresIn: cached.expiresIn,
+      };
+    }
+
+    const response = await this.fetchImpl(`${NHPLUG_AUTH_BASE_URL}/oauth2/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: formEncode({
+        appkey: this.options.appKey,
+        appsecretkey: this.options.secretKey,
+        grant_type: 'client_credentials',
+        scope: 'oob',
+      }),
+    });
+
+    if (response.status === 400) {
+      throw new NhplugValidationError('Invalid token request');
+    }
+    if (response.status === 401) {
+      throw new NhplugAuthenticationError('Authentication failed while requesting token');
+    }
+    if (response.status >= 500) {
+      throw new NhplugServerError('NH PLUG token server error');
+    }
+    if (!response.ok) {
+      const body = await response.text().catch(() => '(unable to read body)');
+      throw new NhplugApiError(`Unexpected token response status ${response.status}: ${body}`);
+    }
+
+    let payload: unknown;
+    try {
+      payload = await response.json();
+    } catch (error) {
+      throw new NhplugNetworkError(error instanceof Error ? error.message : 'Failed to parse token response');
+    }
+
+    const parsed = tokenResponseSchema.parse(payload);
+    const token: NhplugTokenResponse = {
+      accessToken: parsed.access_token,
+      scope: parsed.scope,
+      tokenType: parsed.token_type,
+      expiresIn: Number(parsed.expires_in),
+    };
+    await this.tokenCacheStore.set({ ...token, cachedAt: nowIso() });
+    return token;
+  }
+
+  /**
+   * Revoke an access token (`POST /oauth2/revoke`).
+   *
+   * `token` 을 생략하면 캐시에 있는 토큰을 폐기하고 캐시도 함께 비운다.
+   */
+  public async revoke(
+    token?: string,
+    tokenTypeHint: 'access_token' | 'refresh_token' = 'access_token',
+  ): Promise<NhplugTokenRevokeResponse> {
+    const cached = await this.tokenCacheStore.get();
+    const targetToken = token ?? cached?.accessToken;
+    if (!targetToken) {
+      throw new NhplugApiError('Cannot revoke token before generate() is called');
+    }
+
+    const response = await this.fetchImpl(`${NHPLUG_AUTH_BASE_URL}/oauth2/revoke`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: formEncode({
+        token: targetToken,
+        token_type_hint: tokenTypeHint,
+        appkey: this.options.appKey,
+        appsecretkey: this.options.secretKey,
+      }),
+    });
+
+    if (!response.ok) {
+      throw new NhplugApiError(`Failed to revoke token (status ${response.status})`);
+    }
+
+    const parsed = tokenRevokeResponseSchema.parse(await response.json());
+
+    // 폐기된 토큰이 캐시에 남아 재사용되지 않도록 정리
+    if (cached?.accessToken === targetToken) {
+      await this.tokenCacheStore.clear();
+    }
+
+    return {
+      code: parsed.code,
+      message: parsed.message,
+      errorCode: parsed.error_code,
+      errorDescription: parsed.error_description,
+    };
+  }
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/client.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/client.ts
@@ -1,0 +1,280 @@
+import { camelizeKeys, normalizeHeaders } from '../core/case-convert';
+import {
+  ApiAuthenticationError,
+  ApiAuthorizationError,
+  ApiError,
+  ApiNetworkError,
+  ApiRateLimitError,
+  ApiServerError,
+  ApiTimeoutError,
+  ApiValidationError,
+  NhplugApiError,
+  NhplugAuthenticationError,
+  NhplugAuthorizationError,
+  NhplugNetworkError,
+  NhplugRateLimitError,
+  NhplugServerError,
+  NhplugTimeoutError,
+  NhplugValidationError,
+} from '../core/errors';
+import { BaseHttpClient } from '../core/http';
+import { consoleLogger, type Logger } from '../core/logger';
+import type { ApiEnv, ApiResponse, NhplugEndpointDefinition } from '../core/types';
+import { createInputSchema, nhplugEnvelopeSchema } from '../core/validation';
+import { NhplugCommon } from './common';
+import { NhplugKrstockInquiry } from './krstock-inquiry';
+import { NhplugKrstockOrder } from './krstock-order';
+import { NhplugKrstockQuote } from './krstock-quote';
+import { NhplugOverseasStockInquiry } from './overseas-stock-inquiry';
+import { NhplugOverseasStockOrder } from './overseas-stock-order';
+import { NhplugOverseasStockQuote } from './overseas-stock-quote';
+
+/**
+ * body `rsp_cd` 중 성공을 뜻하는 코드.
+ *
+ * 문서상 성공은 00000 뿐이지만, 모의투자 서버는 일부 조회 API 성공에
+ * XA102("모의투자 조회가 완료되었습니다")를 반환한다 (2026-08-22 파이썬 실측).
+ * 00000 만 성공으로 보면 정상 응답이 오탐되므로, 새 성공 코드가 실측되면 여기에 추가한다.
+ * 파이썬 `_model.SUCCESS_RSP_CODES` 와 같은 값을 유지할 것.
+ */
+export const SUCCESS_RSP_CODES: readonly string[] = ['00000', 'XA102'];
+
+export interface NhplugClientOptions {
+  token: string;
+  appKey: string;
+  secretKey: string;
+  env?: ApiEnv;
+  debug?: boolean;
+  timeoutMs?: number;
+  maxRetries?: number;
+  rateLimitRequestsPerSecond?: number;
+  rateLimitBurst?: number;
+  fetchImpl?: typeof fetch;
+  /** Sink for API error logs. Defaults to the console; pass `silentLogger` to mute. */
+  logger?: Logger;
+}
+
+// prod = 운영(실제 주문 체결), dev = 모의투자(moapi)
+const getBaseUrl = (env: ApiEnv): string =>
+  env === 'prod' ? 'https://api.nhplug.com:8443' : 'https://moapi.nhplug.com:8443';
+
+const stringifyParam = (value: unknown): string => (typeof value === 'string' ? value : String(value));
+
+const mapNhplugError = (error: unknown): never => {
+  if (
+    error instanceof NhplugApiError ||
+    error instanceof NhplugValidationError ||
+    error instanceof NhplugAuthenticationError ||
+    error instanceof NhplugAuthorizationError ||
+    error instanceof NhplugRateLimitError ||
+    error instanceof NhplugServerError ||
+    error instanceof NhplugTimeoutError ||
+    error instanceof NhplugNetworkError
+  ) {
+    throw error;
+  }
+  if (error instanceof ApiValidationError) {
+    throw new NhplugValidationError(error.message, error);
+  }
+  if (error instanceof ApiAuthenticationError) {
+    throw new NhplugAuthenticationError(error.message, error);
+  }
+  if (error instanceof ApiAuthorizationError) {
+    throw new NhplugAuthorizationError(error.message, error);
+  }
+  if (error instanceof ApiRateLimitError) {
+    throw new NhplugRateLimitError(error.message, error);
+  }
+  if (error instanceof ApiServerError) {
+    throw new NhplugServerError(error.message, error);
+  }
+  if (error instanceof ApiTimeoutError) {
+    throw new NhplugTimeoutError(error.message, error);
+  }
+  if (error instanceof ApiNetworkError) {
+    throw new NhplugNetworkError(error.message, error);
+  }
+  if (error instanceof ApiError) {
+    throw new NhplugApiError(error.message, error);
+  }
+  throw new NhplugApiError(error instanceof Error ? error.message : 'Unknown NH PLUG client error');
+};
+
+/**
+ * NH PLUG REST client.
+ *
+ * 모든 호출은 `POST` + JSON 바디이며, 요청 파라미터는 `Input_0` 봉투로 감싸 전송한다.
+ * 응답은 `rsp_cd`/`rsp_msg` + `Output_N` 봉투. 연속조회(페이지네이션)는 요청/응답 헤더
+ * `cts`/`cts_flag` 로 처리한다.
+ */
+export class NhplugClient {
+  private readonly baseUrl: string;
+  private readonly http: BaseHttpClient;
+  private readonly token: string;
+  private readonly appKey: string;
+  private readonly secretKey: string;
+  private readonly logger: Logger;
+
+  private commonInstance?: NhplugCommon;
+  private krstockOrderInstance?: NhplugKrstockOrder;
+  private krstockInquiryInstance?: NhplugKrstockInquiry;
+  private krstockQuoteInstance?: NhplugKrstockQuote;
+  private overseasStockOrderInstance?: NhplugOverseasStockOrder;
+  private overseasStockInquiryInstance?: NhplugOverseasStockInquiry;
+  private overseasStockQuoteInstance?: NhplugOverseasStockQuote;
+
+  public constructor(options: NhplugClientOptions) {
+    const env = options.env ?? 'dev';
+    this.baseUrl = getBaseUrl(env);
+    this.token = options.token;
+    this.appKey = options.appKey;
+    this.secretKey = options.secretKey;
+    this.logger = options.logger ?? consoleLogger;
+    this.http = new BaseHttpClient(
+      {
+        timeoutMs: options.timeoutMs ?? 30_000,
+        retry: {
+          maxRetries: options.maxRetries ?? 3,
+          baseDelayMs: 300,
+        },
+        rateLimit: {
+          // NH 권고 기본값: 초당 20건, 버스트 3건.
+          requestsPerSecond: options.rateLimitRequestsPerSecond ?? 20,
+          burst: options.rateLimitBurst ?? 3,
+        },
+        debug: options.debug ?? false,
+      },
+      options.fetchImpl,
+    );
+  }
+
+  /** 공통 (계좌·실시간 세션) */
+  public get common(): NhplugCommon {
+    if (!this.commonInstance) {
+      this.commonInstance = new NhplugCommon(this);
+    }
+    return this.commonInstance;
+  }
+
+  /** 국내주식 주문 */
+  public get krstockOrder(): NhplugKrstockOrder {
+    if (!this.krstockOrderInstance) {
+      this.krstockOrderInstance = new NhplugKrstockOrder(this);
+    }
+    return this.krstockOrderInstance;
+  }
+
+  /** 국내주식 조회 */
+  public get krstockInquiry(): NhplugKrstockInquiry {
+    if (!this.krstockInquiryInstance) {
+      this.krstockInquiryInstance = new NhplugKrstockInquiry(this);
+    }
+    return this.krstockInquiryInstance;
+  }
+
+  /** 국내주식 시세 */
+  public get krstockQuote(): NhplugKrstockQuote {
+    if (!this.krstockQuoteInstance) {
+      this.krstockQuoteInstance = new NhplugKrstockQuote(this);
+    }
+    return this.krstockQuoteInstance;
+  }
+
+  /** 해외주식 주문 */
+  public get overseasStockOrder(): NhplugOverseasStockOrder {
+    if (!this.overseasStockOrderInstance) {
+      this.overseasStockOrderInstance = new NhplugOverseasStockOrder(this);
+    }
+    return this.overseasStockOrderInstance;
+  }
+
+  /** 해외주식 조회 */
+  public get overseasStockInquiry(): NhplugOverseasStockInquiry {
+    if (!this.overseasStockInquiryInstance) {
+      this.overseasStockInquiryInstance = new NhplugOverseasStockInquiry(this);
+    }
+    return this.overseasStockInquiryInstance;
+  }
+
+  /** 해외주식 시세 */
+  public get overseasStockQuote(): NhplugOverseasStockQuote {
+    if (!this.overseasStockQuoteInstance) {
+      this.overseasStockQuoteInstance = new NhplugOverseasStockQuote(this);
+    }
+    return this.overseasStockQuoteInstance;
+  }
+
+  public async invokeEndpoint(
+    definition: NhplugEndpointDefinition,
+    input: Record<string, unknown>,
+  ): Promise<ApiResponse> {
+    try {
+      const parsedInput = createInputSchema(definition.params).parse(input);
+
+      const body = Object.fromEntries(
+        Object.entries(definition.bodyMap)
+          .map(([apiKey, inputKey]) => {
+            const value = parsedInput[inputKey];
+            if (value === undefined || value === null) {
+              return null;
+            }
+            return [apiKey, stringifyParam(value)];
+          })
+          .filter((entry): entry is [string, string] => entry !== null),
+      );
+
+      // 연속조회: 이전 응답 헤더의 `cts` 값을 그대로 넘기면 다음 페이지를 받는다.
+      const continuationHeaders: Record<string, string> = {};
+      const cts = parsedInput.cts;
+      if (definition.supportsCts && cts !== undefined && cts !== null) {
+        continuationHeaders.cts = stringifyParam(cts);
+        continuationHeaders.cts_flag = 'Y';
+      }
+
+      const response = await this.http.request({
+        method: 'POST',
+        url: `${this.baseUrl}${definition.path}`,
+        headers: {
+          'content-type': 'application/json',
+          accept: 'application/json',
+          authorization: `Bearer ${this.token}`,
+          'x-client-id': this.appKey,
+          'x-client-secret': this.secretKey,
+          ...continuationHeaders,
+        },
+        // 요청 파라미터는 항상 `Input_0` 봉투로 감싼다.
+        body: { Input_0: body },
+      });
+
+      const rawJson = await response.json();
+      const envelope = nhplugEnvelopeSchema.parse(rawJson);
+
+      // HTTP 200 이어도 body `rsp_cd` 가 실패일 수 있으므로 여기서 확인한다.
+      const rspCd = envelope.rsp_cd;
+      if (rspCd !== undefined && !SUCCESS_RSP_CODES.includes(rspCd)) {
+        throw new NhplugApiError(`API error ${rspCd}: ${envelope.rsp_msg ?? ''}`, {
+          statusCode: response.status,
+          responseData: rawJson,
+          requestContext: { path: definition.path },
+          errorCode: rspCd,
+        });
+      }
+
+      if (definition.responseSchema) {
+        definition.responseSchema.parse(rawJson);
+      }
+
+      return {
+        headers: normalizeHeaders(response.headers),
+        body: camelizeKeys(rawJson),
+      };
+    } catch (error) {
+      this.logger.error('NH PLUG API request failed', {
+        path: definition.path,
+        message: error instanceof Error ? error.message : String(error),
+        ...(error instanceof ApiError && error.errorCode !== undefined ? { rspCd: error.errorCode } : {}),
+      });
+      return mapNhplugError(error);
+    }
+  }
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/client.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/client.ts
@@ -214,6 +214,7 @@ export class NhplugClient {
       const body = Object.fromEntries(
         Object.entries(definition.bodyMap)
           .map(([apiKey, inputKey]) => {
+            // eslint-disable-next-line security/detect-object-injection -- inputKey comes from internal endpoint metadata.
             const value = parsedInput[inputKey];
             if (value === undefined || value === null) {
               return null;

--- a/packages/cluefin-openapi-ts/src/nhplug/common.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/common.ts
@@ -1,0 +1,14 @@
+import type { DomainMethods } from '../core/types';
+import type { NhplugClient } from './client';
+import { NhplugDomainBase } from './domain-base';
+import { type CommonMethodName, commonEndpoints } from './metadata/common';
+import type { CommonResponseMap } from './schemas/common';
+
+export type NhplugCommon = NhplugDomainBase & DomainMethods<CommonMethodName, CommonResponseMap>;
+export const NhplugCommon = class NhplugCommon extends NhplugDomainBase {
+  public constructor(client: NhplugClient) {
+    super(client, commonEndpoints);
+  }
+} as {
+  new (client: NhplugClient): NhplugCommon;
+};

--- a/packages/cluefin-openapi-ts/src/nhplug/domain-base.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/domain-base.ts
@@ -1,0 +1,24 @@
+import type { ApiResponse, NhplugEndpointDefinition } from '../core/types';
+import type { NhplugClient } from './client';
+
+export class NhplugDomainBase {
+  public constructor(
+    protected readonly client: NhplugClient,
+    protected readonly endpoints: readonly NhplugEndpointDefinition[],
+  ) {
+    for (const endpoint of endpoints) {
+      Object.defineProperty(this, endpoint.methodName, {
+        value: async (input: Record<string, unknown>) => this.client.invokeEndpoint(endpoint, input),
+        enumerable: true,
+      });
+    }
+  }
+
+  protected invoke(methodName: string, input: Record<string, unknown>): Promise<ApiResponse> {
+    const endpoint = this.endpoints.find((item) => item.methodName === methodName);
+    if (!endpoint) {
+      throw new Error(`Unknown NH PLUG endpoint: ${methodName}`);
+    }
+    return this.client.invokeEndpoint(endpoint, input);
+  }
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/index.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/index.ts
@@ -1,0 +1,32 @@
+export type { NhplugAuthOptions, NhplugTokenResponse, NhplugTokenRevokeResponse } from './auth';
+export { NHPLUG_AUTH_BASE_URL, NhplugAuth } from './auth';
+export type { NhplugClientOptions } from './client';
+export { NhplugClient, SUCCESS_RSP_CODES as NHPLUG_SUCCESS_RSP_CODES } from './client';
+export { NhplugCommon } from './common';
+export { NhplugDomainBase } from './domain-base';
+export { NhplugKrstockInquiry } from './krstock-inquiry';
+export { NhplugKrstockOrder } from './krstock-order';
+export { NhplugKrstockQuote } from './krstock-quote';
+export { NhplugOverseasStockInquiry } from './overseas-stock-inquiry';
+export { NhplugOverseasStockOrder } from './overseas-stock-order';
+export { NhplugOverseasStockQuote } from './overseas-stock-quote';
+// 카테고리별 응답 타입은 수가 많아 개별 나열 대신 타입 전용 재수출로 묶는다.
+export type * from './schemas/common';
+export type * from './schemas/krstock-inquiry';
+export type * from './schemas/krstock-order';
+export type * from './schemas/krstock-quote';
+export type * from './schemas/overseas-stock-inquiry';
+export type * from './schemas/overseas-stock-order';
+export type * from './schemas/overseas-stock-quote';
+export type { NhplugMarket, NhplugSocketClientOptions } from './socket-client';
+export { getNhplugSocketUrl, NhplugSocketClient } from './socket-client';
+// KIS 쪽과 이름이 겹치므로 루트 배럴에서는 Nhplug 접두사를 붙여 내보낸다.
+export type {
+  TokenCacheEntry as NhplugTokenCacheEntry,
+  TokenCacheStore as NhplugTokenCacheStore,
+} from './token-cache';
+export {
+  FileTokenCacheStore as NhplugFileTokenCacheStore,
+  MemoryTokenCacheStore as NhplugMemoryTokenCacheStore,
+  nhplugTokenCacheFileName,
+} from './token-cache';

--- a/packages/cluefin-openapi-ts/src/nhplug/krstock-inquiry.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/krstock-inquiry.ts
@@ -1,0 +1,15 @@
+import type { DomainMethods } from '../core/types';
+import type { NhplugClient } from './client';
+import { NhplugDomainBase } from './domain-base';
+import { type KrstockInquiryMethodName, krstockInquiryEndpoints } from './metadata/krstock-inquiry';
+import type { KrstockInquiryResponseMap } from './schemas/krstock-inquiry';
+
+export type NhplugKrstockInquiry = NhplugDomainBase &
+  DomainMethods<KrstockInquiryMethodName, KrstockInquiryResponseMap>;
+export const NhplugKrstockInquiry = class NhplugKrstockInquiry extends NhplugDomainBase {
+  public constructor(client: NhplugClient) {
+    super(client, krstockInquiryEndpoints);
+  }
+} as {
+  new (client: NhplugClient): NhplugKrstockInquiry;
+};

--- a/packages/cluefin-openapi-ts/src/nhplug/krstock-order.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/krstock-order.ts
@@ -1,0 +1,14 @@
+import type { DomainMethods } from '../core/types';
+import type { NhplugClient } from './client';
+import { NhplugDomainBase } from './domain-base';
+import { type KrstockOrderMethodName, krstockOrderEndpoints } from './metadata/krstock-order';
+import type { KrstockOrderResponseMap } from './schemas/krstock-order';
+
+export type NhplugKrstockOrder = NhplugDomainBase & DomainMethods<KrstockOrderMethodName, KrstockOrderResponseMap>;
+export const NhplugKrstockOrder = class NhplugKrstockOrder extends NhplugDomainBase {
+  public constructor(client: NhplugClient) {
+    super(client, krstockOrderEndpoints);
+  }
+} as {
+  new (client: NhplugClient): NhplugKrstockOrder;
+};

--- a/packages/cluefin-openapi-ts/src/nhplug/krstock-quote.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/krstock-quote.ts
@@ -1,0 +1,14 @@
+import type { DomainMethods } from '../core/types';
+import type { NhplugClient } from './client';
+import { NhplugDomainBase } from './domain-base';
+import { type KrstockQuoteMethodName, krstockQuoteEndpoints } from './metadata/krstock-quote';
+import type { KrstockQuoteResponseMap } from './schemas/krstock-quote';
+
+export type NhplugKrstockQuote = NhplugDomainBase & DomainMethods<KrstockQuoteMethodName, KrstockQuoteResponseMap>;
+export const NhplugKrstockQuote = class NhplugKrstockQuote extends NhplugDomainBase {
+  public constructor(client: NhplugClient) {
+    super(client, krstockQuoteEndpoints);
+  }
+} as {
+  new (client: NhplugClient): NhplugKrstockQuote;
+};

--- a/packages/cluefin-openapi-ts/src/nhplug/metadata/common.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/metadata/common.ts
@@ -1,0 +1,25 @@
+import type { NhplugEndpointDefinition } from '../../core/types';
+
+export const commonEndpoints: NhplugEndpointDefinition[] = [
+  {
+    methodName: 'getAccountList',
+    path: '/n2/acctinfo',
+    bodyMap: {},
+    supportsCts: true,
+    params: [
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'closeWebsocketSession',
+    path: '/websocket/close/session',
+    bodyMap: {},
+    supportsCts: false,
+    params: [],
+  },
+];
+
+export type CommonMethodName = 'getAccountList' | 'closeWebsocketSession';

--- a/packages/cluefin-openapi-ts/src/nhplug/metadata/krstock-inquiry.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/metadata/krstock-inquiry.ts
@@ -1,0 +1,414 @@
+import type { NhplugEndpointDefinition } from '../../core/types';
+
+export const krstockInquiryEndpoints: NhplugEndpointDefinition[] = [
+  {
+    methodName: 'balance',
+    path: '/krstock/inquiry/v1/balance',
+    bodyMap: {
+      act_no: 'actNo',
+      bnc_bse_cd: 'bncBseCd',
+      ltg_aot_dit_cd: 'ltgAotDitCd',
+      aet_bse: 'aetBse',
+      qut_dit_cd: 'qutDitCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'bncBseCd',
+        required: true,
+      },
+      {
+        name: 'ltgAotDitCd',
+        required: true,
+      },
+      {
+        name: 'aetBse',
+        required: true,
+      },
+      {
+        name: 'qutDitCd',
+        required: true,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'dailyOrderExecution',
+    path: '/krstock/inquiry/v1/dailyOrderExecution',
+    bodyMap: {
+      orr_dt: 'orrDt',
+      act_no: 'actNo',
+      itg_orr_no: 'itgOrrNo',
+      orr_mkt_cd: 'orrMktCd',
+      ost_cns_dit: 'ostCnsDit',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'orrDt',
+        required: true,
+      },
+      {
+        name: 'ostCnsDit',
+        required: true,
+      },
+      {
+        name: 'itgOrrNo',
+        required: false,
+      },
+      {
+        name: 'orrMktCd',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'buyableQuantity',
+    path: '/krstock/inquiry/v1/buyableQuantity',
+    bodyMap: {
+      ost_dit_cd: 'ostDitCd',
+      act_no: 'actNo',
+      iem_cd: 'iemCd',
+      nmn_pr_tp_cd: 'nmnPrTpCd',
+      orr_pr: 'orrPr',
+      cfd_lon_cd: 'cfdLonCd',
+      lon_dt: 'lonDt',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'ostDitCd',
+        required: true,
+      },
+      {
+        name: 'nmnPrTpCd',
+        required: true,
+      },
+      {
+        name: 'orrPr',
+        required: false,
+      },
+      {
+        name: 'cfdLonCd',
+        required: false,
+      },
+      {
+        name: 'lonDt',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'sellableQuantity',
+    path: '/krstock/inquiry/v1/sellableQuantity',
+    bodyMap: {
+      act_no: 'actNo',
+      iem_cd: 'iemCd',
+      lon_dt: 'lonDt',
+      cfd_lon_cd: 'cfdLonCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'cfdLonCd',
+        required: true,
+      },
+      {
+        name: 'lonDt',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'reservedInquiry',
+    path: '/krstock/inquiry/v1/reservedInquiry',
+    bodyMap: {
+      bkg_orr_rtn_dt: 'bkgOrrRtnDt',
+      act_no: 'actNo',
+      iem_cd: 'iemCd',
+      sby_dit_cd: 'sbyDitCd',
+      cfd_lon_cd: 'cfdLonCd',
+      bkg_orr_tp_cd: 'bkgOrrTpCd',
+      bkg_orr_can_dit_cd: 'bkgOrrCanDitCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'sbyDitCd',
+        required: true,
+      },
+      {
+        name: 'bkgOrrTpCd',
+        required: true,
+      },
+      {
+        name: 'bkgOrrRtnDt',
+        required: false,
+      },
+      {
+        name: 'iemCd',
+        required: false,
+      },
+      {
+        name: 'cfdLonCd',
+        required: false,
+      },
+      {
+        name: 'bkgOrrCanDitCd',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'realizedPnl',
+    path: '/krstock/inquiry/v1/realizedPnl',
+    bodyMap: {
+      act_no: 'actNo',
+      iqr_dit_cd1: 'iqrDitCd1',
+      fee_dit_cd: 'feeDitCd',
+      qut_dit_cd: 'qutDitCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iqrDitCd1',
+        required: true,
+      },
+      {
+        name: 'feeDitCd',
+        required: true,
+      },
+      {
+        name: 'qutDitCd',
+        required: true,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'assetStatus',
+    path: '/krstock/inquiry/v1/assetStatus',
+    bodyMap: {
+      act_no: 'actNo',
+      eal_aly_cd: 'ealAlyCd',
+      aet_bse: 'aetBse',
+      qut_dit_cd: 'qutDitCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'ealAlyCd',
+        required: true,
+      },
+      {
+        name: 'aetBse',
+        required: true,
+      },
+      {
+        name: 'qutDitCd',
+        required: true,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'dailyPnl',
+    path: '/krstock/inquiry/v1/dailyPnl',
+    bodyMap: {
+      act_no: 'actNo',
+      iem_cd: 'iemCd',
+      iqr_sta_dt: 'iqrStaDt',
+      iqr_end_dt: 'iqrEndDt',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iqrStaDt',
+        required: true,
+      },
+      {
+        name: 'iqrEndDt',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'tradingPnl',
+    path: '/krstock/inquiry/v1/tradingPnl',
+    bodyMap: {
+      act_no: 'actNo',
+      iqr_sta_dt: 'iqrStaDt',
+      iqr_end_dt: 'iqrEndDt',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iqrStaDt',
+        required: true,
+      },
+      {
+        name: 'iqrEndDt',
+        required: true,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'integratedMargin',
+    path: '/krstock/inquiry/v1/integratedMargin',
+    bodyMap: {
+      act_no: 'actNo',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'rightsHeld',
+    path: '/krstock/inquiry/v1/rightsHeld',
+    bodyMap: {
+      sta_dt: 'staDt',
+      act_no: 'actNo',
+      rit_tp_cd: 'ritTpCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'staDt',
+        required: false,
+      },
+      {
+        name: 'ritTpCd',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'rightsScheduled',
+    path: '/krstock/inquiry/v1/rightsScheduled',
+    bodyMap: {
+      act_no: 'actNo',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+];
+
+export type KrstockInquiryMethodName =
+  | 'balance'
+  | 'dailyOrderExecution'
+  | 'buyableQuantity'
+  | 'sellableQuantity'
+  | 'reservedInquiry'
+  | 'realizedPnl'
+  | 'assetStatus'
+  | 'dailyPnl'
+  | 'tradingPnl'
+  | 'integratedMargin'
+  | 'rightsHeld'
+  | 'rightsScheduled';

--- a/packages/cluefin-openapi-ts/src/nhplug/metadata/krstock-order.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/metadata/krstock-order.ts
@@ -1,0 +1,512 @@
+import type { NhplugEndpointDefinition } from '../../core/types';
+
+export const krstockOrderEndpoints: NhplugEndpointDefinition[] = [
+  {
+    methodName: 'cashBuy',
+    path: '/krstock/order/v1/cashBuy',
+    bodyMap: {
+      act_no: 'actNo',
+      iem_cd: 'iemCd',
+      orr_qty: 'orrQty',
+      orr_pr: 'orrPr',
+      orr_amt: 'orrAmt',
+      nmn_pr_tp_cd: 'nmnPrTpCd',
+      orr_cnd_dit_cd: 'orrCndDitCd',
+      ssl_nmn_pr_dit_cd: 'sslNmnPrDitCd',
+      sop_cnd_pr: 'sopCndPr',
+      rmt_mkt_cd: 'rmtMktCd',
+      sor_mkt_sli_yn: 'sorMktSliYn',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'orrQty',
+        required: true,
+      },
+      {
+        name: 'nmnPrTpCd',
+        required: true,
+      },
+      {
+        name: 'rmtMktCd',
+        required: true,
+      },
+      {
+        name: 'sorMktSliYn',
+        required: true,
+      },
+      {
+        name: 'orrCndDitCd',
+        required: false,
+        defaultValue: '00',
+      },
+      {
+        name: 'sslNmnPrDitCd',
+        required: false,
+        defaultValue: '00',
+      },
+      {
+        name: 'orrPr',
+        required: false,
+      },
+      {
+        name: 'orrAmt',
+        required: false,
+      },
+      {
+        name: 'sopCndPr',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'cashSell',
+    path: '/krstock/order/v1/cashSell',
+    bodyMap: {
+      act_no: 'actNo',
+      iem_cd: 'iemCd',
+      orr_qty: 'orrQty',
+      orr_pr: 'orrPr',
+      orr_amt: 'orrAmt',
+      nmn_pr_tp_cd: 'nmnPrTpCd',
+      orr_cnd_dit_cd: 'orrCndDitCd',
+      ssl_nmn_pr_dit_cd: 'sslNmnPrDitCd',
+      sop_cnd_pr: 'sopCndPr',
+      rmt_mkt_cd: 'rmtMktCd',
+      sor_mkt_sli_yn: 'sorMktSliYn',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'orrQty',
+        required: true,
+      },
+      {
+        name: 'nmnPrTpCd',
+        required: true,
+      },
+      {
+        name: 'rmtMktCd',
+        required: true,
+      },
+      {
+        name: 'sorMktSliYn',
+        required: true,
+      },
+      {
+        name: 'orrCndDitCd',
+        required: false,
+        defaultValue: '00',
+      },
+      {
+        name: 'sslNmnPrDitCd',
+        required: false,
+        defaultValue: '00',
+      },
+      {
+        name: 'orrPr',
+        required: false,
+      },
+      {
+        name: 'orrAmt',
+        required: false,
+      },
+      {
+        name: 'sopCndPr',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'creditBuy',
+    path: '/krstock/order/v1/creditBuy',
+    bodyMap: {
+      act_no: 'actNo',
+      iem_cd: 'iemCd',
+      orr_qty: 'orrQty',
+      orr_pr: 'orrPr',
+      orr_amt: 'orrAmt',
+      nmn_pr_tp_cd: 'nmnPrTpCd',
+      orr_cnd_dit_cd: 'orrCndDitCd',
+      cfd_lon_cd: 'cfdLonCd',
+      lon_dt: 'lonDt',
+      sop_cnd_pr: 'sopCndPr',
+      rmt_mkt_cd: 'rmtMktCd',
+      sor_mkt_sli_yn: 'sorMktSliYn',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'orrQty',
+        required: true,
+      },
+      {
+        name: 'nmnPrTpCd',
+        required: true,
+      },
+      {
+        name: 'cfdLonCd',
+        required: true,
+      },
+      {
+        name: 'rmtMktCd',
+        required: true,
+      },
+      {
+        name: 'sorMktSliYn',
+        required: true,
+      },
+      {
+        name: 'orrCndDitCd',
+        required: false,
+        defaultValue: '00',
+      },
+      {
+        name: 'orrPr',
+        required: false,
+      },
+      {
+        name: 'orrAmt',
+        required: false,
+      },
+      {
+        name: 'lonDt',
+        required: false,
+      },
+      {
+        name: 'sopCndPr',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'creditSell',
+    path: '/krstock/order/v1/creditSell',
+    bodyMap: {
+      act_no: 'actNo',
+      iem_cd: 'iemCd',
+      orr_qty: 'orrQty',
+      orr_pr: 'orrPr',
+      orr_amt: 'orrAmt',
+      nmn_pr_tp_cd: 'nmnPrTpCd',
+      orr_cnd_dit_cd: 'orrCndDitCd',
+      cfd_lon_cd: 'cfdLonCd',
+      lon_dt: 'lonDt',
+      sop_cnd_pr: 'sopCndPr',
+      rmt_mkt_cd: 'rmtMktCd',
+      sor_mkt_sli_yn: 'sorMktSliYn',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'orrQty',
+        required: true,
+      },
+      {
+        name: 'nmnPrTpCd',
+        required: true,
+      },
+      {
+        name: 'cfdLonCd',
+        required: true,
+      },
+      {
+        name: 'rmtMktCd',
+        required: true,
+      },
+      {
+        name: 'sorMktSliYn',
+        required: true,
+      },
+      {
+        name: 'orrCndDitCd',
+        required: false,
+        defaultValue: '00',
+      },
+      {
+        name: 'orrPr',
+        required: false,
+      },
+      {
+        name: 'orrAmt',
+        required: false,
+      },
+      {
+        name: 'lonDt',
+        required: false,
+      },
+      {
+        name: 'sopCndPr',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'modify',
+    path: '/krstock/order/v1/modify',
+    bodyMap: {
+      act_no: 'actNo',
+      org_mkt_orr_no: 'orgMktOrrNo',
+      all_pat_dit_cd: 'allPatDitCd',
+      iem_cd: 'iemCd',
+      cor_qty: 'corQty',
+      cor_pr: 'corPr',
+      sop_cnd_pr: 'sopCndPr',
+      rmt_mkt_cd: 'rmtMktCd',
+      sor_mkt_sli_yn: 'sorMktSliYn',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'orgMktOrrNo',
+        required: true,
+      },
+      {
+        name: 'allPatDitCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'corQty',
+        required: true,
+      },
+      {
+        name: 'corPr',
+        required: true,
+      },
+      {
+        name: 'sopCndPr',
+        required: true,
+      },
+      {
+        name: 'rmtMktCd',
+        required: true,
+      },
+      {
+        name: 'sorMktSliYn',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'cancel',
+    path: '/krstock/order/v1/cancel',
+    bodyMap: {
+      act_no: 'actNo',
+      org_mkt_orr_no: 'orgMktOrrNo',
+      all_pat_dit_cd: 'allPatDitCd',
+      iem_cd: 'iemCd',
+      cor_qty: 'corQty',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'orgMktOrrNo',
+        required: true,
+      },
+      {
+        name: 'allPatDitCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'corQty',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'reservedOrder',
+    path: '/krstock/order/v1/reservedOrder',
+    bodyMap: {
+      act_no: 'actNo',
+      iem_cd: 'iemCd',
+      sby_dit_cd: 'sbyDitCd',
+      frs_sba_orr_yn: 'frsSbaOrrYn',
+      nmn_pr_tp_cd: 'nmnPrTpCd',
+      cfd_lon_cd: 'cfdLonCd',
+      lon_dt: 'lonDt',
+      orr_qty: 'orrQty',
+      orr_uit_pr: 'orrUitPr',
+      bkg_orr_tp_cd: 'bkgOrrTpCd',
+      bkg_orr_sta_dt: 'bkgOrrStaDt',
+      bkg_orr_end_dt: 'bkgOrrEndDt',
+      bkg_orr_enf_tp_cd: 'bkgOrrEnfTpCd',
+      end_pr_cmp_ftw_amt: 'endPrCmpFtwAmt',
+      orr_pr_rge_hlm_pr: 'orrPrRgeHlmPr',
+      orr_pr_rge_llm_pr: 'orrPrRgeLlmPr',
+      rmt_mkt_cd: 'rmtMktCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'sbyDitCd',
+        required: true,
+      },
+      {
+        name: 'frsSbaOrrYn',
+        required: true,
+      },
+      {
+        name: 'nmnPrTpCd',
+        required: true,
+      },
+      {
+        name: 'cfdLonCd',
+        required: true,
+      },
+      {
+        name: 'orrQty',
+        required: true,
+      },
+      {
+        name: 'orrUitPr',
+        required: true,
+      },
+      {
+        name: 'bkgOrrTpCd',
+        required: true,
+      },
+      {
+        name: 'bkgOrrEnfTpCd',
+        required: true,
+      },
+      {
+        name: 'rmtMktCd',
+        required: true,
+      },
+      {
+        name: 'lonDt',
+        required: false,
+      },
+      {
+        name: 'bkgOrrStaDt',
+        required: false,
+      },
+      {
+        name: 'bkgOrrEndDt',
+        required: false,
+      },
+      {
+        name: 'endPrCmpFtwAmt',
+        required: false,
+      },
+      {
+        name: 'orrPrRgeHlmPr',
+        required: false,
+      },
+      {
+        name: 'orrPrRgeLlmPr',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'reservedCancel',
+    path: '/krstock/order/v1/reservedCancel',
+    bodyMap: {
+      act_no: 'actNo',
+      sby_dit_cd: 'sbyDitCd',
+      iem_cd: 'iemCd',
+      bkg_orr_no: 'bkgOrrNo',
+      bkg_orr_tp_cd: 'bkgOrrTpCd',
+      bkg_rtn_dt: 'bkgRtnDt',
+      rmt_mkt_cd: 'rmtMktCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'sbyDitCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'bkgOrrNo',
+        required: true,
+      },
+      {
+        name: 'bkgOrrTpCd',
+        required: true,
+      },
+      {
+        name: 'rmtMktCd',
+        required: true,
+      },
+      {
+        name: 'bkgRtnDt',
+        required: false,
+      },
+    ],
+  },
+];
+
+export type KrstockOrderMethodName =
+  | 'cashBuy'
+  | 'cashSell'
+  | 'creditBuy'
+  | 'creditSell'
+  | 'modify'
+  | 'cancel'
+  | 'reservedOrder'
+  | 'reservedCancel';

--- a/packages/cluefin-openapi-ts/src/nhplug/metadata/krstock-quote.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/metadata/krstock-quote.ts
@@ -1,0 +1,296 @@
+import type { NhplugEndpointDefinition } from '../../core/types';
+
+export const krstockQuoteEndpoints: NhplugEndpointDefinition[] = [
+  {
+    methodName: 'currentPrice',
+    path: '/krstock/quote/v1/currentPrice',
+    bodyMap: {
+      market_cd: 'marketCd',
+      iem_cd: 'iemCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'marketCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'currentExecution',
+    path: '/krstock/quote/v1/currentExecution',
+    bodyMap: {
+      market_cd: 'marketCd',
+      iem_cd: 'iemCd',
+      array_cnt: 'arrayCnt',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'marketCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'arrayCnt',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'currentDaily',
+    path: '/krstock/quote/v1/currentDaily',
+    bodyMap: {
+      market_cd: 'marketCd',
+      iem_cd: 'iemCd',
+      array_cnt: 'arrayCnt',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'marketCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'arrayCnt',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'currentInvestor',
+    path: '/krstock/quote/v1/currentInvestor',
+    bodyMap: {
+      market_cd: 'marketCd',
+      iem_cd: 'iemCd',
+      array_cnt: 'arrayCnt',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'marketCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'arrayCnt',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'period',
+    path: '/krstock/quote/v1/period',
+    bodyMap: {
+      market_cd: 'marketCd',
+      iem_cd: 'iemCd',
+      mrkt_div_cls_code: 'mrktDivClsCode',
+      edate: 'edate',
+      array_cnt: 'arrayCnt',
+      maxavg: 'maxavg',
+      gubun: 'gubun',
+      xtick: 'xtick',
+      today_cls_code: 'todayClsCode',
+      fake_tick: 'fakeTick',
+      sur_flag: 'surFlag',
+      sur_gb_day_cnt: 'surGbDayCnt',
+      sur_bf_end_time: 'surBfEndTime',
+      out1_scale_change: 'out1ScaleChange',
+      out2_scale_change: 'out2ScaleChange',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'marketCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'mrktDivClsCode',
+        required: false,
+      },
+      {
+        name: 'edate',
+        required: false,
+      },
+      {
+        name: 'arrayCnt',
+        required: false,
+      },
+      {
+        name: 'maxavg',
+        required: false,
+      },
+      {
+        name: 'gubun',
+        required: false,
+      },
+      {
+        name: 'xtick',
+        required: false,
+      },
+      {
+        name: 'todayClsCode',
+        required: false,
+      },
+      {
+        name: 'fakeTick',
+        required: false,
+      },
+      {
+        name: 'surFlag',
+        required: false,
+      },
+      {
+        name: 'surGbDayCnt',
+        required: false,
+      },
+      {
+        name: 'surBfEndTime',
+        required: false,
+      },
+      {
+        name: 'out1ScaleChange',
+        required: false,
+      },
+      {
+        name: 'out2ScaleChange',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'afterHoursCurrent',
+    path: '/krstock/quote/v1/afterHoursCurrent',
+    bodyMap: {
+      iem_cd: 'iemCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'iemCd',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'currentAfterHoursDaily',
+    path: '/krstock/quote/v1/currentAfterHoursDaily',
+    bodyMap: {
+      iem_cd: 'iemCd',
+      date: 'date',
+      array_cnt: 'arrayCnt',
+      maxavg: 'maxavg',
+      gubun: 'gubun',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'date',
+        required: true,
+      },
+      {
+        name: 'arrayCnt',
+        required: true,
+      },
+      {
+        name: 'maxavg',
+        required: true,
+      },
+      {
+        name: 'gubun',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'currentAfterHoursExecution',
+    path: '/krstock/quote/v1/currentAfterHoursExecution',
+    bodyMap: {
+      iem_cd: 'iemCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'iemCd',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'afterHoursExpected',
+    path: '/krstock/quote/v1/afterHoursExpected',
+    bodyMap: {
+      iem_cd: 'iemCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'iemCd',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'etfCurrent',
+    path: '/krstock/quote/v1/etfCurrent',
+    bodyMap: {
+      iem_cd: 'iemCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'iemCd',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'etfComponents',
+    path: '/krstock/quote/v1/etfComponents',
+    bodyMap: {
+      iem_cd: 'iemCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'iemCd',
+        required: true,
+      },
+    ],
+  },
+];
+
+export type KrstockQuoteMethodName =
+  | 'currentPrice'
+  | 'currentExecution'
+  | 'currentDaily'
+  | 'currentInvestor'
+  | 'period'
+  | 'afterHoursCurrent'
+  | 'currentAfterHoursDaily'
+  | 'currentAfterHoursExecution'
+  | 'afterHoursExpected'
+  | 'etfCurrent'
+  | 'etfComponents';

--- a/packages/cluefin-openapi-ts/src/nhplug/metadata/overseas-stock-inquiry.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/metadata/overseas-stock-inquiry.ts
@@ -1,0 +1,373 @@
+import type { NhplugEndpointDefinition } from '../../core/types';
+
+export const overseasStockInquiryEndpoints: NhplugEndpointDefinition[] = [
+  {
+    methodName: 'buyableAmount',
+    path: '/gbstock/inquiry/v1/buyableAmount',
+    bodyMap: {
+      act_no: 'actNo',
+      pcs_dit: 'pcsDit',
+      fc_sec_trd_nat_cd: 'fcSecTrdNatCd',
+      iem_cd: 'iemCd',
+      wtm_cur_knd_cd: 'wtmCurKndCd',
+      oss_orr_knd_cd: 'ossOrrKndCd',
+      ahi_nmn_pr_tp_cd: 'ahiNmnPrTpCd',
+      fc_orr_uit_pr: 'fcOrrUitPr',
+      cfd_lon_cd: 'cfdLonCd',
+      lon_dt: 'lonDt',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'pcsDit',
+        required: true,
+      },
+      {
+        name: 'fcSecTrdNatCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'wtmCurKndCd',
+        required: true,
+      },
+      {
+        name: 'ossOrrKndCd',
+        required: true,
+      },
+      {
+        name: 'ahiNmnPrTpCd',
+        required: true,
+      },
+      {
+        name: 'fcOrrUitPr',
+        required: false,
+      },
+      {
+        name: 'cfdLonCd',
+        required: false,
+      },
+      {
+        name: 'lonDt',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'unexecuted',
+    path: '/gbstock/inquiry/v1/unexecuted',
+    bodyMap: {
+      orr_dt: 'orrDt',
+      act_no: 'actNo',
+      oss_sby_dit_cd: 'ossSbyDitCd',
+      sot_dit: 'sotDit',
+      ost_cns_dit: 'ostCnsDit',
+      iem_cd: 'iemCd',
+      orr_no: 'orrNo',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'orrDt',
+        required: true,
+      },
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'ossSbyDitCd',
+        required: true,
+      },
+      {
+        name: 'sotDit',
+        required: true,
+      },
+      {
+        name: 'ostCnsDit',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: false,
+      },
+      {
+        name: 'orrNo',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'balance',
+    path: '/gbstock/inquiry/v1/balance',
+    bodyMap: {
+      act_no: 'actNo',
+      qut_iqr_dit_cd: 'qutIqrDitCd',
+      fc_sec_trd_nat_cd: 'fcSecTrdNatCd',
+      cur_cd: 'curCd',
+      xns_dit_cd: 'xnsDitCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'qutIqrDitCd',
+        required: true,
+      },
+      {
+        name: 'fcSecTrdNatCd',
+        required: true,
+      },
+      {
+        name: 'curCd',
+        required: true,
+      },
+      {
+        name: 'xnsDitCd',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'reservedInquiry',
+    path: '/gbstock/inquiry/v1/reservedInquiry',
+    bodyMap: {
+      fc_mkt_dit_cd: 'fcMktDitCd',
+      bkg_orr_dt: 'bkgOrrDt',
+      act_no: 'actNo',
+      sby_dit_cd: 'sbyDitCd',
+      bkg_orr_can_yn: 'bkgOrrCanYn',
+      oss_orr_knd_cd: 'ossOrrKndCd',
+      bkg_orr_tp_cd: 'bkgOrrTpCd',
+      wtm_cur_knd_cd: 'wtmCurKndCd',
+      iem_cd: 'iemCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'fcMktDitCd',
+        required: true,
+      },
+      {
+        name: 'bkgOrrDt',
+        required: true,
+      },
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'sbyDitCd',
+        required: true,
+      },
+      {
+        name: 'bkgOrrCanYn',
+        required: true,
+      },
+      {
+        name: 'ossOrrKndCd',
+        required: true,
+      },
+      {
+        name: 'bkgOrrTpCd',
+        required: true,
+      },
+      {
+        name: 'wtmCurKndCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'dailyTransaction',
+    path: '/gbstock/inquiry/v1/dailyTransaction',
+    bodyMap: {
+      act_no: 'actNo',
+      iqr_sta_dt: 'iqrStaDt',
+      iqr_end_dt: 'iqrEndDt',
+      act_trd_cfc_cd: 'actTrdCfcCd',
+      iem_mlf_cd: 'iemMlfCd',
+      iem_cd: 'iemCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iqrStaDt',
+        required: true,
+      },
+      {
+        name: 'iqrEndDt',
+        required: true,
+      },
+      {
+        name: 'actTrdCfcCd',
+        required: true,
+      },
+      {
+        name: 'iemMlfCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'periodPnl',
+    path: '/gbstock/inquiry/v1/periodPnl',
+    bodyMap: {
+      act_no: 'actNo',
+      iqr_dit: 'iqrDit',
+      sta_orr_dt: 'staOrrDt',
+      end_orr_dt: 'endOrrDt',
+      iem_cd: 'iemCd',
+      trd_cur_cd: 'trdCurCd',
+      fc_sec_trd_nat_cd: 'fcSecTrdNatCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iqrDit',
+        required: true,
+      },
+      {
+        name: 'staOrrDt',
+        required: true,
+      },
+      {
+        name: 'endOrrDt',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: false,
+      },
+      {
+        name: 'trdCurCd',
+        required: false,
+      },
+      {
+        name: 'fcSecTrdNatCd',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'periodPnlDetail',
+    path: '/gbstock/inquiry/v1/periodPnlDetail',
+    bodyMap: {
+      act_no: 'actNo',
+      iqr_dit: 'iqrDit',
+      orr_dt: 'orrDt',
+      fc_sec_trd_nat_cd: 'fcSecTrdNatCd',
+      trd_cur_cd: 'trdCurCd',
+      iem_cd: 'iemCd',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'iqrDit',
+        required: true,
+      },
+      {
+        name: 'orrDt',
+        required: true,
+      },
+      {
+        name: 'fcSecTrdNatCd',
+        required: true,
+      },
+      {
+        name: 'trdCurCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: false,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'margin',
+    path: '/gbstock/inquiry/v1/margin',
+    bodyMap: {
+      act_no: 'actNo',
+    },
+    supportsCts: true,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'cts',
+        required: false,
+      },
+    ],
+  },
+];
+
+export type OverseasStockInquiryMethodName =
+  | 'buyableAmount'
+  | 'unexecuted'
+  | 'balance'
+  | 'reservedInquiry'
+  | 'dailyTransaction'
+  | 'periodPnl'
+  | 'periodPnlDetail'
+  | 'margin';

--- a/packages/cluefin-openapi-ts/src/nhplug/metadata/overseas-stock-order.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/metadata/overseas-stock-order.ts
@@ -1,0 +1,300 @@
+import type { NhplugEndpointDefinition } from '../../core/types';
+
+export const overseasStockOrderEndpoints: NhplugEndpointDefinition[] = [
+  {
+    methodName: 'buy',
+    path: '/gbstock/order/v1/buy',
+    bodyMap: {
+      act_no: 'actNo',
+      fc_sec_trd_nat_cd: 'fcSecTrdNatCd',
+      iem_cd: 'iemCd',
+      orr_qty: 'orrQty',
+      ahi_nmn_pr_tp_cd: 'ahiNmnPrTpCd',
+      wtm_cur_knd_cd: 'wtmCurKndCd',
+      fc_orr_uit_pr: 'fcOrrUitPr',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'fcSecTrdNatCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'orrQty',
+        required: true,
+      },
+      {
+        name: 'ahiNmnPrTpCd',
+        required: true,
+      },
+      {
+        name: 'wtmCurKndCd',
+        required: true,
+      },
+      {
+        name: 'fcOrrUitPr',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'sell',
+    path: '/gbstock/order/v1/sell',
+    bodyMap: {
+      act_no: 'actNo',
+      fc_sec_trd_nat_cd: 'fcSecTrdNatCd',
+      iem_cd: 'iemCd',
+      orr_qty: 'orrQty',
+      ahi_nmn_pr_tp_cd: 'ahiNmnPrTpCd',
+      fc_orr_uit_pr: 'fcOrrUitPr',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'fcSecTrdNatCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'orrQty',
+        required: true,
+      },
+      {
+        name: 'ahiNmnPrTpCd',
+        required: true,
+      },
+      {
+        name: 'fcOrrUitPr',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'modify',
+    path: '/gbstock/order/v1/modify',
+    bodyMap: {
+      act_no: 'actNo',
+      fc_sec_trd_nat_cd: 'fcSecTrdNatCd',
+      iem_cd: 'iemCd',
+      org_orr_no: 'orgOrrNo',
+      fc_orr_uit_pr: 'fcOrrUitPr',
+      fc_stop_orr_bse_pr: 'fcStopOrrBsePr',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'fcSecTrdNatCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'orgOrrNo',
+        required: true,
+      },
+      {
+        name: 'fcOrrUitPr',
+        required: true,
+      },
+      {
+        name: 'fcStopOrrBsePr',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'cancel',
+    path: '/gbstock/order/v1/cancel',
+    bodyMap: {
+      act_no: 'actNo',
+      org_orr_no: 'orgOrrNo',
+      fc_sec_trd_nat_cd: 'fcSecTrdNatCd',
+      iem_cd: 'iemCd',
+      all_pat_dit_cd: 'allPatDitCd',
+      can_qty: 'canQty',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'orgOrrNo',
+        required: true,
+      },
+      {
+        name: 'fcSecTrdNatCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'allPatDitCd',
+        required: true,
+      },
+      {
+        name: 'canQty',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'reservedSubmit',
+    path: '/gbstock/order/v1/reservedSubmit',
+    bodyMap: {
+      act_no: 'actNo',
+      fc_sec_trd_nat_cd: 'fcSecTrdNatCd',
+      iem_cd: 'iemCd',
+      oss_sby_dit_cd: 'ossSbyDitCd',
+      orr_qty: 'orrQty',
+      nmn_pr_tp_cd: 'nmnPrTpCd',
+      fc_orr_uit_pr: 'fcOrrUitPr',
+      oss_orr_knd_cd: 'ossOrrKndCd',
+      ose_ivs_sgy_cd: 'oseIvsSgyCd',
+      bkg_orr_tp_cd: 'bkgOrrTpCd',
+      bkg_orr_sta_dt: 'bkgOrrStaDt',
+      bkg_orr_end_dt: 'bkgOrrEndDt',
+      wtm_cur_knd_cd: 'wtmCurKndCd',
+      fc_stop_orr_bse_pr: 'fcStopOrrBsePr',
+      orr_pdt_dit_cd: 'orrPdtDitCd',
+      lon_dt: 'lonDt',
+      cfd_lon_cd: 'cfdLonCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'fcSecTrdNatCd',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'ossSbyDitCd',
+        required: true,
+      },
+      {
+        name: 'orrQty',
+        required: true,
+      },
+      {
+        name: 'nmnPrTpCd',
+        required: true,
+      },
+      {
+        name: 'fcOrrUitPr',
+        required: false,
+      },
+      {
+        name: 'ossOrrKndCd',
+        required: false,
+      },
+      {
+        name: 'oseIvsSgyCd',
+        required: false,
+      },
+      {
+        name: 'bkgOrrTpCd',
+        required: false,
+      },
+      {
+        name: 'bkgOrrStaDt',
+        required: false,
+      },
+      {
+        name: 'bkgOrrEndDt',
+        required: false,
+      },
+      {
+        name: 'wtmCurKndCd',
+        required: false,
+      },
+      {
+        name: 'fcStopOrrBsePr',
+        required: false,
+      },
+      {
+        name: 'orrPdtDitCd',
+        required: false,
+      },
+      {
+        name: 'lonDt',
+        required: false,
+      },
+      {
+        name: 'cfdLonCd',
+        required: false,
+      },
+    ],
+  },
+  {
+    methodName: 'reservedCancel',
+    path: '/gbstock/order/v1/reservedCancel',
+    bodyMap: {
+      act_no: 'actNo',
+      fc_mkt_dit_cd: 'fcMktDitCd',
+      bkg_orr_dt: 'bkgOrrDt',
+      bkg_rtn_orr_no: 'bkgRtnOrrNo',
+      iem_cd: 'iemCd',
+      orr_pdt_dit_cd: 'orrPdtDitCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'actNo',
+        required: true,
+      },
+      {
+        name: 'fcMktDitCd',
+        required: true,
+      },
+      {
+        name: 'bkgOrrDt',
+        required: true,
+      },
+      {
+        name: 'bkgRtnOrrNo',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: false,
+      },
+      {
+        name: 'orrPdtDitCd',
+        required: false,
+      },
+    ],
+  },
+];
+
+export type OverseasStockOrderMethodName = 'buy' | 'sell' | 'modify' | 'cancel' | 'reservedSubmit' | 'reservedCancel';

--- a/packages/cluefin-openapi-ts/src/nhplug/metadata/overseas-stock-quote.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/metadata/overseas-stock-quote.ts
@@ -1,0 +1,142 @@
+import type { NhplugEndpointDefinition } from '../../core/types';
+
+export const overseasStockQuoteEndpoints: NhplugEndpointDefinition[] = [
+  {
+    methodName: 'current',
+    path: '/gbstock/quote/v1/current',
+    bodyMap: {
+      iem_cd: 'iemCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'iemCd',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'executionTrend',
+    path: '/gbstock/quote/v1/executionTrend',
+    bodyMap: {
+      period_type: 'periodType',
+      req_cnt: 'reqCnt',
+      iem_cd: 'iemCd',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'periodType',
+        required: true,
+      },
+      {
+        name: 'reqCnt',
+        required: true,
+      },
+      {
+        name: 'iemCd',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'period',
+    path: '/gbstock/quote/v1/period',
+    bodyMap: {
+      iem_cd: 'iemCd',
+      end_dt: 'endDt',
+      count: 'count',
+      maxavg: 'maxavg',
+      gubun: 'gubun',
+      xtick: 'xtick',
+      today_cls: 'todayCls',
+      market_cls: 'marketCls',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'endDt',
+        required: true,
+      },
+      {
+        name: 'count',
+        required: true,
+      },
+      {
+        name: 'maxavg',
+        required: true,
+      },
+      {
+        name: 'gubun',
+        required: true,
+      },
+      {
+        name: 'xtick',
+        required: true,
+      },
+      {
+        name: 'todayCls',
+        required: true,
+      },
+      {
+        name: 'marketCls',
+        required: true,
+      },
+    ],
+  },
+  {
+    methodName: 'symbolIndexFxPeriod',
+    path: '/gbstock/quote/v1/symbolIndexFxPeriod',
+    bodyMap: {
+      iem_cd: 'iemCd',
+      end_dt: 'endDt',
+      array_cnt: 'arrayCnt',
+      maxavg: 'maxavg',
+      gubun: 'gubun',
+      today_cls: 'todayCls',
+      xtick: 'xtick',
+      scale_change: 'scaleChange',
+    },
+    supportsCts: false,
+    params: [
+      {
+        name: 'iemCd',
+        required: true,
+      },
+      {
+        name: 'endDt',
+        required: true,
+      },
+      {
+        name: 'arrayCnt',
+        required: true,
+      },
+      {
+        name: 'maxavg',
+        required: true,
+      },
+      {
+        name: 'gubun',
+        required: true,
+      },
+      {
+        name: 'todayCls',
+        required: true,
+      },
+      {
+        name: 'xtick',
+        required: false,
+      },
+      {
+        name: 'scaleChange',
+        required: false,
+      },
+    ],
+  },
+];
+
+export type OverseasStockQuoteMethodName = 'current' | 'executionTrend' | 'period' | 'symbolIndexFxPeriod';

--- a/packages/cluefin-openapi-ts/src/nhplug/overseas-stock-inquiry.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/overseas-stock-inquiry.ts
@@ -1,0 +1,16 @@
+import type { DomainMethods } from '../core/types';
+import type { NhplugClient } from './client';
+import { NhplugDomainBase } from './domain-base';
+import { type OverseasStockInquiryMethodName, overseasStockInquiryEndpoints } from './metadata/overseas-stock-inquiry';
+import type { OverseasStockInquiryResponseMap } from './schemas/overseas-stock-inquiry';
+
+/** NH PLUG 해외주식(gbstock) 조회 API (`/gbstock/inquiry/v1/*`). */
+export type NhplugOverseasStockInquiry = NhplugDomainBase &
+  DomainMethods<OverseasStockInquiryMethodName, OverseasStockInquiryResponseMap>;
+export const NhplugOverseasStockInquiry = class NhplugOverseasStockInquiry extends NhplugDomainBase {
+  public constructor(client: NhplugClient) {
+    super(client, overseasStockInquiryEndpoints);
+  }
+} as {
+  new (client: NhplugClient): NhplugOverseasStockInquiry;
+};

--- a/packages/cluefin-openapi-ts/src/nhplug/overseas-stock-order.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/overseas-stock-order.ts
@@ -1,0 +1,16 @@
+import type { DomainMethods } from '../core/types';
+import type { NhplugClient } from './client';
+import { NhplugDomainBase } from './domain-base';
+import { type OverseasStockOrderMethodName, overseasStockOrderEndpoints } from './metadata/overseas-stock-order';
+import type { OverseasStockOrderResponseMap } from './schemas/overseas-stock-order';
+
+/** NH PLUG 해외주식(gbstock) 주문 API (`/gbstock/order/v1/*`). */
+export type NhplugOverseasStockOrder = NhplugDomainBase &
+  DomainMethods<OverseasStockOrderMethodName, OverseasStockOrderResponseMap>;
+export const NhplugOverseasStockOrder = class NhplugOverseasStockOrder extends NhplugDomainBase {
+  public constructor(client: NhplugClient) {
+    super(client, overseasStockOrderEndpoints);
+  }
+} as {
+  new (client: NhplugClient): NhplugOverseasStockOrder;
+};

--- a/packages/cluefin-openapi-ts/src/nhplug/overseas-stock-quote.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/overseas-stock-quote.ts
@@ -1,0 +1,16 @@
+import type { DomainMethods } from '../core/types';
+import type { NhplugClient } from './client';
+import { NhplugDomainBase } from './domain-base';
+import { type OverseasStockQuoteMethodName, overseasStockQuoteEndpoints } from './metadata/overseas-stock-quote';
+import type { OverseasStockQuoteResponseMap } from './schemas/overseas-stock-quote';
+
+/** NH PLUG 해외주식(gbstock) 시세 API (`/gbstock/quote/v1/*`). */
+export type NhplugOverseasStockQuote = NhplugDomainBase &
+  DomainMethods<OverseasStockQuoteMethodName, OverseasStockQuoteResponseMap>;
+export const NhplugOverseasStockQuote = class NhplugOverseasStockQuote extends NhplugDomainBase {
+  public constructor(client: NhplugClient) {
+    super(client, overseasStockQuoteEndpoints);
+  }
+} as {
+  new (client: NhplugClient): NhplugOverseasStockQuote;
+};

--- a/packages/cluefin-openapi-ts/src/nhplug/schemas/common.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/schemas/common.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+
+import type { CamelizeKeys } from '../../core/types';
+
+/** 공통 응답 봉투 (`rsp_cd`/`rsp_msg`). */
+const commonEnvelope = {
+  /** 응답코드 (00000: 성공) */
+  rsp_cd: z.string(),
+  /** 응답메시지 */
+  rsp_msg: z.string(),
+};
+
+export const accountItemSchema = z
+  .object({
+    /** 계좌번호 (이후 API 의 입력 `act_no` 에 사용) */
+    acct_no: z.string(),
+    /** 계좌구분 (01: 자계좌, 02: 주문대리인계좌, 03: 모의투자계좌) */
+    acct_type: z.enum(['01', '02', '03']),
+  })
+  .passthrough();
+
+/** 계좌 목록 조회 (`POST /n2/acctinfo`) 응답. */
+export const accountListResponseSchema = z
+  .object({
+    /** 응답코드 */
+    rsp_cd: z.string().nullish(),
+    /** 응답메시지 */
+    rsp_msg: z.string().nullish(),
+    /** 고객번호 */
+    cust_no: z.string().nullish(),
+    /** 보유 계좌 목록 */
+    Output_0: z.array(accountItemSchema).nullish(),
+  })
+  .passthrough();
+
+/** 실시간(Websocket) 세션해제 (`POST /websocket/close/session`) 응답. */
+export const websocketCloseResponseSchema = z
+  .object({
+    ...commonEnvelope,
+  })
+  .passthrough();
+
+// ── Response Types ──
+
+export type AccountListResponse = CamelizeKeys<z.infer<typeof accountListResponseSchema>>;
+export type WebsocketCloseResponse = CamelizeKeys<z.infer<typeof websocketCloseResponseSchema>>;
+
+// ── Response Map ──
+
+export interface CommonResponseMap {
+  getAccountList: AccountListResponse;
+  closeWebsocketSession: WebsocketCloseResponse;
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/schemas/krstock-inquiry.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/schemas/krstock-inquiry.ts
@@ -1,0 +1,1196 @@
+import { z } from 'zod';
+
+import type { CamelizeKeys } from '../../core/types';
+
+const messageSchema = z
+  .object({
+    msg_code: z.string().nullish(),
+    usr_msg: z.string().nullish(),
+    msg_lv_code: z.string().nullish(),
+    dvlp_msg_yn: z.string().nullish(),
+    svc_nm: z.string().nullish(),
+    func_nm: z.string().nullish(),
+    line_no: z.string().nullish(),
+    dvlp_msg: z.string().nullish(),
+  })
+  .passthrough();
+
+/**
+ * 자산군(krstock 등) 공통 응답 봉투.
+ *
+ * 스펙은 `Output_N` + `message` 구조로 명세하지만 실서버는 `rsp_cd`/`rsp_msg` 를
+ * 반환하고 `message` 는 null 이다(모의 실측 2026-08-22). 셋 다 optional 로 둔다.
+ */
+const assetEnvelope = {
+  /** 응답코드 (00000: 성공) */
+  rsp_cd: z.string().nullish(),
+  /** 응답메시지 */
+  rsp_msg: z.string().nullish(),
+  /** 스펙상 메시지 봉투 (실서버는 null) */
+  message: messageSchema.nullish(),
+};
+/**
+ * 파이썬 모델이 `int`/`float` 로 선언한 숫자 필드.
+ *
+ * 스펙이 int 라고 해도 실서버가 문자열로 내려주는 사례가 있어(예: 잔고조회
+ * `orr_pbl_amt1`, 2026-08-22 모의 실측) 숫자로 강제 변환한다. 빈 문자열은
+ * `z.coerce.number()` 가 0 으로 바꿔버리므로 null 로 따로 처리한다.
+ */
+const num = z.union([z.number(), z.literal('').transform(() => null), z.coerce.number()]);
+
+/** 주식잔고조회 계좌 종합 정보 (Output_0). */
+export const krStockInquiryBalanceAccountOutputSchema = z
+  .object({
+    /** 예수금 */
+    dca: num.nullish(),
+    /** 익일예수금 — D+1 예수금 */
+    nxt_dd_dca: num.nullish(),
+    /** 익익일예수금 — D+2 예수금 */
+    nxt2_dd_dca: num.nullish(),
+    /** 외화예수금 */
+    fc_dca: z.union([z.string(), num]).nullish(),
+    /** 외화담보금액 */
+    fc_mgg_amt: z.union([z.string(), num]).nullish(),
+    /** 외화주문가능금액 */
+    fc_orr_pbl_amt: z.union([z.string(), num]).nullish(),
+    /** 출금가능금액 */
+    drn_pbl_amt: num.nullish(),
+    /** 융자금액 */
+    fnn_amt: z.union([z.string(), num]).nullish(),
+    /** 담보비율 */
+    mgg_rt: num.nullish(),
+    /** 권리평가금액 */
+    rit_eal_amt: z.union([z.string(), num]).nullish(),
+    /** 주문가능금액 */
+    orr_pbl_amt: z.union([z.string(), num]).nullish(),
+    /** 순자산금액 */
+    nas_amt: num.nullish(),
+    /** 총자산금액 */
+    tot_aet_amt: num.nullish(),
+    /** 총매수금액 */
+    tot_byn_amt: num.nullish(),
+    /** 총평가금액 */
+    tot_eal_amt: num.nullish(),
+    /** 총평가손익 */
+    tot_eal_pls: num.nullish(),
+    /** 수익율 */
+    pft_rt: num.nullish(),
+    /** 미수금 */
+    rba: num.nullish(),
+    /** 이자미납부금액 */
+    int_ny_pmt_amt: num.nullish(),
+    /** 미상환금액 */
+    ny_rdp_amt: num.nullish(),
+    /** 기타대여금 */
+    ect_lga: num.nullish(),
+    /** 대출금액 */
+    lon_amt: num.nullish(),
+    /** 대용금액 */
+    sba_amt: num.nullish(),
+    /** 주문가능금액1 — 20%주문가능금액 (스펙 string, 실측 int — 2026-08-22) */
+    orr_pbl_amt1: z.union([z.string(), num]).nullish(),
+    /** 주문가능금액2 — 30%주문가능금액 */
+    orr_pbl_amt2: num.nullish(),
+    /** 주문가능금액3 — 40%주문가능금액 */
+    orr_pbl_amt3: num.nullish(),
+    /** 주문가능금액4 — 100%주문가능금액 */
+    orr_pbl_amt4: num.nullish(),
+    /** 대주담보금액 */
+    slo_mgg_amt: num.nullish(),
+    /** 현금증거금 */
+    csh_wtm: num.nullish(),
+    /** 대용증거금 */
+    sba_wtm: num.nullish(),
+    /** 매도증거금액 */
+    sll_edn_amt: num.nullish(),
+    /** 신용상품유형명 */
+    cfd_pdt_tp_nm: z.string().nullish(),
+    /** 계좌활동유형세부코드 — 101: 활동 102: 휴면 401: 고객요청폐쇄 */
+    act_atv_tp_dtl_cd: z.string().nullish(),
+    /** 계좌번호 */
+    act_no: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식잔고조회 보유 종목별 상세 (Output_1 배열의 각 항목). */
+export const krStockInquiryBalanceHoldingOutputSchema = z
+  .object({
+    /** 상품유형명 */
+    pdt_tp_nm: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 유형코드명 */
+    tp_cd_nm: z.string().nullish(),
+    /** 통합잔고수량 */
+    itg_bnc_qty: num.nullish(),
+    /** 미결제수량 */
+    ny_stl_qty: num.nullish(),
+    /** 잔량수량 */
+    rsdl_qty: num.nullish(),
+    /** 매입가격 */
+    phs_pr: num.nullish(),
+    /** 현재가격 */
+    now_pr: num.nullish(),
+    /** 매수금액 — 길이 18 (스펙 string, sibling 금액 필드처럼 실측 int 가능성) */
+    byn_amt: z.union([z.string(), num]).nullish(),
+    /** 평가금액 */
+    eal_amt: num.nullish(),
+    /** 평가손익금액 */
+    eal_pls_amt: num.nullish(),
+    /** 매도금액 */
+    sll_amt: num.nullish(),
+    /** 매도손익금액 */
+    sll_pls_amt: num.nullish(),
+    /** 수익율 */
+    pft_rt: num.nullish(),
+    /** 종합과세구분코드 */
+    syn_ttn_dit_cd: z.string().nullish(),
+    /** 종합과세구분코드명 */
+    syn_ttn_dit_cd_nm: z.string().nullish(),
+    /** CRM자산분류코드 */
+    crm_aet_cfc_cd: z.string().nullish(),
+    /** 약정이자율 */
+    ctc_int_rt: z.string().nullish(),
+    /** 대출매수일자 */
+    lon_byn_dt: z.string().nullish(),
+    /** 만기일자 */
+    xrn_dt: z.string().nullish(),
+    /** 증거금율 */
+    wtm_rt: z.string().nullish(),
+    /** 대출잔고금액 */
+    lon_bnc_amt: num.nullish(),
+    /** 종목중분류코드 */
+    iem_mlf_cd: z.string().nullish(),
+    /** 통합잔고유형코드 */
+    itg_bnc_tp_cd: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식잔고조회 (`POST /krstock/inquiry/v1/balance`) 응답. */
+export const krStockInquiryBalanceResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 계좌 종합 정보 */
+    Output_0: krStockInquiryBalanceAccountOutputSchema.nullish(),
+    /** 보유 종목별 상세 목록 */
+    Output_1: z.array(krStockInquiryBalanceHoldingOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 주식일별주문체결조회 고객 정보 (Output_0). */
+export const krStockInquiryDailyOrderExecutionCustomerOutputSchema = z
+  .object({
+    /** 고객성명 */
+    cus_fnm: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식일별주문체결조회 주문·체결 상세 (Output_1 배열의 각 항목). */
+export const krStockInquiryDailyOrderExecutionOutputSchema = z
+  .object({
+    /** 통합주문번호 */
+    itg_orr_no: num.nullish(),
+    /** 주문시장코드명 */
+    orr_mkt_cd_nm: z.string().nullish(),
+    /** 모통합주문번호 */
+    mo_itg_orr_no: z.string().nullish(),
+    /** 원통합주문번호 */
+    org_itg_orr_no: num.nullish(),
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 매매구분코드명 */
+    sby_dit_cd_nm: z.string().nullish(),
+    /** 정정취소구분코드명 */
+    cor_can_dit_cd_nm: z.string().nullish(),
+    /** 대출일자 */
+    lon_dt: z.string().nullish(),
+    /** 신용대출코드 — 00.일반거래 01.유통융자 02.자기융자 03.유통대주 04.자기대주 10.매입자금대출 */
+    cfd_lon_cd: z.string().nullish(),
+    /** 호가유형코드명 */
+    nmn_pr_tp_cd_nm: z.string().nullish(),
+    /** 주문조건구분코드명 */
+    orr_cnd_dit_cd_nm: z.string().nullish(),
+    /** 주문수량 */
+    orr_qty: num.nullish(),
+    /** 주문가격 */
+    orr_pr: num.nullish(),
+    /** 총체결수량 */
+    tot_cns_qty: num.nullish(),
+    /** 체결평균단가 */
+    cns_avg_uit_pr: num.nullish(),
+    /** 체결금액 */
+    cns_amt: num.nullish(),
+    /** 체결건수 */
+    cns_cnt: num.nullish(),
+    /** 미체결수량 */
+    ny_cns_qty: num.nullish(),
+    /** 정정수량 */
+    cor_qty: z.string().nullish(),
+    /** 취소수량 */
+    can_qty: num.nullish(),
+    /** 주문시각 */
+    orr_tm: z.string().nullish(),
+    /** 주문매체 */
+    orr_mdi: z.string().nullish(),
+    /** 채권매수일자 */
+    bnd_byn_dt: z.string().nullish(),
+    /** 종합과세구분코드명 */
+    syn_ttn_dit_cd_nm: z.string().nullish(),
+    /** 주문거부사유코드명 */
+    orr_rjt_rsn_cd_nm: z.string().nullish(),
+    /** 처리사원번호 */
+    pcs_emp_no: z.string().nullish(),
+    /** 요청시장코드 — SOR/KRX/NXT */
+    rmt_mkt_cd: z.string().nullish(),
+    /** SOR시장분할여부 — Y.분할 N.미분할 */
+    sor_mkt_sli_yn: z.string().nullish(),
+    /** 거래소대량상대증권회사코드 */
+    krx_lnt_opi_sec_co_cd: z.string().nullish(),
+    /** 거래소대량상대계좌번호 */
+    krx_lnt_opi_act_no: z.string().nullish(),
+    /** 거래소대량협의완료시간 */
+    krx_lnt_cnf_cpl_hur: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식일별주문체결조회 (`POST /krstock/inquiry/v1/dailyOrderExecution`) 응답. */
+export const krStockInquiryDailyOrderExecutionResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 고객 정보 (스펙은 Object, 실제 예시는 Array — 둘 다 허용) */
+    Output_0: z
+      .union([
+        z.array(krStockInquiryDailyOrderExecutionCustomerOutputSchema),
+        krStockInquiryDailyOrderExecutionCustomerOutputSchema,
+      ])
+      .nullish(),
+    /** 주문·체결 상세 목록 */
+    Output_1: z.array(krStockInquiryDailyOrderExecutionOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 매수가능수량조회 결과 (Output_0). */
+export const krStockInquiryBuyableQuantityOutputSchema = z
+  .object({
+    /** 매도약정금액1 — 전일 매도 약정금액 */
+    sll_ctc_amt1: z.string().nullish(),
+    /** 매수약정금액1 — 전일 매수 약정금액 */
+    byn_ctc_amt1: z.string().nullish(),
+    /** 제비용1 — 전일 제비용 */
+    sdr_xps1: z.string().nullish(),
+    /** 예수금 — 당일 예수금 */
+    dca: num.nullish(),
+    /** 매도약정금액 — 당일 매도 약정금액 */
+    sll_ctc_amt: z.string().nullish(),
+    /** 매수약정금액 — 당일 매수 약정금액 */
+    ost_byn_ctc_amt: z.string().nullish(),
+    /** 제비용 — 당일 제비용 */
+    sdr_xps: z.string().nullish(),
+    /** 익일예수금 — D+1 예수금 */
+    nxt_dd_dca: num.nullish(),
+    /** 익익일예수금 — D+2 예수금 */
+    nxt2_dd_dca: num.nullish(),
+    /** 매수미체결주문금액 — D+2 매수미체결 주문금액 */
+    byn_ny_cns_orr_amt: z.string().nullish(),
+    /** 수수료 — D+2 수수료 */
+    ost_fee: num.nullish(),
+    /** 최대가능금액 — 조회구분 1. 현금 선택시 출력 최대(미수) 가능금액 */
+    max_pbl_amt: num.nullish(),
+    /** 최대가능수량 — 최대(미수) 가능수량 */
+    max_pbl_qty: num.nullish(),
+    /** 미수발생최대가능수수료 — 최대(미수) 수수료 */
+    rvb_orn_max_pbl_fee: num.nullish(),
+    /** 현금주문가능금액 — 미수 미발생 현금 가능금액 */
+    csh_orr_pbl_amt: num.nullish(),
+    /** 현금주문가능수량 — 미수 미발생 현금 가능수량 */
+    csh_orr_pbl_qty: num.nullish(),
+    /** 수수료1 — 미수 미발생 현금 수수료 */
+    ost_fee1: num.nullish(),
+    /** 신용미수주문가능금액 — 조회구분 2. 신용(융자대주) 선택시 출력 최대주문가능 매수주문 주문가능금액 */
+    cfd_rvb_orr_pbl_amt: num.nullish(),
+    /** 신용미수주문가능수량 — 최대주문가능 매수주문 주문가능수량 */
+    cfd_rvb_orr_pbl_qty: num.nullish(),
+    /** 신용최대가능수수료 — 최대주문가능 매수주문 수수료 */
+    cfd_max_pbl_fee: num.nullish(),
+    /** 신용주문가능금액 — 미수미발생 매수주문 주문가능금액 */
+    cfd_orr_pbl_amt: num.nullish(),
+    /** 신용주문가능수량 — 미수미발생 매수주문 주문가능수량 */
+    cfd_orr_pbl_qty: num.nullish(),
+    /** 수수료2 — 미수미발생 매수주문 수수료 */
+    ost_fee2: num.nullish(),
+    /** 한도금액 — 미수 미발생 현금 개인한도금액 */
+    lmt_amt: num.nullish(),
+    /** 사용한도금액 — 미수 미발생 현금 시용한도 */
+    use_lmt_amt: num.nullish(),
+    /** 잔여한도 — 미수 미발생 현금 잔여한도 */
+    rmn_lmt: num.nullish(),
+    /** 사용가능대용금액 — 미수 미발생 현금 사용가능대용(종가) */
+    use_pbl_sba_amt: num.nullish(),
+    /** 사용가능현금 — 미수 미발생 현금 사용가능현금 */
+    use_pbl_csh: num.nullish(),
+    /** 주문가능금액1 — 미수 미발생 현금 주문가능(한도적용전) */
+    orr_pbl_amt1: num.nullish(),
+    /** 대출한도금액 — 조회구분 3.매입자금대출 선택시 출력 대출한도 */
+    lon_lmt_amt: num.nullish(),
+    /** 한도사용금액 — 한도사용금액 */
+    lmt_use_amt: num.nullish(),
+    /** 잔여한도1 — 잔여한도 */
+    rmn_lmt1: num.nullish(),
+    /** 주문가능대용금액 — 주문가능대용 */
+    orr_pbl_sba_amt: num.nullish(),
+    /** 주문가능금액2 — 주문가능금액(한도적용전) */
+    orr_pbl_amt2: num.nullish(),
+    /** 주문가능금액3 — 주문가능금액(한도적용) */
+    orr_pbl_amt3: num.nullish(),
+    /** 주문가능수량 — 주문가능수량 */
+    orr_pbl_qty: num.nullish(),
+    /** 수수료3 — 수수료 */
+    ost_fee3: num.nullish(),
+    /** 이자율 — 이자율 */
+    int_rt: num.nullish(),
+    /** 주문가격 */
+    orr_pr: z.string().nullish(),
+    /** RP평가금액 — CMA 평가금 */
+    rp_eal_amt: z.string().nullish(),
+    /** 미결제수량 */
+    ny_stl_qty: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 매수가능수량조회 (`POST /krstock/inquiry/v1/buyableQuantity`) 응답. */
+export const krStockInquiryBuyableQuantityResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 매수가능수량 조회 결과 */
+    Output_0: krStockInquiryBuyableQuantityOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** 매도가능수량조회 결과 (Output_0). */
+export const krStockInquirySellableQuantityOutputSchema = z
+  .object({
+    /** 고객성명 */
+    cus_fnm: z.string().nullish(),
+    /** 구분코드 — 1.현금 또는 신용 2.대출 */
+    ost_dit_cd: z.string().nullish(),
+    /** 구분명 */
+    dit_nm: z.string().nullish(),
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 대출일자 */
+    lon_dt: z.string().nullish(),
+    /** 신용대출코드 — 00.현금 01.유통융자 02.자기융자 03.유통대주 04.자기대주 10.매입자금대출 11.매도담보대출 12.주식담보대출 13.채권담보대출 14.ELS/DLS담보대출 15.수익증권대출 16.수익환매대출 17.청약자금대출 18.ELS/DLS환매담보대출 19.해외주식담보대출 20.해외주식매도담보대출 99.종합담보대출 _.해당사항없음 */
+    cfd_lon_cd: z.string().nullish(),
+    /** 신용대출코드명 */
+    cfd_lon_cd_nm: z.string().nullish(),
+    /** 과세유형코드 — 01.일반과세 02.비과세 03.세금우대 04.소액부징수 _.해당사항없음 */
+    ttn_tp_cd: z.string().nullish(),
+    /** 과세유형코드명 */
+    ttn_tp_cd_nm: z.string().nullish(),
+    /** 잔고수량 */
+    bnc_qty: num.nullish(),
+    /** 매도미결제수량 */
+    sll_ny_stl_qty: z.string().nullish(),
+    /** 매수미결제수량 */
+    byn_ny_stl_qty: z.string().nullish(),
+    /** 당일매도미체결수량 */
+    tdt_sll_ny_cns_qty: num.nullish(),
+    /** 매도가능수량 — 장중(08:00-15:00)까지는 수량단위미만 절사 */
+    sll_pbl_qty: num.nullish(),
+    /** 매입단가 */
+    phs_uit_pr: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 매도가능수량조회 (`POST /krstock/inquiry/v1/sellableQuantity`) 응답. */
+export const krStockInquirySellableQuantityResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 매도가능수량 조회 결과 */
+    Output_0: krStockInquirySellableQuantityOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** 주식예약주문조회 팀점 정보 (Output_0). */
+export const krStockInquiryReservedInquiryHeaderOutputSchema = z
+  .object({
+    /** 팀점명 */
+    tab_nm: z.string().nullish(),
+    /** 예약주문접수일자 */
+    bkg_orr_rtn_dt: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식예약주문조회 예약주문 내역 (Output_1 배열의 각 항목). */
+export const krStockInquiryReservedInquiryOutputSchema = z
+  .object({
+    /** 계좌번호 */
+    act_no: z.string().nullish(),
+    /** 고객성명 */
+    cus_fnm: z.string().nullish(),
+    /** 관리팀점명 */
+    amn_tab_nm: z.string().nullish(),
+    /** 계좌상품명 */
+    act_pdt_nm: z.string().nullish(),
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 매매구분코드명 */
+    sby_dit_cd_nm: z.string().nullish(),
+    /** 호가유형코드명 */
+    nmn_pr_tp_cd_nm: z.string().nullish(),
+    /** 신용대출코드명 */
+    cfd_lon_cd_nm: z.string().nullish(),
+    /** 대출일자 */
+    lon_dt: z.string().nullish(),
+    /** 주문수량 */
+    orr_qty: num.nullish(),
+    /** 주문가격 */
+    orr_pr: num.nullish(),
+    /** 누적체결수량 */
+    acl_cns_qty: num.nullish(),
+    /** 주문집행시작일자 */
+    orr_enf_sta_dt: z.string().nullish(),
+    /** 주문집행종료일자 */
+    orr_enf_end_dt: z.string().nullish(),
+    /** 최종주문집행일자 */
+    lst_orr_enf_dt: z.string().nullish(),
+    /** 예약주문유형코드명 */
+    bkg_orr_tp_cd_nm: z.string().nullish(),
+    /** 예약주문집행유형코드명 */
+    bkg_orr_enf_tp_cd_nm: z.string().nullish(),
+    /** 종가대비등락폭금액 */
+    end_pr_cmp_ftw_amt: num.nullish(),
+    /** 주문가격범위상한가 */
+    orr_pr_rge_hlm_pr: num.nullish(),
+    /** 주문가격범위하한가 */
+    orr_pr_rge_llm_pr: num.nullish(),
+    /** 예약주문취소구분코드명 */
+    bkg_orr_can_dit_cd_nm: z.string().nullish(),
+    /** 등록일자 */
+    rgs_dt: z.string().nullish(),
+    /** 등록시각 */
+    rgs_tm: z.string().nullish(),
+    /** 등록사원번호 */
+    rgs_emp_no: z.string().nullish(),
+    /** 취소일자 */
+    can_dt: z.string().nullish(),
+    /** 취소시각 */
+    can_tm: z.string().nullish(),
+    /** 취소사원번호 */
+    can_emp_no: z.string().nullish(),
+    /** 예약주문접수일자 */
+    bkg_orr_rtn_dt: z.string().nullish(),
+    /** 예약접수주문번호 */
+    bkg_rtn_orr_no: num.nullish(),
+    /** 매매구분코드 — 1.현금매도 2.현금매수 3.대용매도 4.신용매도 5.신용매수 6.대출매도 7.대출매수 (입력의 매매구분코드(0.전체/1.매도/2.매수)와는 다른 코드 집합) */
+    sby_dit_cd: z.string().nullish(),
+    /** 주식현재가격 */
+    stk_now_pr: num.nullish(),
+    /** 기간예약주문중단여부 */
+    te_bkg_orr_ssp_yn: z.string().nullish(),
+    /** 요청시장코드 */
+    rmt_mkt_cd: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식잔고조회_실현손익 계좌 종합 정보 (Output_0). */
+export const krStockInquiryRealizedPnlAccountOutputSchema = z
+  .object({
+    /** 고객성명 */
+    cus_fnm: z.string().nullish(),
+    /** 실명확인번호 */
+    rnm_cfm_no: z.string().nullish(),
+    /** 계좌활동유형세부코드 */
+    act_atv_tp_dtl_cd: z.string().nullish(),
+    /** 계좌관리팀점코드 */
+    act_amn_tab_cd: z.string().nullish(),
+    /** 계좌상품대분류코드 */
+    act_pdt_llf_cd: z.string().nullish(),
+    /** 금일예수금 — 예수금 */
+    tdy_dca: num.nullish(),
+    /** 익일예수금 — D+1 예수금 */
+    nxt_dd_dca: num.nullish(),
+    /** 익익일예수금 — D+2 예수금 */
+    nxt2_dd_dca: num.nullish(),
+    /** 주문가능금액1 — 100% 주문가능금액 */
+    orr_pbl_amt1: num.nullish(),
+    /** 주문가능금액2 — 20% 주문가능금액 */
+    orr_pbl_amt2: num.nullish(),
+    /** 주문가능금액3 — 30% 주문가능금액 */
+    orr_pbl_amt3: num.nullish(),
+    /** 주문가능금액4 — 40% 주문가능금액 */
+    orr_pbl_amt4: num.nullish(),
+    /** 현금증거금 */
+    csh_wtm: num.nullish(),
+    /** 대용증거금 */
+    sba_wtm: num.nullish(),
+    /** 당일매수금액 */
+    tdt_byn_amt: num.nullish(),
+    /** 당일매도금액 */
+    tdt_sll_amt: num.nullish(),
+    /** 제비용 — 당일매매제비용 */
+    sdr_xps: num.nullish(),
+    /** 매매손익금액 — 당일매매손익 */
+    sby_pls_amt: num.nullish(),
+    /** 평가금액합계 */
+    eal_amt_sum: num.nullish(),
+    /** 평가손익금액 */
+    eal_pls_amt: num.nullish(),
+    /** 매도증거금액 — (-)대용 */
+    sll_edn_amt: num.nullish(),
+    /** 자산금액 — D+2 자산금액 */
+    aet_amt: num.nullish(),
+    /** 자산감소금액 — 전체매도후자산 */
+    aet_drs_amt: num.nullish(),
+    /** 수익율1 — 총수익률 */
+    pft_rt1: num.nullish(),
+    /** 수익율2 — 당일실현수익률 */
+    pft_rt2: num.nullish(),
+    /** 전일평가금액2 — 전일잔고평가금액 */
+    bf_dd_eal_amt2: num.nullish(),
+    /** 평가손익2 — 전일대비손익 */
+    eal_pls2: num.nullish(),
+    /** 수익율3 — 전일대비수익률 */
+    pft_rt3: num.nullish(),
+    /** 원금합계금액 — 당일매도매입총원금 */
+    pna_sum_amt: num.nullish(),
+    /** 매입총액 — 잔고매입총액 */
+    phs_tal: num.nullish(),
+    /** 자산액면총액 — 실자산금액 */
+    aet_par_tal: num.nullish(),
+    /** 제비용2 — 매도제비용합 */
+    sdr_xps2: num.nullish(),
+    /** 매매증거금적용코드명 — 계좌증거금율 */
+    sby_wtm_aly_cd_nm: z.string().nullish(),
+    /** 수익율10 — 잔고평가수익률 */
+    pft_rt10: num.nullish(),
+  })
+  .passthrough();
+
+/** 주식잔고조회_실현손익 종목별 상세 (Output_1 배열의 각 항목). */
+export const krStockInquiryRealizedPnlOutputSchema = z
+  .object({
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 통합잔고수량 */
+    itg_bnc_qty: num.nullish(),
+    /** 주문가능수량 */
+    orr_pbl_qty: num.nullish(),
+    /** 전일매수수량 */
+    bf_dd_byn_qty: num.nullish(),
+    /** 전일매도수량 */
+    bf_dd_sll_qty: num.nullish(),
+    /** 당일매수수량 */
+    tdt_byn_qty: num.nullish(),
+    /** 당일매도수량 */
+    tdt_sll_qty: num.nullish(),
+    /** 평균매입단가 */
+    avg_phs_uit_pr: num.nullish(),
+    /** 매도단가 */
+    sll_uit_pr: num.nullish(),
+    /** 매입금액 */
+    phs_amt: num.nullish(),
+    /** 실현손익금액 */
+    rzt_pls_amt: num.nullish(),
+    /** 제비용 — 당일매매제비용 */
+    sdr_xps: num.nullish(),
+    /** 실현수익매매손익금액 */
+    rzt_pft_sby_pls_amt: num.nullish(),
+    /** 매입금액원금 */
+    ost_phs_amt_pna: num.nullish(),
+    /** 평가손익 */
+    eal_pls: num.nullish(),
+    /** 현재가격 */
+    now_pr: num.nullish(),
+    /** 수익율 */
+    pft_rt: num.nullish(),
+    /** 제비용1 — 매도제비용 */
+    sdr_xps1: num.nullish(),
+    /** 수익율7 — 당일실현수익률 */
+    pft_rt7: num.nullish(),
+    /** 수익율6 — 평가수익률 */
+    pft_rt6: num.nullish(),
+    /** 수익율2 — 당일실현수익률 */
+    pft_rt2: num.nullish(),
+    /** 잔고유형구분코드명 */
+    bnc_tp_dit_cd_nm: z.string().nullish(),
+    /** 대출일자 */
+    lon_dt: z.string().nullish(),
+    /** 전일종가 */
+    bf_dd_end_pr: num.nullish(),
+    /** 전일잔고금액 */
+    bf_dd_bnc_amt: num.nullish(),
+    /** 전일대비증감금액 */
+    bf_dd_cmp_ind_amt: num.nullish(),
+    /** 전일대비증감율 */
+    bf_dd_cmp_ind_rt: num.nullish(),
+    /** 결제잔고수량 */
+    stl_bnc_qty: num.nullish(),
+    /** 평균단가1 */
+    avg_uit_pr1: num.nullish(),
+    /** 만기일자 */
+    xrn_dt: z.string().nullish(),
+    /** 구분명1 */
+    dit_nm1: z.string().nullish(),
+    /** 전일매도금액 */
+    bf_dd_sll_amt: num.nullish(),
+    /** 금일매도금액 */
+    tdy_sll_amt: num.nullish(),
+    /** 전일매수금액 */
+    bf_dd_byn_amt: num.nullish(),
+    /** 금일매수금액 */
+    tdy_byn_amt: num.nullish(),
+    /** 매도원금 */
+    sll_pna: num.nullish(),
+    /** 잔고평가금액 */
+    bnc_eal_amt: num.nullish(),
+  })
+  .passthrough();
+
+/** 주식잔고조회_실현손익 (`POST /krstock/inquiry/v1/realizedPnl`) 응답. */
+export const krStockInquiryRealizedPnlResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 계좌 종합 정보 */
+    Output_0: krStockInquiryRealizedPnlAccountOutputSchema.nullish(),
+    /** 종목별 실현손익 상세 목록 */
+    Output_1: z.array(krStockInquiryRealizedPnlOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 투자계좌자산현황조회 계좌 종합 정보 (Output_0). */
+export const krStockInquiryAssetStatusAccountOutputSchema = z
+  .object({
+    /** 고객성명 */
+    cus_fnm: z.string().nullish(),
+    /** 실명확인번호 */
+    rnm_cfm_no: z.string().nullish(),
+    /** 약정유형코드명 */
+    ctc_tp_cd_nm: z.string().nullish(),
+    /** 계좌관리팀점코드 */
+    act_amn_tab_cd: z.string().nullish(),
+    /** 계좌상품대분류코드 */
+    act_pdt_llf_cd: z.string().nullish(),
+    /** 관리사원성명 */
+    amn_emp_fnm: z.string().nullish(),
+    /** 예수금 — 예수금 */
+    dca: num.nullish(),
+    /** 익일예수금 — D+1 예수금 */
+    nxt_dd_dca: num.nullish(),
+    /** 익익일예수금 — D+2 예수금 */
+    nxt2_dd_dca: num.nullish(),
+    /** 원화환산외화예수금 */
+    krw_tsl_fc_dca: num.nullish(),
+    /** 원화환산외화담보금액 */
+    krw_tsl_fc_mgg_amt: num.nullish(),
+    /** 원화환산외화주문가능금액 */
+    krw_tsl_fc_orr_pbl_amt: num.nullish(),
+    /** 출금가능금액 */
+    drn_pbl_amt: num.nullish(),
+    /** 융자금액 */
+    fnn_amt: num.nullish(),
+    /** 담보비율 */
+    mgg_rt: num.nullish(),
+    /** 주식주문가능금액 */
+    stk_orr_pbl_amt: num.nullish(),
+    /** 총자산금액 */
+    tot_aet_amt: num.nullish(),
+    /** 순자산금액 */
+    nas_amt: num.nullish(),
+    /** 총매수금액 */
+    tot_byn_amt: num.nullish(),
+    /** 총평가금액 */
+    tot_eal_amt: num.nullish(),
+    /** 총평가손익금액 */
+    tot_eal_pls_amt: num.nullish(),
+    /** 수익율 */
+    pft_rt: num.nullish(),
+    /** 미수금 */
+    rba: num.nullish(),
+    /** 이자미납부금액 */
+    int_ny_pmt_amt: num.nullish(),
+    /** 기타대여금 */
+    ect_lga: num.nullish(),
+    /** 대출금액 */
+    lon_amt: num.nullish(),
+    /** 대용금액 */
+    sba_amt: num.nullish(),
+    /** 금융상품주문가능금액 */
+    fnc_pdt_orr_pbl_amt: num.nullish(),
+    /** 미상환금액 */
+    ny_rdp_amt: num.nullish(),
+    /** 신용상품유형명 */
+    cfd_pdt_tp_nm: z.string().nullish(),
+    /** 계좌활동유형코드명 */
+    act_atv_tp_cd_nm: z.string().nullish(),
+    /** 대주금액 */
+    slo_amt: num.nullish(),
+    /** 현금증거금 */
+    csh_wtm: num.nullish(),
+    /** 펀드매도결제예정금액 */
+    fnd_sll_stl_xpn_amt: num.nullish(),
+    /** 청약예수금 */
+    sbi_dca: num.nullish(),
+    /** IMA증거금 */
+    ima_wtm: num.nullish(),
+  })
+  .passthrough();
+
+/** 투자계좌자산현황조회 보유 종목별 상세 (Output_1 배열의 각 항목). */
+export const krStockInquiryAssetStatusOutputSchema = z
+  .object({
+    /** 종목중분류명 */
+    iem_mlf_nm: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 잔고유형구분코드명 */
+    bnc_tp_dit_cd_nm: z.string().nullish(),
+    /** 통합잔고수량 */
+    itg_bnc_qty: num.nullish(),
+    /** 매입가격 */
+    phs_pr: num.nullish(),
+    /** 현재가격 */
+    now_pr: num.nullish(),
+    /** 매수금액 */
+    byn_amt: num.nullish(),
+    /** 평가금액 */
+    eal_amt: num.nullish(),
+    /** 평가손익금액 */
+    eal_pls_amt: num.nullish(),
+    /** 매도손익금액 */
+    sll_pls_amt: num.nullish(),
+    /** 수익율 */
+    pft_rt: num.nullish(),
+    /** 이자율 */
+    int_rt: num.nullish(),
+    /** 매수일자 */
+    byn_dt: z.string().nullish(),
+    /** 만기일자 */
+    xrn_dt: z.string().nullish(),
+    /** 대출만기일자 */
+    lon_xrn_dt: z.string().nullish(),
+    /** 종합과세구분코드 */
+    syn_ttn_dit_cd: z.string().nullish(),
+    /** 종합과세구분코드명 */
+    syn_ttn_dit_cd_nm: z.string().nullish(),
+    /** CRM자산분류코드 */
+    crm_aet_cfc_cd: z.string().nullish(),
+    /** 종목중분류코드 */
+    iem_mlf_cd: z.string().nullish(),
+    /** 매수청구수량 */
+    byn_cim_qty: num.nullish(),
+    /** 실물수량 */
+    rth_qty: num.nullish(),
+    /** 약정이자율 */
+    ctc_int_rt: num.nullish(),
+    /** 대출잔고금액 */
+    lon_bnc_amt: num.nullish(),
+    /** 통화코드 */
+    cur_cd: z.string().nullish(),
+    /** 외화증권거래국가코드 */
+    fc_sec_trd_nat_cd: z.string().nullish(),
+    /** 국가코드명 */
+    nat_cd_nm: z.string().nullish(),
+    /** 통합잔고유형코드 */
+    itg_bnc_tp_cd: z.string().nullish(),
+    /** 티커종목코드 */
+    tck_iem_cd: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 투자계좌자산현황조회 (`POST /krstock/inquiry/v1/assetStatus`) 응답. */
+export const krStockInquiryAssetStatusResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 계좌 종합 정보 */
+    Output_0: krStockInquiryAssetStatusAccountOutputSchema.nullish(),
+    /** 보유 종목별 상세 목록 */
+    Output_1: z.array(krStockInquiryAssetStatusOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 실현손익일별합산조회 계좌 종합 정보 (Output_0). */
+export const krStockInquiryDailyPnlAccountOutputSchema = z
+  .object({
+    /** 계좌성명 */
+    act_fnm: z.string().nullish(),
+    /** 매수대금합계1 */
+    byn_cst_sum: z.union([z.string(), num]).nullish(),
+    /** 매도대금합계1 */
+    sll_cst_sum: z.union([z.string(), num]).nullish(),
+    /** 손익금액합계 */
+    pls_amt_sum: num.nullish(),
+    /** 누적제비용 */
+    acl_sdr_xps: num.nullish(),
+  })
+  .passthrough();
+
+/** 실현손익일별합산조회 일별 상세 (Output_1 배열의 각 항목). */
+export const krStockInquiryDailyPnlOutputSchema = z
+  .object({
+    /** 매매일자 */
+    sby_dt: z.string().nullish(),
+    /** 매수수량 */
+    byn_qty: num.nullish(),
+    /** 매수금액 */
+    byn_amt: num.nullish(),
+    /** 매수수수료 */
+    byn_fee: num.nullish(),
+    /** 매수금액합계 */
+    byn_amt_sum: num.nullish(),
+    /** 매도수량 */
+    sll_qty: num.nullish(),
+    /** 매도금액 */
+    sll_amt: num.nullish(),
+    /** 매도세금합계 */
+    sll_tax_sum: num.nullish(),
+    /** 매도금액합계 */
+    sll_amt_sum: num.nullish(),
+    /** 손익금액 */
+    pls_amt: num.nullish(),
+    /** 수익율 */
+    pft_rt: num.nullish(),
+    /** 종목중분류코드 — 01001.주식 01002.DR 01003.투자회사 01004.신주인수권증권 01005.상장REITS 01006.신주인수권증서 01007.ETF 01008.상장수익증권 */
+    iem_mlf_cd: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 실현손익일별합산조회 (`POST /krstock/inquiry/v1/dailyPnl`) 응답. */
+export const krStockInquiryDailyPnlResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 계좌 종합 정보 */
+    Output_0: krStockInquiryDailyPnlAccountOutputSchema.nullish(),
+    /** 일별 실현손익 상세 목록 */
+    Output_1: z.array(krStockInquiryDailyPnlOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 종목별실현손익현황조회 계좌 합계 정보 (Output_0). */
+export const krStockInquiryTradingPnlAccountOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 매수수량 */
+    byn_qty: num.nullish(),
+    /** 매수단가 */
+    byn_uit_pr: num.nullish(),
+    /** 매수수수료 */
+    byn_fee: num.nullish(),
+    /** 매수건수 */
+    byn_cnt: num.nullish(),
+    /** 매수금액 */
+    byn_amt: num.nullish(),
+    /** 매도수량 */
+    sll_qty: num.nullish(),
+    /** 매도단가 */
+    sll_uit_pr: num.nullish(),
+    /** 매도세금합계 */
+    sll_tax_sum: num.nullish(),
+    /** 매도건수 */
+    sll_cnt: num.nullish(),
+    /** 매도금액 */
+    sll_amt: num.nullish(),
+    /** 매도장부금액 */
+    sll_abk_amt: num.nullish(),
+    /** 손익금액 */
+    pls_amt: num.nullish(),
+    /** 수익율 */
+    pft_rt: num.nullish(),
+    /** 수수료합계 */
+    fee_sum: z.union([z.string(), num]).nullish(),
+    /** 세금합계 */
+    tax_sum: z.union([z.string(), num]).nullish(),
+  })
+  .passthrough();
+
+/** 종목별실현손익현황조회 종목별 상세 (Output_1 배열의 각 항목). */
+export const krStockInquiryTradingPnlOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 매수수량 */
+    byn_qty: num.nullish(),
+    /** 매수단가 */
+    byn_uit_pr: num.nullish(),
+    /** 매수수수료 */
+    byn_fee: num.nullish(),
+    /** 매수건수 */
+    byn_cnt: num.nullish(),
+    /** 매수금액 */
+    byn_amt: num.nullish(),
+    /** 매도수량 */
+    sll_qty: num.nullish(),
+    /** 매도단가 */
+    sll_uit_pr: num.nullish(),
+    /** 매도세금합계 */
+    sll_tax_sum: num.nullish(),
+    /** 매도건수 */
+    sll_cnt: num.nullish(),
+    /** 매도금액 */
+    sll_amt: num.nullish(),
+    /** 매도장부금액 */
+    sll_abk_amt: num.nullish(),
+    /** 손익금액 */
+    pls_amt: num.nullish(),
+    /** 수익율 */
+    pft_rt: num.nullish(),
+    /** 수수료합계 */
+    fee_sum: z.union([z.string(), num]).nullish(),
+    /** 세금합계 */
+    tax_sum: z.union([z.string(), num]).nullish(),
+    /** 종목중분류코드 — 01001.주식 01002.DR 01003.투자회사 01004.신주인수권증권 01005.상장REITS 01006.신주인수권증서 01007.ETF 01008.상장수익증권 */
+    iem_mlf_cd: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 종목별실현손익현황조회 (`POST /krstock/inquiry/v1/tradingPnl`) 응답. */
+export const krStockInquiryTradingPnlResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 계좌 합계 정보 */
+    Output_0: krStockInquiryTradingPnlAccountOutputSchema.nullish(),
+    /** 종목별 실현손익 상세 목록 */
+    Output_1: z.array(krStockInquiryTradingPnlOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 주식통합증거금 현황 계좌 한도 정보 (Output_0). */
+export const krStockInquiryIntegratedMarginAccountOutputSchema = z
+  .object({
+    /** 외화주문가능금액3 — 주문가능금액 */
+    fc_orr_pbl_amt3: num.nullish(),
+    /** 교차매매결제금액 — 결제금(원) */
+    cro_sby_stl_amt: num.nullish(),
+    /** 교차매매계좌여부 — 약정여부 */
+    cro_sby_act_yn: z.string().nullish(),
+    /** 한도금액 — 한도금액(원) */
+    lmt_amt: num.nullish(),
+    /** 한도사용금액 — 한도사용금액(원) */
+    lmt_use_amt: num.nullish(),
+    /** 잔여한도금액 — 한도잔여금액(원) */
+    rmn_lmt_amt: num.nullish(),
+  })
+  .passthrough();
+
+/** 주식통합증거금 현황 통화별 상세 (Output_1 배열의 각 항목). */
+export const krStockInquiryIntegratedMarginOutputSchema = z
+  .object({
+    /** 통화코드 */
+    cur_cd: z.string().nullish(),
+    /** 외화예수금 */
+    fc_dca: num.nullish(),
+    /** 외화담보금액 */
+    fc_mgg_amt: num.nullish(),
+    /** 해외거래세 */
+    ose_trd_tax: num.nullish(),
+    /** 외화자동재매매대상금액 — 매도금액 */
+    fc_ato_re_sby_obj_amt: num.nullish(),
+    /** 외화주문가능금액 — 자국통화 주문가능금액 */
+    fc_orr_pbl_amt: num.nullish(),
+    /** 적용환율 */
+    aly_xcg_rt: num.nullish(),
+    /** 주문가능금액현금 */
+    orr_pbl_amt_csh: num.nullish(),
+    /** 전환비율 — 통합증거금 통화간 전환비율 */
+    cnv_rt: num.nullish(),
+    /** 원화환산교차가능금액 — 타국통화 통합증거금 가능금액(원) */
+    krw_tsl_cro_pbl_amt: num.nullish(),
+    /** 거래통화교차가능금액 — 타국통화 주문가능금액 */
+    trd_cur_cro_pbl_amt: num.nullish(),
+    /** 외화주문가능금액1 — 주문가능금액 */
+    fc_orr_pbl_amt1: num.nullish(),
+    /** 외화주문가능금액2 — 가능금액 */
+    fc_orr_pbl_amt2: num.nullish(),
+    /** 거래통화교차사용금액 — 사용금액 */
+    trd_cur_cro_use_amt: num.nullish(),
+  })
+  .passthrough();
+
+/** 주식통합증거금 현황 (`POST /krstock/inquiry/v1/integratedMargin`) 응답. */
+export const krStockInquiryIntegratedMarginResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 계좌 한도 정보 */
+    Output_0: krStockInquiryIntegratedMarginAccountOutputSchema.nullish(),
+    /** 통화별 상세 목록 */
+    Output_1: z.array(krStockInquiryIntegratedMarginOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 기간별계좌권리현황조회보유 조회 조건 정보 (Output_0). */
+export const krStockInquiryRightsHeldHeaderOutputSchema = z
+  .object({
+    /** 시작일자 — YYYYMMDD */
+    sta_dt: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 기간별계좌권리현황조회보유 보유 권리 상세 (Output_1 배열의 각 항목). */
+export const krStockInquiryRightsHeldOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 기준일자 — YYYYMMDD */
+    bse_dt: z.string().nullish(),
+    /** 권리유형코드 — _.해당사항없음 01.배당 02.유상 03.무상 04.매수청구 05.신주인수권증서 06.뮤추얼 07.ETF분배금 08.선박펀드 09.투융자펀드 10.해외자원개발펀드 11.Ritz(부동산신탁) 12.ELS상환 13.DLS상환 14.ELW만기결제 15.기타청산 16.전환/상환 17.ETN분배금 21.흡수합병 22.회사분할 23.주식교환 24.자본감소 25.액면분할 26.액면병합 27.종목변경 등 (전체 코드 목록은 스펙 참고, 문자·숫자 혼용 코드 다수) */
+    rit_tp_cd: z.string().nullish(),
+    /** 보유수량 */
+    hld_qty: num.nullish(),
+    /** 배정기준가격 */
+    aloc_bse_pr: num.nullish(),
+    /** 신청금액 */
+    req_amt: num.nullish(),
+    /** 배정금액지급일자 — YYYYMMDD */
+    aloc_amt_pym_dt: z.string().nullish(),
+    /** 상장일자 — YYYYMMDD */
+    ltg_dt: z.string().nullish(),
+    /** 신청여부 */
+    req_yn: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 대여차입구분코드 — 01.차입 02.대여(주식) 03.대여풀 04.대여(채권) 05.대여(해외주식) 06.대여(해외채권) */
+    ldg_brw_dit_cd: z.string().nullish(),
+    /** 유통구분코드 — 01.일반 02.유통금융 03.유통대주 */
+    cln_dit_cd: z.string().nullish(),
+    /** 배정수량 */
+    aloc_qty: num.nullish(),
+    /** 신청종료일자 — YYYYMMDD */
+    req_end_dt: z.string().nullish(),
+    /** 신청수량 */
+    req_qty: num.nullish(),
+    /** 권리배정금액 */
+    rit_aloc_amt: num.nullish(),
+    /** 상장종목코드 */
+    ltg_iem_cd: z.string().nullish(),
+    /** 처리여부 */
+    pcs_yn: z.string().nullish(),
+    /** 고배당여부 */
+    hdd_yn: z.string().nullish(),
+    /** 예약시작일자 — YYYYMMDD */
+    bkg_sta_dt: z.string().nullish(),
+    /** 예약종료일자 — YYYYMMDD */
+    bkg_end_dt: z.string().nullish(),
+    /** 반대의사접수종료일자 — YYYYMMDD */
+    rrs_itn_rtn_end_dt: z.string().nullish(),
+    /** 매수청구접수종료일자 — YYYYMMDD */
+    byn_cim_rtn_end_dt: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 기간별계좌권리현황조회보유 (`POST /krstock/inquiry/v1/rightsHeld`) 응답. */
+export const krStockInquiryRightsHeldResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 조회 조건 정보 */
+    Output_0: krStockInquiryRightsHeldHeaderOutputSchema.nullish(),
+    /** 보유 권리 상세 목록 */
+    Output_1: z.array(krStockInquiryRightsHeldOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 기간별계좌권리현황조회예정 예정 권리 상세 (Output_0 배열의 각 항목). */
+export const krStockInquiryRightsScheduledOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 권리유형코드 — _.전체 01.배당 02.유상 03.무상 04.매수청구 05.신주인수권증서 06.뮤추얼 07.ETF분배금 08.선박펀드 09.투융자펀드 10.해외자원개발펀드 11.Ritz(부동산신탁) 12.ELS상환 13.DLS상환 14.ELW만기결제 15.기타청산 16.전환/상환 17.ETN분배금 21.흡수합병 22.회사분할 등 (전체 코드 목록은 스펙 참고, 문자·숫자 혼용 코드 다수) */
+    rit_tp_cd: z.string().nullish(),
+    /** 권리유형명 */
+    rit_tp_nm: z.string().nullish(),
+    /** 배정수량 */
+    aloc_qty: num.nullish(),
+    /** 배정비율 */
+    aloc_rt: num.nullish(),
+    /** 권리락일자 */
+    xgt_dt: z.string().nullish(),
+    /** 기준일자 */
+    bse_dt: z.string().nullish(),
+    /** 권리행사종료일자 */
+    rit_erc_end_dt: z.string().nullish(),
+    /** 상장일자 */
+    ltg_dt: z.string().nullish(),
+    /** 권리행사가격 */
+    rit_erc_pr: num.nullish(),
+  })
+  .passthrough();
+
+/** 기간별계좌권리현황조회예정 (`POST /krstock/inquiry/v1/rightsScheduled`) 응답. */
+export const krStockInquiryRightsScheduledResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 예정 권리 상세 목록 */
+    Output_0: z.array(krStockInquiryRightsScheduledOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 주식예약주문조회 (`POST /krstock/inquiry/v1/reservedInquiry`) 응답. */
+export const krStockInquiryReservedInquiryResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 팀점 정보 */
+    Output_0: krStockInquiryReservedInquiryHeaderOutputSchema.nullish(),
+    /** 예약주문 내역 목록 */
+    Output_1: z.array(krStockInquiryReservedInquiryOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── Response Types ──
+
+export type KrStockInquiryBalanceResponse = CamelizeKeys<z.infer<typeof krStockInquiryBalanceResponseSchema>>;
+export type KrStockInquiryDailyOrderExecutionResponse = CamelizeKeys<
+  z.infer<typeof krStockInquiryDailyOrderExecutionResponseSchema>
+>;
+export type KrStockInquiryBuyableQuantityResponse = CamelizeKeys<
+  z.infer<typeof krStockInquiryBuyableQuantityResponseSchema>
+>;
+export type KrStockInquirySellableQuantityResponse = CamelizeKeys<
+  z.infer<typeof krStockInquirySellableQuantityResponseSchema>
+>;
+export type KrStockInquiryRealizedPnlResponse = CamelizeKeys<z.infer<typeof krStockInquiryRealizedPnlResponseSchema>>;
+export type KrStockInquiryAssetStatusResponse = CamelizeKeys<z.infer<typeof krStockInquiryAssetStatusResponseSchema>>;
+export type KrStockInquiryDailyPnlResponse = CamelizeKeys<z.infer<typeof krStockInquiryDailyPnlResponseSchema>>;
+export type KrStockInquiryTradingPnlResponse = CamelizeKeys<z.infer<typeof krStockInquiryTradingPnlResponseSchema>>;
+export type KrStockInquiryIntegratedMarginResponse = CamelizeKeys<
+  z.infer<typeof krStockInquiryIntegratedMarginResponseSchema>
+>;
+export type KrStockInquiryRightsHeldResponse = CamelizeKeys<z.infer<typeof krStockInquiryRightsHeldResponseSchema>>;
+export type KrStockInquiryRightsScheduledResponse = CamelizeKeys<
+  z.infer<typeof krStockInquiryRightsScheduledResponseSchema>
+>;
+export type KrStockInquiryReservedInquiryResponse = CamelizeKeys<
+  z.infer<typeof krStockInquiryReservedInquiryResponseSchema>
+>;
+
+// ── Response Map ──
+
+export interface KrstockInquiryResponseMap {
+  balance: KrStockInquiryBalanceResponse;
+  dailyOrderExecution: KrStockInquiryDailyOrderExecutionResponse;
+  buyableQuantity: KrStockInquiryBuyableQuantityResponse;
+  sellableQuantity: KrStockInquirySellableQuantityResponse;
+  reservedInquiry: KrStockInquiryReservedInquiryResponse;
+  realizedPnl: KrStockInquiryRealizedPnlResponse;
+  assetStatus: KrStockInquiryAssetStatusResponse;
+  dailyPnl: KrStockInquiryDailyPnlResponse;
+  tradingPnl: KrStockInquiryTradingPnlResponse;
+  integratedMargin: KrStockInquiryIntegratedMarginResponse;
+  rightsHeld: KrStockInquiryRightsHeldResponse;
+  rightsScheduled: KrStockInquiryRightsScheduledResponse;
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/schemas/krstock-order.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/schemas/krstock-order.ts
@@ -1,0 +1,255 @@
+import { z } from 'zod';
+
+import type { CamelizeKeys } from '../../core/types';
+
+const messageSchema = z
+  .object({
+    msg_code: z.string().nullish(),
+    usr_msg: z.string().nullish(),
+    msg_lv_code: z.string().nullish(),
+    dvlp_msg_yn: z.string().nullish(),
+    svc_nm: z.string().nullish(),
+    func_nm: z.string().nullish(),
+    line_no: z.string().nullish(),
+    dvlp_msg: z.string().nullish(),
+  })
+  .passthrough();
+
+/**
+ * 자산군(krstock 등) 공통 응답 봉투.
+ *
+ * 스펙은 `Output_N` + `message` 구조로 명세하지만 실서버는 `rsp_cd`/`rsp_msg` 를
+ * 반환하고 `message` 는 null 이다(모의 실측 2026-08-22). 셋 다 optional 로 둔다.
+ */
+const assetEnvelope = {
+  /** 응답코드 (00000: 성공) */
+  rsp_cd: z.string().nullish(),
+  /** 응답메시지 */
+  rsp_msg: z.string().nullish(),
+  /** 스펙상 메시지 봉투 (실서버는 null) */
+  message: messageSchema.nullish(),
+};
+/**
+ * 파이썬 모델이 `int`/`float` 로 선언한 숫자 필드.
+ *
+ * 스펙이 int 라고 해도 실서버가 문자열로 내려주는 사례가 있어(예: 잔고조회
+ * `orr_pbl_amt1`, 2026-08-22 모의 실측) 숫자로 강제 변환한다. 빈 문자열은
+ * `z.coerce.number()` 가 0 으로 바꿔버리므로 null 로 따로 처리한다.
+ */
+const num = z.union([z.number(), z.literal('').transform(() => null), z.coerce.number()]);
+
+/** 신규 주문(현금·신용 매수/매도) 공통 접수 결과 — 스펙상 4개 API 의 Output_0 이 동일하다. */
+export const krStockOrderPlacedOutputSchema = z
+  .object({
+    /** 주문채번팀점코드 */
+    orr_gno_tab_cd: z.string().nullish(),
+    /** 시장주문번호 — 정정·취소시 필요한 주문번호 */
+    mkt_orr_no: num.nullish(),
+    /** SOR파일ID — 요청시장코드 SOR 경우에만 세팅 */
+    sor_fle_id: z.string().nullish(),
+    /** SOR배분비율1 (KRX) — SOR 경우에만 세팅 */
+    sor_ant_rt1: num.nullish(),
+    /** SOR배분비율2 (NXT) — SOR 경우에만 세팅 */
+    sor_ant_rt2: num.nullish(),
+    /** 주문수량1 (KRX) */
+    orr_qty1: num.nullish(),
+    /** 주문수량2 (NXT) */
+    orr_qty2: num.nullish(),
+    /** 신규자시장주문번호1 (KRX) */
+    anw_cld_mkt_orr_no1: num.nullish(),
+    /** 신규자시장주문번호2 (NXT) */
+    anw_cld_mkt_orr_no2: num.nullish(),
+  })
+  .passthrough();
+
+/** 주식주문(현금) 매수 (`POST /krstock/order/v1/cashBuy`) 응답. */
+export const krStockOrderCashBuyResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 주문 접수 결과 */
+    Output_0: krStockOrderPlacedOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** 주식주문(현금) 매도 (`POST /krstock/order/v1/cashSell`) 응답. */
+export const krStockOrderCashSellResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 주문 접수 결과 */
+    Output_0: krStockOrderPlacedOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** 주식주문(신용) 매수 (`POST /krstock/order/v1/creditBuy`) 응답. */
+export const krStockOrderCreditBuyResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 주문 접수 결과 */
+    Output_0: krStockOrderPlacedOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** 주식주문(신용) 매도 (`POST /krstock/order/v1/creditSell`) 응답. */
+export const krStockOrderCreditSellResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 주문 접수 결과 */
+    Output_0: krStockOrderPlacedOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** 정정·취소(modify·cancel) 공통 접수 결과 — 스펙상 두 API 의 Output_0 이 동일하다. */
+export const krStockOrderAmendedOutputSchema = z
+  .object({
+    /** 주문채번팀점코드 */
+    orr_gno_tab_cd: z.string().nullish(),
+    /** 시장주문번호 — 정정·취소시 필요한 주문번호 */
+    mkt_orr_no: num.nullish(),
+    /** SOR파일ID — 요청시장코드 SOR 경우에만 세팅 */
+    sor_fle_id: z.string().nullish(),
+    /** 취소SOR배분비율1 (KRX) — SOR 경우에만 세팅 */
+    can_sor_ant_rt1: num.nullish(),
+    /** 취소SOR배분비율2 (NXT) — SOR 경우에만 세팅 */
+    can_sor_ant_rt2: num.nullish(),
+    /** 취소주문수량1 (KRX) */
+    can_orr_qty1: num.nullish(),
+    /** 취소주문수량2 (NXT) */
+    can_orr_qty2: num.nullish(),
+    /** 취소자시장주문번호1 (KRX) */
+    can_cld_mkt_orr_no1: num.nullish(),
+    /** 취소자시장주문번호2 (NXT) */
+    can_cld_mkt_orr_no2: num.nullish(),
+  })
+  .passthrough();
+
+/** 주식주문(정정취소) 정정 (`POST /krstock/order/v1/modify`) 응답. */
+export const krStockOrderModifyResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 정정 접수 결과 */
+    Output_0: krStockOrderAmendedOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** 주식주문(정정취소) 취소 (`POST /krstock/order/v1/cancel`) 응답. */
+export const krStockOrderCancelResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 취소 접수 결과 */
+    Output_0: krStockOrderAmendedOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/**
+ * 주식예약주문 접수 결과 — 신규·정정취소 계열과 달리 전용 스키마(입력값 표시 위주)다.
+ *
+ * 주의: 아래 필드는 스펙(krstock/openapi.json)의 200 응답 스키마 선언을 옮긴 것이고
+ * 실서버 응답으로 확인된 것이 아니다. 스펙에 이 API 의 예시 응답이 없고, 예약주문은
+ * 실주문이라 모의투자에서도 접수가 안 돼 실측 경로가 없다. 실제로는 `bkg_orr_no` 만
+ * 내려올 가능성이 크다. 전부 nullish 이므로 어느 쪽이든 파싱은 안전하다.
+ */
+export const krStockOrderReservedOrderOutputSchema = z
+  .object({
+    /** 예약주문번호 — 예약 접수된 번호 */
+    bkg_orr_no: num.nullish(),
+    /** 계좌번호 — 입력값 표시 */
+    act_no: z.string().nullish(),
+    /** 종목코드 — 입력값 표시 */
+    iem_cd: z.string().nullish(),
+    /** 매매구분코드 — 입력값 표시 (1.매도 2.매수) */
+    sby_dit_cd: z.string().nullish(),
+    /** 선물대용주문여부 — 입력값 표시 */
+    frs_sba_orr_yn: z.string().nullish(),
+    /** 호가유형코드 — 입력값 표시 */
+    nmn_pr_tp_cd: z.string().nullish(),
+    /** 신용대출코드 — 입력값 표시 */
+    cfd_lon_cd: z.string().nullish(),
+    /** 대출일자 — 입력값 표시 (YYYYMMDD) */
+    lon_dt: z.string().nullish(),
+    /** 주문수량 — 입력값 표시 */
+    orr_qty: z.string().nullish(),
+    /** 주문단가 — 입력값 표시 */
+    orr_uit_pr: z.string().nullish(),
+    /** 연락처전화번호 — 입력값 표시. 스펙 선언이며 실응답 미확인. 내려온다면 개인정보 */
+    aca_tel_no: z.string().nullish(),
+    /** 예약주문유형코드 — 입력값 표시 */
+    bkg_orr_tp_cd: z.string().nullish(),
+    /** 예약주문시작일자 — 입력값 표시 (YYYYMMDD) */
+    bkg_orr_sta_dt: z.string().nullish(),
+    /** 예약주문종료일자 — 입력값 표시 (YYYYMMDD) */
+    bkg_orr_end_dt: z.string().nullish(),
+    /** 예약주문집행유형코드 — 입력값 표시 */
+    bkg_orr_enf_tp_cd: z.string().nullish(),
+    /** 종가대비등락폭금액 — 입력값 표시 */
+    end_pr_cmp_ftw_amt: z.string().nullish(),
+    /** 주문가격범위상한가 — 입력값 표시 */
+    orr_pr_rge_hlm_pr: z.string().nullish(),
+    /** 주문가격범위하한가 — 입력값 표시 */
+    orr_pr_rge_llm_pr: z.string().nullish(),
+    /**
+     * 비밀번호 — 입력값 표시. 스펙 선언이며 실응답 미확인(파이썬 모델 주석 참고).
+     * 값이 실제로 내려온다면 계좌 비밀번호이므로 로그·출력에 남기지 말 것.
+     */
+    pwd: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식예약주문 (`POST /krstock/order/v1/reservedOrder`) 응답. */
+export const krStockOrderReservedOrderResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 예약주문 접수 결과 */
+    Output_0: krStockOrderReservedOrderOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** 주식예약주문취소 접수 결과 — 신규·정정취소·예약주문 계열과 다른 전용 스키마(입력값 표시)다. */
+export const krStockOrderReservedCancelOutputSchema = z
+  .object({
+    /** 계좌번호 — 입력값 표시 */
+    act_no: z.string().nullish(),
+    /** 매매구분코드 — 입력값 표시 (1.매도 2.매수) */
+    sby_dit_cd: z.string().nullish(),
+    /** 종목코드 — 입력값 표시 */
+    iem_cd: z.string().nullish(),
+    /** 예약주문번호 — 입력값 표시 */
+    bkg_orr_no: num.nullish(),
+    /** 예약주문유형코드 — 입력값 표시 */
+    bkg_orr_tp_cd: z.string().nullish(),
+    /** 예약접수일자 — 입력값 표시 (YYYYMMDD) */
+    bkg_rtn_dt: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식예약주문취소 (`POST /krstock/order/v1/reservedCancel`) 응답. */
+export const krStockOrderReservedCancelResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 예약주문취소 접수 결과 */
+    Output_0: krStockOrderReservedCancelOutputSchema.nullish(),
+  })
+  .passthrough();
+
+// ── Response Types ──
+
+export type KrStockOrderCashBuyResponse = CamelizeKeys<z.infer<typeof krStockOrderCashBuyResponseSchema>>;
+export type KrStockOrderCashSellResponse = CamelizeKeys<z.infer<typeof krStockOrderCashSellResponseSchema>>;
+export type KrStockOrderCreditBuyResponse = CamelizeKeys<z.infer<typeof krStockOrderCreditBuyResponseSchema>>;
+export type KrStockOrderCreditSellResponse = CamelizeKeys<z.infer<typeof krStockOrderCreditSellResponseSchema>>;
+export type KrStockOrderModifyResponse = CamelizeKeys<z.infer<typeof krStockOrderModifyResponseSchema>>;
+export type KrStockOrderCancelResponse = CamelizeKeys<z.infer<typeof krStockOrderCancelResponseSchema>>;
+export type KrStockOrderReservedOrderResponse = CamelizeKeys<z.infer<typeof krStockOrderReservedOrderResponseSchema>>;
+export type KrStockOrderReservedCancelResponse = CamelizeKeys<z.infer<typeof krStockOrderReservedCancelResponseSchema>>;
+
+// ── Response Map ──
+
+export interface KrstockOrderResponseMap {
+  cashBuy: KrStockOrderCashBuyResponse;
+  cashSell: KrStockOrderCashSellResponse;
+  creditBuy: KrStockOrderCreditBuyResponse;
+  creditSell: KrStockOrderCreditSellResponse;
+  modify: KrStockOrderModifyResponse;
+  cancel: KrStockOrderCancelResponse;
+  reservedOrder: KrStockOrderReservedOrderResponse;
+  reservedCancel: KrStockOrderReservedCancelResponse;
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/schemas/krstock-order.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/schemas/krstock-order.ts
@@ -140,14 +140,7 @@ export const krStockOrderCancelResponseSchema = z
   })
   .passthrough();
 
-/**
- * 주식예약주문 접수 결과 — 신규·정정취소 계열과 달리 전용 스키마(입력값 표시 위주)다.
- *
- * 주의: 아래 필드는 스펙(krstock/openapi.json)의 200 응답 스키마 선언을 옮긴 것이고
- * 실서버 응답으로 확인된 것이 아니다. 스펙에 이 API 의 예시 응답이 없고, 예약주문은
- * 실주문이라 모의투자에서도 접수가 안 돼 실측 경로가 없다. 실제로는 `bkg_orr_no` 만
- * 내려올 가능성이 크다. 전부 nullish 이므로 어느 쪽이든 파싱은 안전하다.
- */
+/** 주식예약주문 접수 결과 — 신규·정정취소 계열과 달리 전용 스키마(입력값 표시 위주)다. */
 export const krStockOrderReservedOrderOutputSchema = z
   .object({
     /** 예약주문번호 — 예약 접수된 번호 */
@@ -170,7 +163,7 @@ export const krStockOrderReservedOrderOutputSchema = z
     orr_qty: z.string().nullish(),
     /** 주문단가 — 입력값 표시 */
     orr_uit_pr: z.string().nullish(),
-    /** 연락처전화번호 — 입력값 표시. 스펙 선언이며 실응답 미확인. 내려온다면 개인정보 */
+    /** 연락처전화번호 — 입력값 표시 */
     aca_tel_no: z.string().nullish(),
     /** 예약주문유형코드 — 입력값 표시 */
     bkg_orr_tp_cd: z.string().nullish(),
@@ -186,10 +179,7 @@ export const krStockOrderReservedOrderOutputSchema = z
     orr_pr_rge_hlm_pr: z.string().nullish(),
     /** 주문가격범위하한가 — 입력값 표시 */
     orr_pr_rge_llm_pr: z.string().nullish(),
-    /**
-     * 비밀번호 — 입력값 표시. 스펙 선언이며 실응답 미확인(파이썬 모델 주석 참고).
-     * 값이 실제로 내려온다면 계좌 비밀번호이므로 로그·출력에 남기지 말 것.
-     */
+    /** 비밀번호 — 입력값 표시 */
     pwd: z.string().nullish(),
   })
   .passthrough();

--- a/packages/cluefin-openapi-ts/src/nhplug/schemas/krstock-quote.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/schemas/krstock-quote.ts
@@ -47,7 +47,7 @@ export const krStockQuoteCurrentPriceOutputSchema = z
     iem_nm: z.string().nullish(),
     /** 현재가 */
     stck_prpr: num.nullish(),
-    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     prdy_vrss_sign: z.string().nullish(),
     /** 등락폭 */
     prdy_vrss: num.nullish(),
@@ -411,7 +411,7 @@ export const krStockQuoteCurrentPriceTickOutputSchema = z
     bsop_hour: z.string().nullish(),
     /** 현재가 */
     stck_prpr: num.nullish(),
-    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     prdy_vrss_sign: z.string().nullish(),
     /** 등락폭 */
     prdy_vrss: num.nullish(),
@@ -433,7 +433,7 @@ export const krStockQuoteCurrentPriceExpectedOutputSchema = z
     cncc_aspr_code: z.string().nullish(),
     /** 예상체결가 */
     antc_cnpr: z.union([z.string(), num, num]).nullish(),
-    /** 예상체결부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** 예상체결부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     antc_cntg_sign: z.string().nullish(),
     /** 예상체결등락폭 */
     antc_cntg_vrss: z.union([z.string(), num, num]).nullish(),
@@ -453,7 +453,7 @@ export const krStockQuoteCurrentPriceExpectedOutputSchema = z
     ovtm_untp_ctrt: z.union([z.string(), num, num]).nullish(),
     /** ECN체결수량 */
     ovtm_untp_vol: z.union([z.string(), num, num]).nullish(),
-    /** ECN대비예상체결부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** ECN대비예상체결부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     ovtm_antc_sign: z.string().nullish(),
     /** ECN대비예상체결등락폭 */
     ovtm_antc_vrss: z.union([z.string(), num, num]).nullish(),
@@ -488,7 +488,7 @@ export const krStockQuoteCurrentExecutionTickOutputSchema = z
     bsop_hour: z.string().nullish(),
     /** 현재가 */
     stck_prpr: num.nullish(),
-    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     prdy_vrss_sign: z.string().nullish(),
     /** 등락폭 */
     prdy_vrss: num.nullish(),
@@ -542,7 +542,7 @@ export const krStockQuoteCurrentExecutionSummaryOutputSchema = z
     tbosu: z.union([z.string(), num]).nullish(),
     /** 현재가 */
     stck_prpr: num.nullish(),
-    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     prdy_vrss_sign: z.string().nullish(),
     /** 등락폭 */
     prdy_vrss: num.nullish(),
@@ -642,7 +642,7 @@ export const krStockQuoteCurrentInvestorOutputSchema = z
     bsop_date2: z.string().nullish(),
     /** 종가 */
     stck_prpr: num.nullish(),
-    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     prdy_vrss_sign: z.string().nullish(),
     /** 등락폭 */
     prdy_vrss: num.nullish(),
@@ -880,7 +880,7 @@ export const krStockQuoteAfterHoursCurrentOutputSchema = z
     ovtm_cntg_hour: z.string().nullish(),
     /** 체결가 */
     ovtm_untp_prpr: num.nullish(),
-    /** 체결등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** 체결등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     prdy_vrss_sign: z.string().nullish(),
     /** 체결등락폭 */
     ovtm_prdy_vrss: num.nullish(),
@@ -1058,7 +1058,7 @@ export const krStockQuoteAfterHoursCurrentRegularOutputSchema = z
     frgn_hour: z.string().nullish(),
     /** 외국인지분율 */
     for_rate: z.union([z.string(), num]).nullish(),
-    /** 체결등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** 체결등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     prdy_vrss_sign: z.string().nullish(),
     /** 등락폭 */
     prdy_vrss: z.union([z.string(), num]).nullish(),
@@ -1146,7 +1146,7 @@ export const krStockQuoteCurrentAfterHoursExecutionOutputSchema = z
     low: num.nullish(),
     /** 현재가 */
     stck_prpr: num.nullish(),
-    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     prdy_vrss_sign: z.string().nullish(),
     /** 등락폭 */
     prdy_vrss: num.nullish(),
@@ -1185,7 +1185,7 @@ export const krStockQuoteAfterHoursExpectedOutputSchema = z
     bsop_hour: z.string().nullish(),
     /** 현재가 */
     stck_prpr: num.nullish(),
-    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
     prdy_vrss_sign: z.string().nullish(),
     /** 등락폭 */
     prdy_vrss: num.nullish(),

--- a/packages/cluefin-openapi-ts/src/nhplug/schemas/krstock-quote.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/schemas/krstock-quote.ts
@@ -1,0 +1,1726 @@
+import { z } from 'zod';
+
+import type { CamelizeKeys } from '../../core/types';
+
+const messageSchema = z
+  .object({
+    msg_code: z.string().nullish(),
+    usr_msg: z.string().nullish(),
+    msg_lv_code: z.string().nullish(),
+    dvlp_msg_yn: z.string().nullish(),
+    svc_nm: z.string().nullish(),
+    func_nm: z.string().nullish(),
+    line_no: z.string().nullish(),
+    dvlp_msg: z.string().nullish(),
+  })
+  .passthrough();
+
+/**
+ * 자산군(krstock 등) 공통 응답 봉투.
+ *
+ * 스펙은 `Output_N` + `message` 구조로 명세하지만 실서버는 `rsp_cd`/`rsp_msg` 를
+ * 반환하고 `message` 는 null 이다(모의 실측 2026-08-22). 셋 다 optional 로 둔다.
+ */
+const assetEnvelope = {
+  /** 응답코드 (00000: 성공) */
+  rsp_cd: z.string().nullish(),
+  /** 응답메시지 */
+  rsp_msg: z.string().nullish(),
+  /** 스펙상 메시지 봉투 (실서버는 null) */
+  message: messageSchema.nullish(),
+};
+/**
+ * 파이썬 모델이 `int`/`float` 로 선언한 숫자 필드.
+ *
+ * 스펙이 int 라고 해도 실서버가 문자열로 내려주는 사례가 있어(예: 잔고조회
+ * `orr_pbl_amt1`, 2026-08-22 모의 실측) 숫자로 강제 변환한다. 빈 문자열은
+ * `z.coerce.number()` 가 0 으로 바꿔버리므로 null 로 따로 처리한다.
+ */
+const num = z.union([z.number(), z.literal('').transform(() => null), z.coerce.number()]);
+
+/** 주식현재가 시세 종합 정보 (Output_0). */
+export const krStockQuoteCurrentPriceOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 현재가 */
+    stck_prpr: num.nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: num.nullish(),
+    /** 등락률 */
+    prdy_ctrt: num.nullish(),
+    /** 매도호가 */
+    askp: num.nullish(),
+    /** 매수호가 */
+    bidp: num.nullish(),
+    /** 거래량 */
+    acml_vol: num.nullish(),
+    /** 거래비율 */
+    vol_rate: num.nullish(),
+    /** 유동주회전율 */
+    move_rate: num.nullish(),
+    /** 거래대금 */
+    acml_tr_pbmn: num.nullish(),
+    /** 상한가 */
+    stck_mxpr: num.nullish(),
+    /** 고가 */
+    stck_hgpr: num.nullish(),
+    /** 시가 */
+    stck_oprc: num.nullish(),
+    /** 시가대비부호 */
+    stck_oprc_sign: z.string().nullish(),
+    /** 시가대비등락폭 */
+    stck_oprc_vrss: num.nullish(),
+    /** 저가 */
+    stck_lwpr: num.nullish(),
+    /** 하한가 */
+    stck_llam: num.nullish(),
+    /** 호가시간 */
+    hoga_bsop_hour: z.string().nullish(),
+    /** 매도호가1 */
+    askp1: num.nullish(),
+    /** 매도호가2 */
+    askp2: num.nullish(),
+    /** 매도호가3 */
+    askp3: num.nullish(),
+    /** 매도호가4 */
+    askp4: num.nullish(),
+    /** 매도호가5 */
+    askp5: num.nullish(),
+    /** 매도호가6 */
+    askp6: num.nullish(),
+    /** 매도호가7 */
+    askp7: num.nullish(),
+    /** 매도호가8 */
+    askp8: num.nullish(),
+    /** 매도호가9 */
+    askp9: num.nullish(),
+    /** 매도호가10 */
+    askp10: num.nullish(),
+    /** 매수호가1 */
+    bidp1: num.nullish(),
+    /** 매수호가2 */
+    bidp2: num.nullish(),
+    /** 매수호가3 */
+    bidp3: num.nullish(),
+    /** 매수호가4 */
+    bidp4: num.nullish(),
+    /** 매수호가5 */
+    bidp5: num.nullish(),
+    /** 매수호가6 */
+    bidp6: num.nullish(),
+    /** 매수호가7 */
+    bidp7: num.nullish(),
+    /** 매수호가8 */
+    bidp8: num.nullish(),
+    /** 매수호가9 */
+    bidp9: num.nullish(),
+    /** 매수호가10 */
+    bidp10: num.nullish(),
+    /** 매도호가잔량1 */
+    askp_rsqn1: num.nullish(),
+    /** 매도호가잔량2 */
+    askp_rsqn2: num.nullish(),
+    /** 매도호가잔량3 */
+    askp_rsqn3: num.nullish(),
+    /** 매도호가잔량4 */
+    askp_rsqn4: num.nullish(),
+    /** 매도호가잔량5 */
+    askp_rsqn5: num.nullish(),
+    /** 매도호가잔량6 */
+    askp_rsqn6: num.nullish(),
+    /** 매도호가잔량7 */
+    askp_rsqn7: num.nullish(),
+    /** 매도호가잔량8 */
+    askp_rsqn8: num.nullish(),
+    /** 매도호가잔량9 */
+    askp_rsqn9: num.nullish(),
+    /** 매도호가잔량10 */
+    askp_rsqn10: num.nullish(),
+    /** 매수호가잔량1 */
+    bidp_rsqn1: num.nullish(),
+    /** 매수호가잔량2 */
+    bidp_rsqn2: num.nullish(),
+    /** 매수호가잔량3 */
+    bidp_rsqn3: num.nullish(),
+    /** 매수호가잔량4 */
+    bidp_rsqn4: num.nullish(),
+    /** 매수호가잔량5 */
+    bidp_rsqn5: num.nullish(),
+    /** 매수호가잔량6 */
+    bidp_rsqn6: num.nullish(),
+    /** 매수호가잔량7 */
+    bidp_rsqn7: num.nullish(),
+    /** 매수호가잔량8 */
+    bidp_rsqn8: num.nullish(),
+    /** 매수호가잔량9 */
+    bidp_rsqn9: num.nullish(),
+    /** 매수호가잔량10 */
+    bidp_rsqn10: num.nullish(),
+    /** 총매도잔량 */
+    total_askp_rsqn: num.nullish(),
+    /** 총매수잔량 */
+    total_bidp_rsqn: num.nullish(),
+    /** 시간외매도잔량 */
+    ovtm_askp_rsqn: num.nullish(),
+    /** 시간외매수잔량 */
+    ovtm_bidp_rsqn: num.nullish(),
+    /** 피봇2차저항 */
+    pvt_scnd_dmrs: num.nullish(),
+    /** 피봇1차저항 */
+    pvt_frst_dmrs: num.nullish(),
+    /** 피봇가 */
+    pvt_pont_val: num.nullish(),
+    /** 피봇1차지지 */
+    pvt_frst_dmsp: num.nullish(),
+    /** 피봇2차지지 */
+    pvt_scnd_dmsp: num.nullish(),
+    /** 코스피코스닥구분 */
+    mrkt_div_isnm: z.string().nullish(),
+    /** 업종명 */
+    bstp_kor_isnm: z.string().nullish(),
+    /** 업종코드 */
+    bstp_cls_code: z.string().nullish(),
+    /** 자본금규모 */
+    avls_scal_isnm: z.string().nullish(),
+    /** 결산월 */
+    stac_month: z.string().nullish(),
+    /** 시장조치1 */
+    market1: z.string().nullish(),
+    /** 시장조치2 */
+    market2: z.string().nullish(),
+    /** 시장조치3 */
+    market3: z.string().nullish(),
+    /** 시장조치4 */
+    market4: z.string().nullish(),
+    /** 시장조치5 */
+    market5: z.string().nullish(),
+    /** 시장조치6 */
+    market6: z.string().nullish(),
+    /** CB구분 */
+    cb_text: z.string().nullish(),
+    /** 액면가 */
+    stck_fcam: num.nullish(),
+    /** 전일종가타이틀 */
+    prdy_clpr_title: z.string().nullish(),
+    /** 전일종가 */
+    stck_prdy_clpr: num.nullish(),
+    /** 대용가 */
+    stck_sspr: num.nullish(),
+    /** 공모가 */
+    gongprice: num.nullish(),
+    /** 5일고가 */
+    d5_hgpr: num.nullish(),
+    /** 5일저가 */
+    d5_lwpr: num.nullish(),
+    /** 20일고가 */
+    d20_hgpr: num.nullish(),
+    /** 20일저가 */
+    d20_lwpr: num.nullish(),
+    /** 52주최고가 */
+    w52_hgpr: num.nullish(),
+    /** 52주최고가일 */
+    w52_hgpr_date: z.string().nullish(),
+    /** 52주최저가 */
+    w52_lwpr: num.nullish(),
+    /** 52주최저가일 */
+    w52_lwpr_date: z.string().nullish(),
+    /** 유동주식수 */
+    move_stcn: num.nullish(),
+    /** 상장주식수 */
+    lstn_stcn_unit3: num.nullish(),
+    /** 시가총액 */
+    hts_avls: num.nullish(),
+    /** 시간 */
+    memb_bsop_hour: z.string().nullish(),
+    /** 매도거래원1 */
+    seln_mbcr_name1: z.string().nullish(),
+    /** 매수거래원1 */
+    shnu_mbcr_name1: z.string().nullish(),
+    /** 매도거래량1 */
+    seln_qty1: num.nullish(),
+    /** 매수거래량1 */
+    shnu_qty1: num.nullish(),
+    /** 매도거래원2 */
+    seln_mbcr_name2: z.string().nullish(),
+    /** 매수거래원2 */
+    shnu_mbcr_name2: z.string().nullish(),
+    /** 매도거래량2 */
+    seln_qty2: num.nullish(),
+    /** 매수거래량2 */
+    shnu_qty2: num.nullish(),
+    /** 매도거래원3 */
+    seln_mbcr_name3: z.string().nullish(),
+    /** 매수거래원3 */
+    shnu_mbcr_name3: z.string().nullish(),
+    /** 매도거래량3 */
+    seln_qty3: num.nullish(),
+    /** 매수거래량3 */
+    shnu_qty3: num.nullish(),
+    /** 매도거래원4 */
+    seln_mbcr_name4: z.string().nullish(),
+    /** 매수거래원4 */
+    shnu_mbcr_name4: z.string().nullish(),
+    /** 매도거래량4 */
+    seln_qty4: num.nullish(),
+    /** 매수거래량4 */
+    shnu_qty4: num.nullish(),
+    /** 매도거래원5 */
+    seln_mbcr_name5: z.string().nullish(),
+    /** 매수거래원5 */
+    shnu_mbcr_name5: z.string().nullish(),
+    /** 매도거래량5 */
+    seln_qty5: num.nullish(),
+    /** 매수거래량5 */
+    shnu_qty5: num.nullish(),
+    /** 매도외국인거래량 */
+    glob_seln_qty: num.nullish(),
+    /** 매수외국인거래량 */
+    glob_shnu_qty: num.nullish(),
+    /** 외국인시간 */
+    for_hour: z.string().nullish(),
+    /** 외국인지분율 */
+    for_rate: num.nullish(),
+    /** 결제일 */
+    crdt_stlm_date: z.string().nullish(),
+    /** 잔고비율(%) */
+    crdt_rmnd_rate: num.nullish(),
+    /** 유상기준일 */
+    yu_date: z.string().nullish(),
+    /** 무상기준일 */
+    mu_date: z.string().nullish(),
+    /** 유상배정비율 */
+    yu_rate: num.nullish(),
+    /** 무상배정비율 */
+    mu_rate: num.nullish(),
+    /** 외국인변동주수 */
+    frgn_ntby_vol: num.nullish(),
+    /** 자사주 */
+    jasa: z.string().nullish(),
+    /** 상장일 */
+    stck_lstn_date: z.string().nullish(),
+    /** 대주주지분율 */
+    dae_rate: num.nullish(),
+    /** 대주주지분일자 */
+    dae_date: z.string().nullish(),
+    /** FILLER */
+    filler: z.string().nullish(),
+    /** 증거금율 */
+    deposit_gb: z.string().nullish(),
+    /** 자본금 */
+    cpfn: num.nullish(),
+    /** 전체거래원매도합 */
+    total_seln_qty: num.nullish(),
+    /** 전체거래원매수합 */
+    total_shnu_qty: num.nullish(),
+    /** 우회상장여부 */
+    detour_gb: z.string().nullish(),
+    /** 증권구분 */
+    scrt_grp_isnm: z.string().nullish(),
+    /** 공여율기준일 */
+    crdt_deal_date: z.string().nullish(),
+    /** 공여율(%) */
+    crdt_loan_gvrt: num.nullish(),
+    /** PER */
+    per: num.nullish(),
+    /** 종목별신용한도 */
+    hando_gb: z.string().nullish(),
+    /** 가중가 */
+    wghn_avrg_prc: num.nullish(),
+    /** 상장주식수_주 */
+    lstn_stcn_unit0: num.nullish(),
+    /** 추가상장주수 */
+    add_lstn_stcn: num.nullish(),
+    /** 종목comment */
+    gicomment: z.string().nullish(),
+    /** 전일거래량 */
+    prdy_vol: num.nullish(),
+    /** 전일대비등락부호 */
+    pre_prdy_sign: z.string().nullish(),
+    /** 전일대비등락폭 */
+    pre_prdy_vrss: num.nullish(),
+    /** 연종최고가 */
+    stck_dryy_hgpr: num.nullish(),
+    /** 연중최고가일 */
+    dryy_hgpr_date: z.string().nullish(),
+    /** 연중최저가 */
+    stck_dryy_lwpr: num.nullish(),
+    /** 연중최저가일 */
+    dryy_lwpr_date: z.string().nullish(),
+    /** 외국인보유주식수 */
+    frgn_hldn_qty: num.nullish(),
+    /** 외국인한도율(%) */
+    issu_limt_rate: num.nullish(),
+    /** 매매수량단위 */
+    frml_mrkt_unit: num.nullish(),
+    /** 경쟁대량방향구분 */
+    comp_cls_code: z.string().nullish(),
+    /** 대량매매구분 */
+    largem_gb: z.string().nullish(),
+    /** PBR */
+    pbr: num.nullish(),
+    /** 디저항값 */
+    dmrs_val: num.nullish(),
+    /** 디지지값 */
+    dmsp_val: num.nullish(),
+    /** 전일거래대금 */
+    prdy_tr_pbmn: num.nullish(),
+    /** VI기준가 */
+    vi_antc_sdpr: num.nullish(),
+    /** VI상승발동가 */
+    vi_antc_mxpr: num.nullish(),
+    /** VI하락발동가 */
+    vi_antc_llam: num.nullish(),
+    /** 투자유의종목여부 */
+    invt_epmd_yn: z.string().nullish(),
+    /** 상한수량 */
+    uplm_qty: num.nullish(),
+    /** 단기과열구분코드 — 1.단기과열예고 2.단기과열지정 3.단기과열연장 */
+    short_over_code: z.string().nullish(),
+    /** 투자주의경고구분코드 — 1.투자주의 2.투자경고 3.투자주의>투자위험예고 4.투자경고투자위험예고 5.투자위험 */
+    mrkt_alrm_code: z.string().nullish(),
+    /** 정리매매여부 — Y.정리매매종목 */
+    sltr_yn: z.string().nullish(),
+    /** 담보유지비율(%) */
+    crd_rt_grd_nm: z.string().nullish(),
+    /** 중간가 */
+    mid_prc: num.nullish(),
+    /** 매도중간가잔량합계수량 */
+    midp_total_askp_rsqn: num.nullish(),
+    /** 매수중간가잔량합계수량 */
+    midp_total_bidp_rsqn: num.nullish(),
+    /** nxt중간가 */
+    nxt_mid_prc: num.nullish(),
+    /** nxt매도중간가잔량합계수량 */
+    nxt_midp_total_askp_rsqn: num.nullish(),
+    /** nxt매수중간가잔량합계수량 */
+    nxt_midp_total_bidp_rsqn: num.nullish(),
+    /** 증거금등급구분코드 */
+    marg_grad_cls_code: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 시세 시간대별 체결 (Output_1 배열의 각 항목). */
+export const krStockQuoteCurrentPriceTickOutputSchema = z
+  .object({
+    /** 시간 */
+    bsop_hour: z.string().nullish(),
+    /** 현재가 */
+    stck_prpr: num.nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: num.nullish(),
+    /** 매도호가 */
+    askp: num.nullish(),
+    /** 매수호가 */
+    bidp: num.nullish(),
+    /** 변동거래량 */
+    cntg_vol: z.union([z.string(), num]).nullish(),
+    /** 거래량 */
+    acml_vol: num.nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 시세 예상체결/ECN 정보 (Output_2). */
+export const krStockQuoteCurrentPriceExpectedOutputSchema = z
+  .object({
+    /** 동시호가구분 — 1.동시호가 이외 정규시장 */
+    cncc_aspr_code: z.string().nullish(),
+    /** 예상체결가 */
+    antc_cnpr: z.union([z.string(), num, num]).nullish(),
+    /** 예상체결부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    antc_cntg_sign: z.string().nullish(),
+    /** 예상체결등락폭 */
+    antc_cntg_vrss: z.union([z.string(), num, num]).nullish(),
+    /** 예상체결등락률 */
+    antc_prdy_ctrt: z.union([z.string(), num, num]).nullish(),
+    /** 예상체결수량 */
+    antc_vol: z.union([z.string(), num, num]).nullish(),
+    /** ECN정보유무구분 */
+    chkdata: z.string().nullish(),
+    /** ECN전일종가 */
+    ovtm_untp_prpr: z.union([z.string(), num, num]).nullish(),
+    /** ECN부호 */
+    ovtm_untp_sign: z.string().nullish(),
+    /** ECN등락폭 */
+    ovtm_untp_vrss: z.union([z.string(), num, num]).nullish(),
+    /** ECN등락률 */
+    ovtm_untp_ctrt: z.union([z.string(), num, num]).nullish(),
+    /** ECN체결수량 */
+    ovtm_untp_vol: z.union([z.string(), num, num]).nullish(),
+    /** ECN대비예상체결부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    ovtm_antc_sign: z.string().nullish(),
+    /** ECN대비예상체결등락폭 */
+    ovtm_antc_vrss: z.union([z.string(), num, num]).nullish(),
+    /** ECN대비예상체결등락률 */
+    ovtm_antc_ctrt: z.union([z.string(), num, num]).nullish(),
+    /** 종합스코어링 */
+    scoring: z.union([z.string(), num, num]).nullish(),
+    /** VI거래중지여부 — 1.VI발동 N.그외 */
+    vi_type_code: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 시세 (`POST /krstock/quote/v1/currentPrice`) 응답. */
+export const krStockQuoteCurrentPriceResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 현재가 종합 정보 */
+    Output_0: krStockQuoteCurrentPriceOutputSchema.nullish(),
+    /** 시간대별 체결 목록 */
+    Output_1: z.array(krStockQuoteCurrentPriceTickOutputSchema).nullish(),
+    /** 예상체결/ECN 정보 (스펙은 Array, 실제 예시는 Object — 둘 다 허용) */
+    Output_2: z
+      .union([z.array(krStockQuoteCurrentPriceExpectedOutputSchema), krStockQuoteCurrentPriceExpectedOutputSchema])
+      .nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 체결 시간대별 체결 상세 (Output_0 배열의 각 항목). */
+export const krStockQuoteCurrentExecutionTickOutputSchema = z
+  .object({
+    /** 시간 */
+    bsop_hour: z.string().nullish(),
+    /** 현재가 */
+    stck_prpr: num.nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: num.nullish(),
+    /** 등락률 */
+    prdy_ctrt: num.nullish(),
+    /** 변동거래량 */
+    cntg_vol: num.nullish(),
+    /** 누적매수체결량 */
+    shnu_cntg_smtn: num.nullish(),
+    /** 당일매수비중 */
+    bidrate: num.nullish(),
+    /** 누적매도체결량 */
+    seln_cntg_smtn: num.nullish(),
+    /** 당일매도비중 */
+    askrate: num.nullish(),
+    /** 누적보합체결량 */
+    stnr_cntg_smtn: num.nullish(),
+    /** 당일보합비중 */
+    uncrate: num.nullish(),
+    /** 체결강도 */
+    cttr: num.nullish(),
+    /** 매도호가 */
+    askp: num.nullish(),
+    /** 매수호가 */
+    bidp: num.nullish(),
+    /** 전체거래량 */
+    acml_vol: num.nullish(),
+    /** filler */
+    filler: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 체결 종목 종합 정보 (Output_1). */
+export const krStockQuoteCurrentExecutionSummaryOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** KOR_종목명 */
+    iem_nm: z.string().nullish(),
+    /** 누적매도가체결량 */
+    toffervol: z.union([z.string(), num]).nullish(),
+    /** 누적매수가체결량 */
+    tbidvol: z.union([z.string(), num]).nullish(),
+    /** 누적보합가체결량 */
+    tbovol: z.union([z.string(), num]).nullish(),
+    /** 누적매도가체결건수 */
+    toffersu: z.union([z.string(), num]).nullish(),
+    /** 누적매수가체결건수 */
+    tbidsu: z.union([z.string(), num]).nullish(),
+    /** 누적보합가체결건수 */
+    tbosu: z.union([z.string(), num]).nullish(),
+    /** 현재가 */
+    stck_prpr: num.nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: num.nullish(),
+    /** 전체거래량 */
+    acml_vol: num.nullish(),
+    /** 시가 */
+    stck_oprc: z.union([z.string(), num]).nullish(),
+    /** 고가 */
+    stck_hgpr: z.union([z.string(), num]).nullish(),
+    /** 저가 */
+    stck_lwpr: z.union([z.string(), num]).nullish(),
+    /** 매도호가 */
+    askp: num.nullish(),
+    /** 매수호가 */
+    bidp: num.nullish(),
+    /** 체결강도 */
+    cttr: num.nullish(),
+    /** 신규거래량 */
+    new_volume: z.union([z.string(), num]).nullish(),
+    /** 전일종가 — 기준가 혹은 전일종가 기준가 우선 셋팅 */
+    stck_prdy_clpr: z.union([z.string(), num]).nullish(),
+    /** filler */
+    filler: z.string().nullish(),
+    /** CTSz20 */
+    ctsz20: z.string().nullish(),
+    /** NEXTBUTTON */
+    nextbutton: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 체결 (`POST /krstock/quote/v1/currentExecution`) 응답. */
+export const krStockQuoteCurrentExecutionResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 시간대별 체결 상세 목록 */
+    Output_0: z.array(krStockQuoteCurrentExecutionTickOutputSchema).nullish(),
+    /** 종목 종합 정보 */
+    Output_1: krStockQuoteCurrentExecutionSummaryOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 일자별 일별 시세 상세 (Output_0 배열의 각 항목). */
+export const krStockQuoteCurrentDailyOutputSchema = z
+  .object({
+    /** 일자 — YY/MM/DD */
+    bsop_date: z.string().nullish(),
+    /** 시가 */
+    stck_oprc: z.union([z.string(), num]).nullish(),
+    /** 고가 */
+    stck_hgpr: z.union([z.string(), num]).nullish(),
+    /** 저가 */
+    stck_lwpr: z.union([z.string(), num]).nullish(),
+    /** 종가 */
+    stck_clpr: z.union([z.string(), num]).nullish(),
+    /** FILLER */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: z.union([z.string(), num]).nullish(),
+    /** 등락률 */
+    prdy_ctrt: z.union([z.string(), num]).nullish(),
+    /** 거래량 */
+    acml_vol: z.union([z.string(), num]).nullish(),
+    /** 거래대금 */
+    acml_tr_pbmn: z.union([z.string(), num]).nullish(),
+    /** 고가일 */
+    high_date: z.string().nullish(),
+    /** 저가일 */
+    low_date: z.string().nullish(),
+    /** 거래량전일비 */
+    vol_prdy_rt: z.union([z.string(), num]).nullish(),
+    /** 체결강도 */
+    cttr: z.union([z.string(), num]).nullish(),
+    /** FILLER */
+    filler: z.string().nullish(),
+    /** NEXT_KEY */
+    next_key: z.string().nullish(),
+    /** NEXTBUTTON */
+    nextbutton: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 일자별 (`POST /krstock/quote/v1/currentDaily`) 응답. */
+export const krStockQuoteCurrentDailyResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 일별 시세 상세 목록 */
+    Output_0: z.array(krStockQuoteCurrentDailyOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 투자자 투자자별 거래현황 상세 (Output_0 배열의 각 항목). */
+export const krStockQuoteCurrentInvestorOutputSchema = z
+  .object({
+    /** 거래일자 — YYYYMMDD */
+    bsop_date1: z.string().nullish(),
+    /** 거래일자 — YYMMDD00 */
+    bsop_date2: z.string().nullish(),
+    /** 종가 */
+    stck_prpr: num.nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: num.nullish(),
+    /** 등락률 */
+    prdy_ctrt: num.nullish(),
+    /** 거래량 */
+    acml_vol: num.nullish(),
+    /** 외국인지분율 */
+    for_rate: num.nullish(),
+    /** 외국인순매수량 */
+    frgn_ntby_qty: num.nullish(),
+    /** 개인투자자순매수량 */
+    person: num.nullish(),
+    /** 기관계투자자순매수량 */
+    gigwan: num.nullish(),
+    /** 외국인투자자순매수량 */
+    invest: num.nullish(),
+    /** 거래원순매수량 */
+    account: num.nullish(),
+    /** 프로그램 */
+    program: num.nullish(),
+    /** 자사주 */
+    jasaz10: z.string().nullish(),
+    /** FILLER */
+    filler: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 투자자 (`POST /krstock/quote/v1/currentInvestor`) 응답. */
+export const krStockQuoteCurrentInvestorResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 투자자별 거래현황 상세 목록 */
+    Output_0: z.array(krStockQuoteCurrentInvestorOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 국내주식기간별시세(일/주/월/년) 종합 정보 (Output_0). */
+export const krStockQuotePeriodOutputSchema = z
+  .object({
+    /** 조회날짜 — YYYYMMDD */
+    qry_date: z.string().nullish(),
+    /** 조회시간 — HHmmSS */
+    qry_time: z.string().nullish(),
+    /** 단축종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 한글종목명 */
+    iem_nm: z.string().nullish(),
+    /** 현재가 */
+    stck_prpr: z.string().nullish(),
+    /** 전일대비부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 전일대비 */
+    prdy_vrss: z.string().nullish(),
+    /** 전일대비율 — float 5.2 */
+    prdy_ctrt: z.string().nullish(),
+    /** 누적거래량 */
+    acml_vol: z.string().nullish(),
+    /** 누적거래대금 */
+    acml_tr_pbmn: z.string().nullish(),
+    /** 전일거래량 */
+    prdy_vol: z.string().nullish(),
+    /** 거래량전일비 — float 15.2 */
+    prdy_vol_rate: z.string().nullish(),
+    /** 거래량회전율 — float 10.5 */
+    vol_rate: z.string().nullish(),
+    /** 체결강도 — float 6.2 */
+    cttr: z.string().nullish(),
+    /** 전일체결강도 — float 6.2 */
+    prdy_cttr: z.string().nullish(),
+    /** 매도호가 */
+    askp: z.string().nullish(),
+    /** 매수호가 */
+    bidp: z.string().nullish(),
+    /** 매도1호가잔량 */
+    askp_rsqn1: z.string().nullish(),
+    /** 매수1호가잔량 */
+    bidp_rsqn1: z.string().nullish(),
+    /** 상한가 */
+    stck_mxpr: z.string().nullish(),
+    /** 하한가 */
+    stck_llam: z.string().nullish(),
+    /** 시가 */
+    stck_oprc: z.string().nullish(),
+    /** 고가 */
+    stck_hgpr: z.string().nullish(),
+    /** 저가 */
+    stck_lwpr: z.string().nullish(),
+    /** 상장주수 */
+    lstn_stcn: z.string().nullish(),
+    /** 시가총액 — 억단위 */
+    hts_avls: z.string().nullish(),
+    /** 대주주지분율 — float 5.2 */
+    dae_rate: z.string().nullish(),
+    /** PER — float 5.2 */
+    per: z.string().nullish(),
+    /** PBR — float 5.2 */
+    pbr: z.string().nullish(),
+    /** EPS */
+    eps: z.string().nullish(),
+    /** BPS */
+    bps: z.string().nullish(),
+    /** 전일시가 */
+    prdy_oprc: z.string().nullish(),
+    /** 전일고가 */
+    prdy_high: z.string().nullish(),
+    /** 전일저가 */
+    prdy_low: z.string().nullish(),
+    /** 전일종가 */
+    prdy_clpr: z.string().nullish(),
+    /** 이번주시가 */
+    tdw_oprc: z.string().nullish(),
+    /** 이번주고가 */
+    tdw_high: z.string().nullish(),
+    /** 이번주저가 */
+    tdw_low: z.string().nullish(),
+    /** 이번달시가 */
+    tdm_oprc: z.string().nullish(),
+    /** 이번달고가 */
+    tdm_high: z.string().nullish(),
+    /** 이번달저가 */
+    tdm_low: z.string().nullish(),
+    /** VI정적발동상승 */
+    vi_sttc_mxpr: z.string().nullish(),
+    /** VI정적발동하락 */
+    vi_sttc_llam: z.string().nullish(),
+    /** 장시작시간 — HHmmSS */
+    start_time: z.string().nullish(),
+    /** 장마감시간 — HHmmSS */
+    end_time: z.string().nullish(),
+    /** 영업일 */
+    bsop_date: z.string().nullish(),
+    /** 주식기준가 */
+    stck_sdpr: z.string().nullish(),
+    /** 주식액면가 */
+    stck_fcam: z.string().nullish(),
+    /** 업종한글명 */
+    bstp_kor_isnm: z.string().nullish(),
+    /** 업종코드 */
+    bstp_cls_code: z.string().nullish(),
+    /** 달러환율 */
+    exchange_prpr: z.string().nullish(),
+    /** 연속조회키 */
+    ctsz30: z.string().nullish(),
+    /** 마지막N틱봉의틱묶음갯수 — 최근봉마지막틱갯수 */
+    lasttickcount: z.string().nullish(),
+    /** 전송레코드건수 */
+    send_cnt: z.string().nullish(),
+    /** 프리마켓시작시간 — NXT/UNT프리마켓시작시간 */
+    pre_tr_sta_hour: z.string().nullish(),
+    /** 프리마켓종료시간 — NXT/UNT프리마켓종료시간 */
+    pre_tr_fin_hour: z.string().nullish(),
+    /** 메인마겟시작시간 — NXT/UNT메인마켓시작시간 */
+    main_tr_sta_hour: z.string().nullish(),
+    /** 메인마겟종료시간 — NXT/UNT메인마켓종료시간 */
+    main_tr_fin_hour: z.string().nullish(),
+    /** 에프터마겟시작시간 — NXT/UNT에프터마켓시작시간 */
+    aft_tr_sta_hour: z.string().nullish(),
+    /** 에프터마겟종료시간 — NXT/UNT에프터마켓종료시간 */
+    aft_tr_fin_hour: z.string().nullish(),
+    /** 정규장마감전동시호가 — KRX/UNT종료전동시호가시작시간 */
+    cncc_aspr_sta_hour: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 국내주식기간별시세(일/주/월/년) 주기별 봉 상세 (Output_1 배열의 각 항목). */
+export const krStockQuotePeriodBarOutputSchema = z
+  .object({
+    /** 영업일 */
+    bsop_date: z.string().nullish(),
+    /** 시간 — HHmmSS */
+    bsop_time: z.string().nullish(),
+    /** 주식기준가 */
+    stck_sdpr: z.string().nullish(),
+    /** 시가 */
+    stck_oprc: z.string().nullish(),
+    /** 고가 */
+    stck_hgpr: z.string().nullish(),
+    /** 저가 */
+    stck_lwpr: z.string().nullish(),
+    /** 현재가 */
+    stck_prpr: z.string().nullish(),
+    /** 거래량 */
+    vol: z.string().nullish(),
+    /** 거래대금 */
+    tr_pbmn: z.string().nullish(),
+    /** 락구분코드 — 01.권리락 02.배당락 03.분배락 04.권배락 05.중간배당락 06.권리중간배당락 07.권리분기배당락 99.기타 */
+    flng_cls_code: z.string().nullish(),
+    /** 락비율 — float 8.2 */
+    prtt_rate: z.string().nullish(),
+    /** 뉴스건수 — 일간일때만처리 */
+    news_cnt: z.string().nullish(),
+    /** 상하한가표시 — 0.기본 1.상한 4.하한 */
+    updownmark: z.string().nullish(),
+    /** 액면가변경구분코드 — 00.해당없음 01.액면분할 02.액면병합 03.주식분할 04.주식병합 99.기타 */
+    fcam_mod_cls_code: z.string().nullish(),
+    /** 거래량수정비율 */
+    vol_prtt_rate: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 국내주식기간별시세(일/주/월/년) (`POST /krstock/quote/v1/period`) 응답. */
+export const krStockQuotePeriodResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 종합 정보 (스펙은 Array, 실제 예시는 Object — 둘 다 허용) */
+    Output_0: z.union([z.array(krStockQuotePeriodOutputSchema), krStockQuotePeriodOutputSchema]).nullish(),
+    /** 주기별 봉 상세 목록 */
+    Output_1: z.array(krStockQuotePeriodBarOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 국내주식 시간외현재가 시간외 단일가 종합 정보 (Output_0). */
+export const krStockQuoteAfterHoursCurrentOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 시장구분 */
+    mrkt_cls_code: z.string().nullish(),
+    /** 거래구분 */
+    trht_yn: z.string().nullish(),
+    /** 장구분 */
+    mkop_cls_code: z.string().nullish(),
+    /** 정규장종가 */
+    stck_prpr: num.nullish(),
+    /** 기준가 */
+    ovtm_untp_sdpr: num.nullish(),
+    /** 상한가 */
+    ovtm_untp_mxpr: num.nullish(),
+    /** 하한가 */
+    ovtm_untp_llam: num.nullish(),
+    /** 체결시간 */
+    ovtm_cntg_hour: z.string().nullish(),
+    /** 체결가 */
+    ovtm_untp_prpr: num.nullish(),
+    /** 체결등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 체결등락폭 */
+    ovtm_prdy_vrss: num.nullish(),
+    /** 체결등락률 */
+    ovtm_prdy_ctrt: num.nullish(),
+    /** 시가 */
+    ovtm_untp_oprc: num.nullish(),
+    /** 고가 */
+    ovtm_untp_hgpr: num.nullish(),
+    /** 저가 */
+    ovtm_untp_lwpr: num.nullish(),
+    /** 거래량 */
+    ovtm_untp_vol: num.nullish(),
+    /** 거래대금 */
+    ovtm_tr_pbmn: num.nullish(),
+    /** 매도호가 */
+    ovtm_untp_askp: num.nullish(),
+    /** 매수호가 */
+    ovtm_untp_bidp: num.nullish(),
+    /** 호가시간 */
+    ovtm_bsop_hour: z.string().nullish(),
+    /** 매도1차선호가 */
+    ovtm_untp_askp1: num.nullish(),
+    /** 매도2차선호가 */
+    ovtm_untp_askp2: num.nullish(),
+    /** 매도3차선호가 */
+    ovtm_untp_askp3: num.nullish(),
+    /** 매도4차선호가 */
+    ovtm_untp_askp4: num.nullish(),
+    /** 매도5차선호가 */
+    ovtm_untp_askp5: num.nullish(),
+    /** 매도6차선호가 */
+    ovtm_untp_askp6: num.nullish(),
+    /** 매도7차선호가 */
+    ovtm_untp_askp7: num.nullish(),
+    /** 매도8차선호가 */
+    ovtm_untp_askp8: num.nullish(),
+    /** 매도9차선호가 */
+    ovtm_untp_askp9: num.nullish(),
+    /** 매도10차선호가 */
+    ovtm_untp_askp10: num.nullish(),
+    /** 매수1차선호가 */
+    ovtm_untp_bidp1: num.nullish(),
+    /** 매수2차선호가 */
+    ovtm_untp_bidp2: num.nullish(),
+    /** 매수3차선호가 */
+    ovtm_untp_bidp3: num.nullish(),
+    /** 매수4차선호가 */
+    ovtm_untp_bidp4: num.nullish(),
+    /** 매수5차선호가 */
+    ovtm_untp_bidp5: num.nullish(),
+    /** 매수6차선호가 */
+    ovtm_untp_bidp6: num.nullish(),
+    /** 매수7차선호가 */
+    ovtm_untp_bidp7: num.nullish(),
+    /** 매수8차선호가 */
+    ovtm_untp_bidp8: num.nullish(),
+    /** 매수9차선호가 */
+    ovtm_untp_bidp9: num.nullish(),
+    /** 매수10차선호가 */
+    ovtm_untp_bidp10: num.nullish(),
+    /** 매도1차선잔량 */
+    ovtm_askp_rsqn1: num.nullish(),
+    /** 매도2차선잔량 */
+    ovtm_askp_rsqn2: num.nullish(),
+    /** 매도3차선잔량 */
+    ovtm_askp_rsqn3: num.nullish(),
+    /** 매도4차선잔량 */
+    ovtm_askp_rsqn4: num.nullish(),
+    /** 매도5차선잔량 */
+    ovtm_askp_rsqn5: num.nullish(),
+    /** 매도6차선잔량 */
+    ovtm_askp_rsqn6: num.nullish(),
+    /** 매도7차선잔량 */
+    ovtm_askp_rsqn7: num.nullish(),
+    /** 매도8차선잔량 */
+    ovtm_askp_rsqn8: num.nullish(),
+    /** 매도9차선잔량 */
+    ovtm_askp_rsqn9: num.nullish(),
+    /** 매도10차선잔량 */
+    ovtm_askp_rsqn10: num.nullish(),
+    /** 매수1차선잔량 */
+    ovtm_bidp_rsqn1: num.nullish(),
+    /** 매수2차선잔량 */
+    ovtm_bidp_rsqn2: num.nullish(),
+    /** 매수3차선잔량 */
+    ovtm_bidp_rsqn3: num.nullish(),
+    /** 매수4차선잔량 */
+    ovtm_bidp_rsqn4: num.nullish(),
+    /** 매수5차선잔량 */
+    ovtm_bidp_rsqn5: num.nullish(),
+    /** 매수6차선잔량 */
+    ovtm_bidp_rsqn6: num.nullish(),
+    /** 매수7차선잔량 */
+    ovtm_bidp_rsqn7: num.nullish(),
+    /** 매수8차선잔량 */
+    ovtm_bidp_rsqn8: num.nullish(),
+    /** 매수9차선잔량 */
+    ovtm_bidp_rsqn9: num.nullish(),
+    /** 매수10차선잔량 */
+    ovtm_bidp_rsqn10: num.nullish(),
+    /** 매도잔량합 */
+    total_askp_rsqn: num.nullish(),
+    /** 매수잔량합 */
+    total_bidp_rsqn: num.nullish(),
+    /** 동시구분 — 1.동시호가 이외 정규시장 */
+    ecn_dongsi: z.string().nullish(),
+    /** 예상체결가 */
+    ovtm_antc_cnpr: num.nullish(),
+    /** 예상체결부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    antc_vrss_sign: z.string().nullish(),
+    /** 예상체결등락폭 */
+    antc_cntg_vrss: num.nullish(),
+    /** 예상체결등락률 */
+    antc_cntg_ctrt: num.nullish(),
+    /** 예상체결수량 */
+    antc_vol: num.nullish(),
+    /** 예상대금 */
+    antc_tr_pbmn: num.nullish(),
+    /** 종목정보 */
+    item_info: z.string().nullish(),
+    /** 투자유의종목여부 — Y.투자유의종목 */
+    ivs_hed_yn: z.string().nullish(),
+    /** 단기과열구분코드 — 1.단기과열예고 2.단기과열지정 3.단기과열연장 */
+    short_ovh_gb: z.string().nullish(),
+    /** 투자주의경고구분코드 — 1.투자주의 2.투자경고 3.투자주의>투자위험예고 4.투자경고투자위험예고 5.투자위험 */
+    alert_gb: z.string().nullish(),
+    /** 정리매매여부 — Y.정리매매종목 */
+    jungri_yn: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 국내주식 시간외현재가 정규장 종합 정보 (Output_1). */
+export const krStockQuoteAfterHoursCurrentRegularOutputSchema = z
+  .object({
+    /** 일자 */
+    bsop_date: z.string().nullish(),
+    /** 거래량 */
+    acml_vol: z.union([z.string(), num]).nullish(),
+    /** 거래량전일비 */
+    vol_rate: z.union([z.string(), num]).nullish(),
+    /** 거래대금 */
+    acml_tr_pbmn: z.union([z.string(), num]).nullish(),
+    /** 시가 */
+    stck_oprc: z.union([z.string(), num]).nullish(),
+    /** 고가 */
+    stck_hgpr: z.union([z.string(), num]).nullish(),
+    /** 저가 */
+    stck_lwpr: z.union([z.string(), num]).nullish(),
+    /** 정규장종가 */
+    stck_prpr: num.nullish(),
+    /** 상한가 */
+    stck_mxpr: z.union([z.string(), num]).nullish(),
+    /** 하한가 */
+    stck_llam: z.union([z.string(), num]).nullish(),
+    /** 액면가 */
+    stck_fcam: z.union([z.string(), num]).nullish(),
+    /** 매도호가 */
+    askp: z.union([z.string(), num]).nullish(),
+    /** 매수호가 */
+    bidp: z.union([z.string(), num]).nullish(),
+    /** 매도잔량 */
+    askp_rsqn: z.union([z.string(), num]).nullish(),
+    /** 매수잔량 */
+    bidp_rsqn: z.union([z.string(), num]).nullish(),
+    /** 매도잔량합 */
+    total_askp_rsqn: num.nullish(),
+    /** 매수잔량합 */
+    total_bidp_rsqn: num.nullish(),
+    /** 시간외매도잔량 */
+    ovtm_askp_rsqn: z.union([z.string(), num]).nullish(),
+    /** 시간외매수잔량 */
+    ovtm_bidp_rsqn: z.union([z.string(), num]).nullish(),
+    /** 외국인시간 */
+    frgn_hour: z.string().nullish(),
+    /** 외국인지분율 */
+    for_rate: z.union([z.string(), num]).nullish(),
+    /** 체결등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: z.union([z.string(), num]).nullish(),
+    /** 등락률 */
+    prdy_ctrt: z.union([z.string(), num]).nullish(),
+    /** 코스피구분 */
+    sosokz6: z.string().nullish(),
+    /** 업종명 */
+    bstp_kor_isnm: z.string().nullish(),
+    /** 업종코드 */
+    bstp_cls_code: z.string().nullish(),
+    /** 자본금규모 */
+    cap_size: z.string().nullish(),
+    /** 신규거래량 */
+    new_volume: z.union([z.string(), num]).nullish(),
+  })
+  .passthrough();
+
+/** 국내주식 시간외현재가 (`POST /krstock/quote/v1/afterHoursCurrent`) 응답. */
+export const krStockQuoteAfterHoursCurrentResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 시간외 단일가 종합 정보 */
+    Output_0: krStockQuoteAfterHoursCurrentOutputSchema.nullish(),
+    /** 정규장 종합 정보 */
+    Output_1: krStockQuoteAfterHoursCurrentRegularOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 시간외일자별주가 시간외 체결 상세 (Output_0 배열의 각 항목). */
+export const krStockQuoteCurrentAfterHoursDailyTickOutputSchema = z
+  .object({
+    /** 일자 */
+    qry_date: z.string().nullish(),
+    /** 시가 */
+    qry_time: z.string().nullish(),
+    /** 고가 */
+    shrn_iscd: z.string().nullish(),
+    /** 저가 */
+    hts_kor_isnm: z.string().nullish(),
+    /** 락구분 */
+    stck_prpr: z.string().nullish(),
+    /** Filler */
+    prdy_vrss_sign: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 시간외일자별주가 종합 상세 (Output_1 배열의 각 항목). */
+export const krStockQuoteCurrentAfterHoursDailyOutputSchema = z
+  .object({
+    /** 현재가 */
+    prdy_ctrt: z.string().nullish(),
+    /** 거래량 */
+    acml_vol: z.union([z.string(), num]).nullish(),
+    /** 거래대금 */
+    acml_tr_pbmn: z.union([z.string(), num]).nullish(),
+    /** Filler */
+    prdy_vol: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 시간외일자별주가 (`POST /krstock/quote/v1/currentAfterHoursDaily`) 응답. */
+export const krStockQuoteCurrentAfterHoursDailyResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 시간외 체결 상세 목록 */
+    Output_0: z.array(krStockQuoteCurrentAfterHoursDailyTickOutputSchema).nullish(),
+    /** 종합 상세 목록 */
+    Output_1: z.array(krStockQuoteCurrentAfterHoursDailyOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 시간외시간별체결 상세 (Output_0 배열의 각 항목). */
+export const krStockQuoteCurrentAfterHoursExecutionOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 시간 */
+    bsop_hour: z.string().nullish(),
+    /** 시가 */
+    open: num.nullish(),
+    /** 고가 */
+    high: num.nullish(),
+    /** 저가 */
+    low: num.nullish(),
+    /** 현재가 */
+    stck_prpr: num.nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: num.nullish(),
+    /** 등락률 */
+    prdy_ctrt: num.nullish(),
+    /** 거래량 */
+    acml_vol: num.nullish(),
+    /** 변동거래량 */
+    cntg_vol: num.nullish(),
+    /** 거래대금 */
+    cntg_tr_pbmn: num.nullish(),
+    /** 매도호가 */
+    askp1: num.nullish(),
+    /** 매수호가 */
+    bidp1: num.nullish(),
+    /** Filler */
+    filler: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 시간외시간별체결 (`POST /krstock/quote/v1/currentAfterHoursExecution`) 응답. */
+export const krStockQuoteCurrentAfterHoursExecutionResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 시간외 시간별 체결 상세 목록 */
+    Output_0: z.array(krStockQuoteCurrentAfterHoursExecutionOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 시간외시간별예상 상세 (Output_0 배열의 각 항목). */
+export const krStockQuoteAfterHoursExpectedOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 시간 */
+    bsop_hour: z.string().nullish(),
+    /** 현재가 */
+    stck_prpr: num.nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: num.nullish(),
+    /** 등락률 */
+    prdy_ctrt: num.nullish(),
+    /** 거래량 */
+    cntg_vol: num.nullish(),
+    /** 매도호가 */
+    askp1: num.nullish(),
+    /** 매수호가 */
+    bidp1: num.nullish(),
+    /** 매도잔량 */
+    askp_rsqn1: num.nullish(),
+    /** 매수잔량 */
+    bidp_rsqn1: num.nullish(),
+    /** Filler */
+    filler: z.string().nullish(),
+  })
+  .passthrough();
+
+/** 주식현재가 시간외시간별예상 (`POST /krstock/quote/v1/afterHoursExpected`) 응답. */
+export const krStockQuoteAfterHoursExpectedResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 시간외 시간별 예상체결 상세 목록 */
+    Output_0: z.array(krStockQuoteAfterHoursExpectedOutputSchema).nullish(),
+  })
+  .passthrough();
+
+/** ETF/ETN 현재가 종합 정보 (Output_0). */
+export const krStockQuoteEtfCurrentOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 현재가 */
+    stck_prpr: num.nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: num.nullish(),
+    /** 등락률 */
+    prdy_ctrt: num.nullish(),
+    /** 매도호가 */
+    askp: num.nullish(),
+    /** 매수호가 */
+    bidp: num.nullish(),
+    /** 거래량 */
+    acml_vol: num.nullish(),
+    /** 거래비율 */
+    acml_rate: num.nullish(),
+    /** 유동주회전율 */
+    yu_rate: num.nullish(),
+    /** 거래대금 */
+    acml_tr_pbmn: num.nullish(),
+    /** 상한가 */
+    stck_mxpr: num.nullish(),
+    /** 고가 */
+    stck_hgpr: num.nullish(),
+    /** 시가 */
+    stck_oprc: num.nullish(),
+    /** 시가대비부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    oprc_sign: z.string().nullish(),
+    /** 시가대비등락폭 */
+    oprc_vrss: num.nullish(),
+    /** 저가 */
+    stck_lwpr: num.nullish(),
+    /** 하한가 */
+    stck_llam: num.nullish(),
+    /** 호가시간 */
+    bsop_hour: z.string().nullish(),
+    /** 매도1호가 */
+    askp1: num.nullish(),
+    /** 매도2호가 */
+    askp2: num.nullish(),
+    /** 매도3호가 */
+    askp3: num.nullish(),
+    /** 매도4호가 */
+    askp4: num.nullish(),
+    /** 매도5호가 */
+    askp5: num.nullish(),
+    /** 매도6호가 */
+    askp6: num.nullish(),
+    /** 매도7호가 */
+    askp7: num.nullish(),
+    /** 매도8호가 */
+    askp8: num.nullish(),
+    /** 매도9호가 */
+    askp9: num.nullish(),
+    /** 매도10호가 */
+    askp10: num.nullish(),
+    /** 매수1호가 */
+    bidp1: num.nullish(),
+    /** 매수2호가 */
+    bidp2: num.nullish(),
+    /** 매수3호가 */
+    bidp3: num.nullish(),
+    /** 매수4호가 */
+    bidp4: num.nullish(),
+    /** 매수5호가 */
+    bidp5: num.nullish(),
+    /** 매수6호가 */
+    bidp6: num.nullish(),
+    /** 매수7호가 */
+    bidp7: num.nullish(),
+    /** 매수8호가 */
+    bidp8: num.nullish(),
+    /** 매수9호가 */
+    bidp9: num.nullish(),
+    /** 매수10호가 */
+    bidp10: num.nullish(),
+    /** 매도1호가잔량 */
+    askp_rsqn1: num.nullish(),
+    /** 매도2호가잔량 */
+    askp_rsqn2: num.nullish(),
+    /** 매도3호가잔량 */
+    askp_rsqn3: num.nullish(),
+    /** 매도4호가잔량 */
+    askp_rsqn4: num.nullish(),
+    /** 매도5호가잔량 */
+    askp_rsqn5: num.nullish(),
+    /** 매도6호가잔량 */
+    askp_rsqn6: num.nullish(),
+    /** 매도7호가잔량 */
+    askp_rsqn7: num.nullish(),
+    /** 매도8호가잔량 */
+    askp_rsqn8: num.nullish(),
+    /** 매도9호가잔량 */
+    askp_rsqn9: num.nullish(),
+    /** 매도10호가잔량 */
+    askp_rsqn10: num.nullish(),
+    /** 매수1호가잔량 */
+    bidp_rsqn1: num.nullish(),
+    /** 매수2호가잔량 */
+    bidp_rsqn2: num.nullish(),
+    /** 매수3호가잔량 */
+    bidp_rsqn3: num.nullish(),
+    /** 매수4호가잔량 */
+    bidp_rsqn4: num.nullish(),
+    /** 매수5호가잔량 */
+    bidp_rsqn5: num.nullish(),
+    /** 매수6호가잔량 */
+    bidp_rsqn6: num.nullish(),
+    /** 매수7호가잔량 */
+    bidp_rsqn7: num.nullish(),
+    /** 매수8호가잔량 */
+    bidp_rsqn8: num.nullish(),
+    /** 매수9호가잔량 */
+    bidp_rsqn9: num.nullish(),
+    /** 매수10호가잔량 */
+    bidp_rsqn10: num.nullish(),
+    /** 총매도호가잔량 */
+    total_askp_rsqn: num.nullish(),
+    /** 총매수호가잔량 */
+    total_bidp_rsqn: num.nullish(),
+    /** 시간외매도잔량 */
+    ovtm_askp_rsqn: num.nullish(),
+    /** 시간외매수잔량 */
+    ovtm_bidp_rsqn: num.nullish(),
+    /** 피벗2차저항 */
+    pvt_scnd_dmrs: num.nullish(),
+    /** 피벗1차저항 */
+    pvt_frst_dmrs: num.nullish(),
+    /** 피벗가 */
+    pvt_pont_val: num.nullish(),
+    /** 피벗1차지지 */
+    pvt_frst_dmsp: num.nullish(),
+    /** 피벗2차지지 */
+    pvt_scnd_dmsp: num.nullish(),
+    /** 코스닥코스피구분 */
+    mrkt_div_code: z.string().nullish(),
+    /** 지수코드 */
+    bstp_cls_code: z.string().nullish(),
+    /** 업종명 */
+    bstp_kor_isnm: z.string().nullish(),
+    /** 자본금규모 */
+    cap_size: z.string().nullish(),
+    /** 결산월 */
+    stac_month: z.string().nullish(),
+    /** 시장조치1 */
+    market1: z.string().nullish(),
+    /** 시장조치2 */
+    market2: z.string().nullish(),
+    /** 시장조치3 */
+    market3: z.string().nullish(),
+    /** 시장조치4 */
+    market4: z.string().nullish(),
+    /** 시장조치5 */
+    market5: z.string().nullish(),
+    /** 시장조치6 */
+    market6: z.string().nullish(),
+    /** CB구분 */
+    cb_text: z.string().nullish(),
+    /** 액면가 */
+    stck_fcam: num.nullish(),
+    /** 전일종가타이틀 */
+    prdy_clpr_title: z.string().nullish(),
+    /** 전일종가 */
+    prdy_clpr: num.nullish(),
+    /** 대용가 */
+    stck_sspr: num.nullish(),
+    /** 공모가 */
+    gongprice: num.nullish(),
+    /** 5일고가 */
+    d5_hgpr: num.nullish(),
+    /** 5일저가 */
+    d5_lwpr: num.nullish(),
+    /** 20일고가 */
+    d20_hgpr: num.nullish(),
+    /** 20일저가 */
+    d20_lwpr: num.nullish(),
+    /** 52주최고가 */
+    w52_hgpr: num.nullish(),
+    /** 52주최저가 */
+    w52_lwpr: num.nullish(),
+    /** 유동주식수 */
+    move_stcn: num.nullish(),
+    /** 상장주식수_천주 */
+    lstn_stcn1: num.nullish(),
+    /** 시가총액 */
+    hts_avls: num.nullish(),
+    /** 시간 */
+    cntg_hour: z.string().nullish(),
+    /** 매도거래원1 */
+    seln_mbcr_no1: z.string().nullish(),
+    /** 매수거래원1 */
+    shnu_mbcr_no1: z.string().nullish(),
+    /** 매도거래량1 */
+    seln_acml_vol1: num.nullish(),
+    /** 매수거래량1 */
+    shnu_acml_vol1: num.nullish(),
+    /** 매도거래원2 */
+    seln_mbcr_no2: z.string().nullish(),
+    /** 매수거래원2 */
+    shnu_mbcr_no2: z.string().nullish(),
+    /** 매도거래량2 */
+    seln_acml_vol2: num.nullish(),
+    /** 매수거래량2 */
+    shnu_acml_vol2: num.nullish(),
+    /** 매도거래원3 */
+    seln_mbcr_no3: z.string().nullish(),
+    /** 매수거래원3 */
+    shnu_mbcr_no3: z.string().nullish(),
+    /** 매도거래량3 */
+    seln_acml_vol3: num.nullish(),
+    /** 매수거래량3 */
+    shnu_acml_vol3: num.nullish(),
+    /** 매도거래원4 */
+    seln_mbcr_no4: z.string().nullish(),
+    /** 매수거래원4 */
+    shnu_mbcr_no4: z.string().nullish(),
+    /** 매도거래량4 */
+    seln_acml_vol4: num.nullish(),
+    /** 매수거래량4 */
+    shnu_acml_vol4: num.nullish(),
+    /** 매도거래원5 */
+    seln_mbcr_no5: z.string().nullish(),
+    /** 매수거래원5 */
+    shnu_mbcr_no5: z.string().nullish(),
+    /** 매도거래량5 */
+    seln_acml_vol5: num.nullish(),
+    /** 매수거래량5 */
+    shnu_acml_vol5: num.nullish(),
+    /** 매도외국인거래량 */
+    seln_frgn_vol: num.nullish(),
+    /** 매수외국인거래량 */
+    shnu_frgn_vol: num.nullish(),
+    /** 외국인시간 */
+    frgn_hour: z.string().nullish(),
+    /** 외국인지분율 */
+    for_rate: num.nullish(),
+    /** 결제일 */
+    settdate: z.string().nullish(),
+    /** 잔고비율(%) */
+    crate: num.nullish(),
+    /** 유상기준일 */
+    yudate: z.string().nullish(),
+    /** 무상기준일 */
+    mudate: z.string().nullish(),
+    /** 유상배정비율 */
+    yurate: num.nullish(),
+    /** 무상배정비율 */
+    murate: num.nullish(),
+    /** 상장일 */
+    lstn_date: z.string().nullish(),
+    /** 상장주식수_주 */
+    lstn_stcn: num.nullish(),
+    /** 전체거래원매도합 */
+    total_seln_qty: num.nullish(),
+    /** 전체거래원매수합 */
+    total_shnu_qty: num.nullish(),
+    /** 신규거래량 */
+    new_volume: num.nullish(),
+  })
+  .passthrough();
+
+/** ETF/ETN 시간대별 체결 상세 (Output_1 배열의 각 항목). */
+export const krStockQuoteEtfCurrentTickOutputSchema = z
+  .object({
+    /** 호가시간 */
+    bsop_hour: z.string().nullish(),
+    /** 현재가 */
+    stck_prpr: num.nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: num.nullish(),
+    /** 매도호가 */
+    askp: num.nullish(),
+    /** 매수호가 */
+    bidp: num.nullish(),
+    /** 변동거래량 */
+    cntg_vol: z.union([z.string(), num]).nullish(),
+    /** 거래량 */
+    acml_vol: num.nullish(),
+  })
+  .passthrough();
+
+/** ETF/ETN 예상체결 정보 (Output_2). */
+export const krStockQuoteEtfCurrentExpectedOutputSchema = z
+  .object({
+    /** 동시호가구분 — 1.동시호가 이외 정규시장 */
+    aspr_cls_code: z.string().nullish(),
+    /** 예상체결가 */
+    antc_cnpr: z.union([z.string(), num]).nullish(),
+    /** 예상체결부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    antc_sign: z.string().nullish(),
+    /** 예상체결등락폭 */
+    antc_vrss: z.union([z.string(), num]).nullish(),
+    /** 예상체결등락률 */
+    antc_ctrt: z.union([z.string(), num]).nullish(),
+    /** 예상체결수량 */
+    antc_vol: z.union([z.string(), num]).nullish(),
+  })
+  .passthrough();
+
+/** ETF/ETN NAV·괴리율·LP 잔량 상세 (Output_3, 공식 스펙 문서에는 없고 예시 응답에만 존재). */
+export const krStockQuoteEtfCurrentNavOutputSchema = z
+  .object({
+    /** ETF구분 */
+    bu12: z.string().nullish(),
+    /** 장중/최종NAV */
+    itmt_last_nav: z.union([z.string(), num]).nullish(),
+    /** NAV등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    nav_sign: z.string().nullish(),
+    /** NAV등락폭 */
+    nav_vrss: z.union([z.string(), num]).nullish(),
+    /** 전일NAV */
+    prdy_last_nav: z.union([z.string(), num]).nullish(),
+    /** 괴리율 */
+    dprt: z.union([z.string(), num]).nullish(),
+    /** 괴리율부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    dprt_sign: z.string().nullish(),
+    /** 구성종목수 */
+    cnfg_cnt: z.union([z.string(), num]).nullish(),
+    /** 순자산총액(억원) */
+    totvalue: z.union([z.string(), num]).nullish(),
+    /** 추적오차율 */
+    trc_errt: z.union([z.string(), num]).nullish(),
+    /** LP매도호가잔량1 */
+    lp_askp_rsqn1: z.union([z.string(), num]).nullish(),
+    /** LP매도호가잔량2 */
+    lp_askp_rsqn2: z.union([z.string(), num]).nullish(),
+    /** LP매도호가잔량3 */
+    lp_askp_rsqn3: z.union([z.string(), num]).nullish(),
+    /** LP매도호가잔량4 */
+    lp_askp_rsqn4: z.union([z.string(), num]).nullish(),
+    /** LP매도호가잔량5 */
+    lp_askp_rsqn5: z.union([z.string(), num]).nullish(),
+    /** LP매도호가잔량6 */
+    lp_askp_rsqn6: z.union([z.string(), num]).nullish(),
+    /** LP매도호가잔량7 */
+    lp_askp_rsqn7: z.union([z.string(), num]).nullish(),
+    /** LP매도호가잔량8 */
+    lp_askp_rsqn8: z.union([z.string(), num]).nullish(),
+    /** LP매도호가잔량9 */
+    lp_askp_rsqn9: z.union([z.string(), num]).nullish(),
+    /** LP매도호가잔량10 */
+    lp_askp_rsqn10: z.union([z.string(), num]).nullish(),
+    /** LP매수호가잔량1 */
+    lp_bidp_rsqn1: z.union([z.string(), num]).nullish(),
+    /** LP매수호가잔량2 */
+    lp_bidp_rsqn2: z.union([z.string(), num]).nullish(),
+    /** LP매수호가잔량3 */
+    lp_bidp_rsqn3: z.union([z.string(), num]).nullish(),
+    /** LP매수호가잔량4 */
+    lp_bidp_rsqn4: z.union([z.string(), num]).nullish(),
+    /** LP매수호가잔량5 */
+    lp_bidp_rsqn5: z.union([z.string(), num]).nullish(),
+    /** LP매수호가잔량6 */
+    lp_bidp_rsqn6: z.union([z.string(), num]).nullish(),
+    /** LP매수호가잔량7 */
+    lp_bidp_rsqn7: z.union([z.string(), num]).nullish(),
+    /** LP매수호가잔량8 */
+    lp_bidp_rsqn8: z.union([z.string(), num]).nullish(),
+    /** LP매수호가잔량9 */
+    lp_bidp_rsqn9: z.union([z.string(), num]).nullish(),
+    /** LP매수호가잔량10 */
+    lp_bidp_rsqn10: z.union([z.string(), num]).nullish(),
+    /** ETF복제방법구분코드 */
+    clon_cls_code: z.string().nullish(),
+    /** ETF과세유형코드 */
+    txtn_type_code: z.string().nullish(),
+  })
+  .passthrough();
+
+/** ETF/ETN 기초지수 상세 (Output_4, 공식 스펙 문서에는 없고 예시 응답에만 존재). */
+export const krStockQuoteEtfCurrentIndexOutputSchema = z
+  .object({
+    /** 지수코드 */
+    bstp_cls_code: z.string().nullish(),
+    /** 업종명 */
+    bstp_kor_isnm: z.string().nullish(),
+    /** 지수 */
+    prpr_nmix: z.union([z.string(), num]).nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 — 길이 10 (스펙은 int 지만 실측은 소수부 있는 float) */
+    prdy_vrss: num.nullish(),
+    /** 채권지수코드 */
+    ubjiid: z.string().nullish(),
+    /** 채권지수세부코드 */
+    ubjiid2: z.string().nullish(),
+    /** 채권지수 */
+    ubjisu: z.union([z.string(), num, num]).nullish(),
+    /** 채권등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    ubsign: z.string().nullish(),
+    /** 채권등락폭 */
+    ubchange: z.union([z.string(), num, num]).nullish(),
+    /** 해외지수심볼 */
+    symbol: z.string().nullish(),
+    /** 해외지수 */
+    ovrs_nmix: z.union([z.string(), num, num]).nullish(),
+    /** 해외지수등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    ovrs_sign: z.string().nullish(),
+    /** 해외지수등락폭 */
+    ovrs_vrss: z.union([z.string(), num, num]).nullish(),
+    /** 지수거래소구분 — 1.코스피 2.코스닥 */
+    jisukpgubun: z.string().nullish(),
+  })
+  .passthrough();
+
+/** ETF/ETN 현재가 (`POST /krstock/quote/v1/etfCurrent`) 응답. */
+export const krStockQuoteEtfCurrentResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** ETF/ETN 현재가 종합 정보 */
+    Output_0: krStockQuoteEtfCurrentOutputSchema.nullish(),
+    /** 시간대별 체결 상세 목록 */
+    Output_1: z.array(krStockQuoteEtfCurrentTickOutputSchema).nullish(),
+    /** 예상체결 정보 */
+    Output_2: krStockQuoteEtfCurrentExpectedOutputSchema.nullish(),
+    /** NAV·괴리율·LP 잔량 상세 (스펙 문서 미기재, 예시 응답에만 존재) */
+    Output_3: krStockQuoteEtfCurrentNavOutputSchema.nullish(),
+    /** 기초지수 상세 (스펙 문서 미기재, 예시 응답에만 존재) */
+    Output_4: krStockQuoteEtfCurrentIndexOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/** ETF 구성종목시세 상세 (Output_0 배열의 각 항목). */
+export const krStockQuoteEtfComponentsOutputSchema = z
+  .object({
+    /** 종목코드 */
+    iem_cd: z.string().nullish(),
+    /** 종목명 */
+    iem_nm: z.string().nullish(),
+    /** 현재가 */
+    stck_prpr: num.nullish(),
+    /** 등락부호 — 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세) */
+    prdy_vrss_sign: z.string().nullish(),
+    /** 등락폭 */
+    prdy_vrss: num.nullish(),
+    /** 등락률 */
+    prdy_ctrt: num.nullish(),
+    /** 1CU단위증권수(주) */
+    cu_unit: num.nullish(),
+    /** 평가금액2 */
+    totprice: num.nullish(),
+    /** 비중 */
+    vol: num.nullish(),
+    /** 평가금액 */
+    vltn_amt: num.nullish(),
+    /** Filler */
+    filler: z.string().nullish(),
+  })
+  .passthrough();
+
+/** ETF 구성종목시세 (`POST /krstock/quote/v1/etfComponents`) 응답. */
+export const krStockQuoteEtfComponentsResponseSchema = z
+  .object({
+    ...assetEnvelope,
+    /** 구성종목 상세 목록 */
+    Output_0: z.array(krStockQuoteEtfComponentsOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── Response Types ──
+
+export type KrStockQuoteCurrentPriceResponse = CamelizeKeys<z.infer<typeof krStockQuoteCurrentPriceResponseSchema>>;
+export type KrStockQuoteCurrentExecutionResponse = CamelizeKeys<
+  z.infer<typeof krStockQuoteCurrentExecutionResponseSchema>
+>;
+export type KrStockQuoteCurrentDailyResponse = CamelizeKeys<z.infer<typeof krStockQuoteCurrentDailyResponseSchema>>;
+export type KrStockQuoteCurrentInvestorResponse = CamelizeKeys<
+  z.infer<typeof krStockQuoteCurrentInvestorResponseSchema>
+>;
+export type KrStockQuotePeriodResponse = CamelizeKeys<z.infer<typeof krStockQuotePeriodResponseSchema>>;
+export type KrStockQuoteAfterHoursCurrentResponse = CamelizeKeys<
+  z.infer<typeof krStockQuoteAfterHoursCurrentResponseSchema>
+>;
+export type KrStockQuoteCurrentAfterHoursDailyResponse = CamelizeKeys<
+  z.infer<typeof krStockQuoteCurrentAfterHoursDailyResponseSchema>
+>;
+export type KrStockQuoteCurrentAfterHoursExecutionResponse = CamelizeKeys<
+  z.infer<typeof krStockQuoteCurrentAfterHoursExecutionResponseSchema>
+>;
+export type KrStockQuoteAfterHoursExpectedResponse = CamelizeKeys<
+  z.infer<typeof krStockQuoteAfterHoursExpectedResponseSchema>
+>;
+export type KrStockQuoteEtfCurrentResponse = CamelizeKeys<z.infer<typeof krStockQuoteEtfCurrentResponseSchema>>;
+export type KrStockQuoteEtfComponentsResponse = CamelizeKeys<z.infer<typeof krStockQuoteEtfComponentsResponseSchema>>;
+
+// ── Response Map ──
+
+export interface KrstockQuoteResponseMap {
+  currentPrice: KrStockQuoteCurrentPriceResponse;
+  currentExecution: KrStockQuoteCurrentExecutionResponse;
+  currentDaily: KrStockQuoteCurrentDailyResponse;
+  currentInvestor: KrStockQuoteCurrentInvestorResponse;
+  period: KrStockQuotePeriodResponse;
+  afterHoursCurrent: KrStockQuoteAfterHoursCurrentResponse;
+  currentAfterHoursDaily: KrStockQuoteCurrentAfterHoursDailyResponse;
+  currentAfterHoursExecution: KrStockQuoteCurrentAfterHoursExecutionResponse;
+  afterHoursExpected: KrStockQuoteAfterHoursExpectedResponse;
+  etfCurrent: KrStockQuoteEtfCurrentResponse;
+  etfComponents: KrStockQuoteEtfComponentsResponse;
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/schemas/overseas-stock-inquiry.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/schemas/overseas-stock-inquiry.ts
@@ -1,0 +1,560 @@
+import { z } from 'zod';
+
+import type { CamelizeKeys } from '../../core/types';
+
+/**
+ * NH PLUG 해외주식(조회) 응답 스키마.
+ *
+ * 와이어 포맷은 snake_case 이며 (`Output_0`, `Output_1` … 블록 이름도 원문 그대로),
+ * 공개 API 는 `camelizeKeys` 로 자동 camelCase 변환한다 — 스키마는 와이어를 그대로 기술한다.
+ * 모든 블록·필드는 데이터가 있을 때만 내려오므로 전부 optional/nullable 이고,
+ * 스펙에 없는 실서버 필드가 살아남도록 모든 객체에 `.passthrough()` 를 건다.
+ */
+
+/** 스펙상 문자열 필드. 실서버가 숫자로 내려주는 경우가 있어 문자열로 강제 변환한다. */
+const str = () => z.coerce.string().nullish();
+
+/**
+ * 스펙상 숫자(`int`/`float`) 필드.
+ *
+ * 실서버는 숫자를 문자열로, 값 없는 숫자를 빈 문자열(`""`)로 내려주는 사례가 있어
+ * (파이썬 `_overseas_stock_quote_types` 의 `_empty_str_to_none` 참고)
+ * 빈 문자열은 null 로 접고 나머지는 숫자로 강제 변환한다.
+ */
+const num = () => z.preprocess((value) => (value === '' ? null : value), z.coerce.number().nullish()).nullish();
+
+/** 스펙상 `message` 봉투. 실서버는 null 을 내려주고 `rsp_cd`/`rsp_msg` 를 대신 쓴다. */
+const messageSchema = z
+  .object({
+    msg_code: str(),
+    usr_msg: str(),
+    msg_lv_code: str(),
+    dvlp_msg_yn: str(),
+  })
+  .passthrough();
+
+const envelope = {
+  /** 응답코드 (00000·XA102: 성공) */
+  rsp_cd: str(),
+  /** 응답메시지 */
+  rsp_msg: str(),
+  /** 스펙상 메시지 봉투 (실서버는 null) */
+  message: messageSchema.nullish(),
+};
+
+// ── 해외주식 매수가능금액·수량 조회 결과 (`Output_0`). ──
+
+export const overseasStockInquiryBuyableAmountOutputSchema = z
+  .object({
+    fc_dca: num(), // 외화예수금
+    mgg_fc_amt: num(), // 담보외화금액
+    csh_wtm: num(), // 현금증거금
+    re_use_obj_amt: num(), // 재사용대상금액
+    re_use_rtr_use_amt: num(), // 재사용환원사용금액
+    ect_use_amt: num(), // 기타사용금액
+    orr_pbl_amt: num(), // 주문가능금액
+    wtm_cur_cd: str(), // 증거금통화코드
+    hld_qty: num(), // 보유수량
+    orr_pbl_qty: num(), // 주문가능수량
+    sll_pbl_qty: num(), // 매도가능수량
+    sll_pbl_qty1: num(), // 매도가능수량1
+    byn_cns_qty: num(), // 매수체결수량
+    sll_cns_qty: num(), // 매도체결수량
+    sll_orr_qty: num(), // 매도주문수량
+    dps_rsc_qty: num(), // 처분제한수량
+    byn_pbl_qty: num(), // 매수가능수량
+    max_pbl_amt: num(), // 최대가능금액
+    max_pbl_qty: num(), // 최대가능수량
+    csh_wtm_rt: num(), // 현금증거금율
+  })
+  .passthrough();
+
+/**
+ * 해외주식 매수가능금액·수량 조회 (`POST /gbstock/inquiry/v1/buyableAmount`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체
+ */
+export const overseasStockInquiryBuyableAmountResponseSchema = z
+  .object({
+    ...envelope,
+    /** 매수가능금액·수량 조회 결과 */
+    Output_0: overseasStockInquiryBuyableAmountOutputSchema.nullish(),
+  })
+  .passthrough();
+
+// ── 해외주식 주문체결내역 조회 결과 항목 (`Output_0` 배열 원소). ──
+
+export const overseasStockInquiryUnexecutedOutputSchema = z
+  .object({
+    rgs_tm: str(), // 등록시각
+    oss_orr_knd_cd: str(), // 해외증권주문종류코드
+    orr_knd_nm: str(), // 주문종류명
+    orr_no: num(), // 주문번호
+    org_orr_no: num(), // 원주문번호
+    oss_sby_dit_cd: str(), // 해외증권매매구분코드
+    sby_dit_nm: str(), // 매매구분명
+    fc_sec_trd_nat_cd: str(), // 외화증권거래국가코드
+    mkt_dit_cd_nm: str(), // 시장구분코드명
+    iem_cd: str(), // 종목코드
+    iem_nm: str(), // 종목명
+    orr_qty: num(), // 주문수량
+    fc_orr_uit_pr: num(), // 외화주문단가
+    cns_qty: num(), // 체결수량
+    cns_pr: num(), // 체결가격
+    ny_cns_orr_qty: num(), // 미체결주문수량
+    cor_can_dit_cd: str(), // 정정취소구분코드
+    cor_can_dit_nm: str(), // 정정취소구분명
+    cor_qty: num(), // 정정수량
+    can_qty: num(), // 취소수량
+    oss_ato_orr_sts_cd: str(), // 해외증권자동주문상태코드
+    orr_sts_nm: str(), // 주문상태명
+    oms_cus_orr_no: str(), // OMS고객주문번호
+    rjt_rsn_cts: str(), // 거부사유내용
+    ivs_nat_krx_dit_cd: str(), // 투자국가거래소구분코드
+    fix_sgy_tgt_sgy_nm: str(), // FIX전략타겟전략명
+    fix_orr_pcs_mtd_cd: str(), // FIX주문처리방법코드
+    orr_pcs_mtd_cd_nm: str(), // 주문처리방법코드명
+    rut_orr_krx_cd: str(), // 로이터주문거래소코드
+    hts_usr_id: str(), // HTS사용자ID
+    usr_ip_adr: str(), // 사용자IP주소
+    cuc_mdi_cd: str(), // 통신매체코드
+    cuc_mdi_cd_nm: str(), // 통신매체코드명
+    ahi_nmn_pr_tp_cd: str(), // 현물호가유형코드
+    ahi_nmn_pr_tp_cd_nm: str(), // 현물호가유형코드명
+    fc_stop_orr_bse_pr: num(), // 외화STOP주문기준가격
+    orr_pdt_dit_cd: str(), // 주문상품구분코드
+    orr_dt: str(), // 주문일자
+    csh_wtm_rt: num(), // 현금증거금율
+    cfd_lon_cd: str(), // 신용대출코드
+    cfd_lon_cd_nm: str(), // 신용대출코드명
+    lon_dt: str(), // 대출일자
+  })
+  .passthrough();
+
+/**
+ * 해외주식 주문체결내역 조회 (`POST /gbstock/inquiry/v1/unexecuted`) 응답.
+ *
+ * 응답 블록: `Output_0`: 배열
+ */
+export const overseasStockInquiryUnexecutedResponseSchema = z
+  .object({
+    ...envelope,
+    /** 주문체결내역 조회 결과 */
+    Output_0: z.array(overseasStockInquiryUnexecutedOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── 해외주식 잔고조회 결과 (`Output_0`). ──
+
+export const overseasStockInquiryBalanceAccountOutputSchema = z
+  .object({
+    abk_amt: num(), // 장부금액
+    eal_amt_sum: num(), // 평가금액합계
+    eal_pls_sum_amt: num(), // 평가손익합계금액
+    krw_pft_rt: num(), // 원화수익율
+    krw_dca: num(), // 원화예수금
+    krw_ny_stl_xcl_amt: num(), // 원화미결제정산금액
+    tot_aet_amt: num(), // 총자산금액
+    fc_abk_amt: num(), // 외화장부금액
+    fc_eal_amt: num(), // 외화평가금액
+    fc_eal_pls_amt: num(), // 외화평가손익금액
+    pft_rt: num(), // 수익율
+    fc_dca: num(), // 외화예수금
+    fc_ny_stl_xcl_amt: num(), // 외화미결제정산금액
+    fc_aet_amt: num(), // 외화자산금액
+    ptps_ttn_amt: num(), // PTP과세금액
+    ptps_ttn_amt1: num(), // PTP과세금액1
+  })
+  .passthrough();
+
+// ── 해외주식 잔고조회 결과 항목 (`Output_1` 배열 원소). ──
+
+export const overseasStockInquiryBalanceHoldingOutputSchema = z
+  .object({
+    fc_sec_trd_nat_cd: str(), // 외화증권거래국가코드
+    fc_sec_trd_nat_nm: str(), // 외화증권거래국가명
+    iem_cd: str(), // 종목코드
+    oss_iem_eng_nm: str(), // 해외증권종목영문명
+    iem_nm: str(), // 외화증권한글명
+    cns_bse_bnc_qty: num(), // 체결기준잔고수량
+    sll_cns_qty: num(), // 매도체결수량
+    byn_cns_qty: num(), // 매수체결수량
+    sll_pbl_qty1: num(), // 매도가능수량1
+    fc_abk_amt: num(), // 외화장부금액
+    krw_abk_amt1: num(), // 원화장부금액1
+    fc_phs_uit_pr: num(), // 외화매입단가
+    phs_uit_pr: num(), // 매입단가
+    fc_sec_end_pr: num(), // 외화증권종가
+    end_pr: num(), // 종가
+    fc_eal_amt: num(), // 외화평가금액
+    krw_eal_amt: num(), // 원화평가금액
+    fc_eal_pls_amt: num(), // 외화평가손익금액
+    krw_eal_pls_amt: num(), // 원화평가손익금액
+    eal_pft_rt: num(), // 평가수익율
+    eal_pft_rt1: num(), // 평가수익율1
+    cur_cd: str(), // 통화코드
+    phs_xcg_rt: num(), // 매입환율
+    tdt_sby_bse_xcg_rt: num(), // 당일매매기준환율
+    fc_mkt_dit_cd: str(), // 외화시장구분코드
+    fc_sll_pls_amt: num(), // 외화매도손익금액
+    krw_sll_pls_amt: num(), // 원화매도손익금액
+    fc_sll_pft_rt: num(), // 외화매도수익율
+    krw_sll_pft_rt: num(), // 원화매도수익율
+    fc_cns_bse_phs_xps: num(), // 외화체결기준매입비
+    krw_cns_bse_phs_xps: num(), // 원화체결기준매입비
+    fc_avg_phs_pr: num(), // 외화평균매입가격
+    krw_avg_phs_pr: num(), // 원화평균매입가격
+    fc_fee: num(), // 외화수수료
+    krw_fee: num(), // 원화수수료
+    fc_tax_amt: num(), // 외화세금금액
+    krw_tax_amt: num(), // 원화세금금액
+    fc_pls_qtr_phs_pr: num(), // 외화손익분기매입가격
+    krw_pls_qtr_phs_pr: num(), // 원화손익분기매입가격
+    sby_fee_rt: num(), // 매매수수료율
+    fc_stk_lws_sby_fee: num(), // 외화주식최저매매수수료
+    cfd_lon_cd_nm: str(), // 신용대출코드명
+    lon_dt: str(), // 대출일자
+    xrn_dt: str(), // 만기일자
+  })
+  .passthrough();
+
+/**
+ * 해외주식 잔고조회 (`POST /gbstock/inquiry/v1/balance`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체, `Output_1`: 배열
+ */
+export const overseasStockInquiryBalanceResponseSchema = z
+  .object({
+    ...envelope,
+    /** 잔고 요약 조회 결과 */
+    Output_0: overseasStockInquiryBalanceAccountOutputSchema.nullish(),
+    /** 잔고 종목별 조회 결과 */
+    Output_1: z.array(overseasStockInquiryBalanceHoldingOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── 해외주식 예약주문조회 결과 항목 (`Output_0` 배열 원소). ──
+
+export const overseasStockInquiryReservedInquiryOutputSchema = z
+  .object({
+    fc_mkt_dit_cd: str(), // 외화시장구분코드 / 200.미국 070.일본 120.홍콩 160.상해 170.심천
+    bkg_orr_dt: str(), // 예약주문일자 / YYYYMMDD
+    act_no: str(), // 계좌번호
+    cus_fnm: str(), // 고객성명
+    iem_cd: str(), // 티커종목코드
+    iem_nm: str(), // 종목명
+    cur_cd: str(), // 통화코드 / KRW.KRW USD.USD CNY.CNY HKD.HKD JPY.JPY
+    sby_dit_cd: str(), // 매매구분코드 / 1.매도 2.매수
+    sby_dit_nm: str(), // 매매구분명
+    orr_qty: num(), // 주문수량
+    orr_pr: num(), // 주문가격
+    cns_qty: num(), // 체결수량
+    cns_pr: num(), // 체결가격
+    bkg_orr_can_yn: str(), // 예약주문취소여부
+    orr_can_dit_nm: str(), // 주문취소구분명
+    bkg_orr_rtn_dt: str(), // 예약주문접수일자 / YYYYMMDD
+    bkg_orr_rtn_tm: str(), // 예약주문접수시각
+    rgs_tab_cd: str(), // 등록팀점코드
+    rgs_emp_no: str(), // 등록사원번호
+    rgs_emp_fnm: str(), // 등록사원성명
+    cct_dt: str(), // 해지일자 / YYYYMMDD
+    cct_tm: str(), // 해지시각
+    cct_emp_no: str(), // 해지사원번호
+    cct_emp_fnm: str(), // 해지사원성명
+    bkg_rtn_orr_no: num(), // 예약접수주문번호
+    orr_sno: num(), // 주문일련번호
+    ost_orr_mdi: str(), // 주문매체
+    orr_cpl_yn: str(), // 주문완료여부
+    ost_pcs_cd: str(), // 처리코드
+    pcs_msg_cts: str(), // 처리메시지내용
+    aca_tel_no: str(), // 연락처전화번호
+    ahi_nmn_pr_tp_cd: str(), // 현물호가유형코드
+    ahi_nmn_pr_tp_cd_nm: str(), // 현물호가유형코드명
+    oss_orr_knd_cd_nm: str(), // 해외증권주문종류코드명
+    ivs_sgy_cd_nm: str(), // 투자전략코드명
+    fc_csh_wtm: num(), // 외화현금증거금
+    fc_csh_wtm_fee: num(), // 외화현금증거금수수료
+    fc_csh_wtm_tax_amt: num(), // 외화현금증거금세금금액
+    fc_csh_wtm_trd_tax: num(), // 외화현금증거금거래세
+    fc_mkt_dit_cd_nm: str(), // 외화시장구분코드명
+    bkg_orr_tp_cd: str(), // 예약주문유형코드 / 1. 일반예약주문 / 2. 잔량기준기간예약주문 / 3. 수량기준기간예약주문 / 4. 증거금징수 예약
+    bkg_orr_tp_cd_nm: str(), // 예약주문유형코드명
+    orr_enf_sta_dt: str(), // 주문집행시작일자 / YYYYMMDD
+    orr_enf_end_dt: str(), // 주문집행종료일자 / YYYYMMDD
+    acl_cns_qty: num(), // 누적체결수량
+    lst_orr_enf_dt: str(), // 최종주문집행일자 / YYYYMMDD
+    rmn_qty: num(), // 잔여수량
+    wtm_cur_knd_cd: str(), // 증거금통화종류코드 / 1.거래국가통화 2.원화 3.기타통화
+    cd_nm: str(), // 코드명
+    fc_stop_orr_bse_pr: num(), // 외화STOP주문기준가격
+    orr_pdt_dit_cd: str(), // 주문상품구분코드
+    cfd_lon_cd: str(), // 신용대출코드
+    cfd_lon_cd_nm: str(), // 신용대출코드명
+    lon_dt: str(), // 대출일자 / YYYYMMDD
+  })
+  .passthrough();
+
+/**
+ * 해외주식 예약주문조회 (`POST /gbstock/inquiry/v1/reservedInquiry`) 응답.
+ *
+ * 응답 블록: `Output_0`: 배열
+ */
+export const overseasStockInquiryReservedInquiryResponseSchema = z
+  .object({
+    ...envelope,
+    /** 예약주문내역 조회 결과 */
+    Output_0: z.array(overseasStockInquiryReservedInquiryOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── 해외주식 일별거래내역 조회 결과 항목 (`Output_0` 배열 원소). ──
+
+export const overseasStockInquiryDailyTransactionOutputSchema = z
+  .object({
+    trd_dt: str(), // 거래일자
+    trd_sno: num(), // 거래일련번호
+    act_trd_tp_nm: str(), // 계좌거래유형명
+    sps_cd_nm: str(), // 적요코드명
+    iem_krl_nm: str(), // 종목한글명
+    iem_cd: str(), // 종목코드
+    trd_qty: num(), // 거래수량
+    trd_uit_pr: num(), // 거래단가
+    cur_cd_nm: str(), // 통화코드명
+    aly_xcg_rt: num(), // 적용환율
+    trd_bf_bnc_qty: num(), // 거래전잔고수량
+    trd_af_bnc_qty: num(), // 거래후잔고수량
+    fc_trd_amt: num(), // 외화거래금액
+    krw_trd_amt: num(), // 원화거래금액
+    trd_af_fc_dca: num(), // 거래후외화예수금
+    trd_af_dca: num(), // 거래후예수금
+    trd_af_fc_mgg_amt: num(), // 거래후외화담보금액
+    trd_af_krw_mgg_amt: num(), // 거래후원화담보금액
+    abd_sdr_xps_fc_amt: num(), // 국외제비용외화금액
+    tsl_mgg_amt: num(), // 환산담보금액
+    ose_fee: num(), // 해외수수료
+    dmt_fee: num(), // 국내수수료
+    icm_tax: num(), // 소득세
+    rsd_tax: num(), // 주민세
+    rgs_cuc_mdi_cd_nm: str(), // 등록통신매체코드명
+    rgs_tm: str(), // 등록시각
+    rgs_tab_cd: str(), // 등록팀점코드
+    rgs_emp_no: str(), // 등록사원번호
+    oss_iem_cd: str(), // 해외증권종목코드
+    oss_iem_nm: str(), // 해외증권종목명
+    trd_bf_fc_dca: num(), // 거래전외화예수금
+    trd_bf_dca: num(), // 거래전예수금
+    oss_stm_tax: num(), // 해외증권인지세
+    fc_tsl_txa: num(), // 외화환산세액
+    fc_amt: num(), // 외화금액
+    krw_amt: num(), // 원화금액
+    fc_tax_sum: num(), // 외화세금합계
+    tax_sum: num(), // 세금합계
+    fc_icm_tax: num(), // 외화소득세
+    fc_rsd_tax: num(), // 외화주민세
+    fc_sas_amt: num(), // 외화과세표준금액
+    krw_sas_amt: num(), // 원화과세표준금액
+    tsl_cmu_txa: num(), // 환산산출세액
+    fc_trd_dit_cd: str(), // 외화거래구분코드
+    ral_trd_dt: str(), // 실거래일자
+  })
+  .passthrough();
+
+// ── 해외주식 일별거래내역 조회 결과 요약 (`Output_1`). ──
+
+export const overseasStockInquiryDailyTransactionSummaryOutputSchema = z
+  .object({
+    cus_fnm: str(), // 고객성명
+    rnm_cfm_no: str(), // 실명확인번호
+    rpm_tal: num(), // 입금총액
+    drn_tal: num(), // 출금총액
+    amt_sum: num(), // 금액합계
+    tax_sum_amt: num(), // 세금합계금액
+    fee_sum_amt: num(), // 수수료합계금액
+  })
+  .passthrough();
+
+/**
+ * 해외주식 일별거래내역 조회 (`POST /gbstock/inquiry/v1/dailyTransaction`) 응답.
+ *
+ * 응답 블록: `Output_0`: 배열, `Output_1`: 객체
+ */
+export const overseasStockInquiryDailyTransactionResponseSchema = z
+  .object({
+    ...envelope,
+    /** 일별거래내역 조회 결과 */
+    Output_0: z.array(overseasStockInquiryDailyTransactionOutputSchema).nullish(),
+    /** 일별거래내역 조회 결과 요약 */
+    Output_1: overseasStockInquiryDailyTransactionSummaryOutputSchema.nullish(),
+  })
+  .passthrough();
+
+// ── 해외주식 기간손익 조회 결과 요약 (`Output_0`). ──
+
+export const overseasStockInquiryPeriodPnlSummaryOutputSchema = z
+  .object({
+    act_fnm: str(), // 계좌성명
+    byn_qty_sum: num(), // 매수수량합계
+    fc_byn_amt_sum: num(), // 외화매수금액합계
+    sll_qty_sum: num(), // 매도수량합계
+    fc_sll_amt_sum: num(), // 외화매도금액합계
+    fc_sby_pls_sum: num(), // 외화매매손익합계
+    fc_sby_pft_rt: num(), // 외화매매수익율
+    fc_sdr_xps_sum: num(), // 외화제비용합계
+    fc_rzt_pls_sum: num(), // 외화실현손익합계
+    fc_rzt_pft_rt: num(), // 외화실현수익율
+  })
+  .passthrough();
+
+// ── 해외주식 기간손익 조회 결과 항목 (`Output_1` 배열 원소). ──
+
+export const overseasStockInquiryPeriodPnlDailyOutputSchema = z
+  .object({
+    orr_dt: str(), // 주문일자 / YYYYMMDD
+    fc_sec_trd_nat_cd: str(), // 외화증권거래국가코드 / 200.미국 070.일본 120.홍콩 160.상해 170.심천
+    fc_sec_trd_nat_nm: str(), // 외화증권거래국가명
+    trd_cur_cd: str(), // 거래통화코드 / KRW.KRW USD.USD CNY.CNY HKD.HKD JPY.JPY
+    byn_qty: num(), // 매수수량
+    byn_uit_pr: num(), // 매수단가
+    fc_byn_amt1: num(), // 외화매수금액1
+    sll_qty: num(), // 매도수량
+    sll_uit_pr: num(), // 매도단가
+    fc_sll_amt: num(), // 외화매도금액
+    fc_sby_pls: num(), // 외화매매손익
+    fc_sby_pft_rt: num(), // 외화매매수익율
+    fc_sdr_xps: num(), // 외화제비용
+    fc_rzt_pls: num(), // 외화실현손익
+    fc_rzt_pft_rt: num(), // 외화실현수익율
+  })
+  .passthrough();
+
+/**
+ * 해외주식 기간손익 조회 (`POST /gbstock/inquiry/v1/periodPnl`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체, `Output_1`: 배열
+ */
+export const overseasStockInquiryPeriodPnlResponseSchema = z
+  .object({
+    ...envelope,
+    /** 기간손익 조회 결과 요약 */
+    Output_0: overseasStockInquiryPeriodPnlSummaryOutputSchema.nullish(),
+    /** 기간손익 조회 결과 목록 */
+    Output_1: z.array(overseasStockInquiryPeriodPnlDailyOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── 해외주식 기간손익 상세 조회 결과 항목 (`Output_0` 배열 원소). ──
+
+export const overseasStockInquiryPeriodPnlDetailOutputSchema = z
+  .object({
+    iem_cd: str(), // 종목코드
+    iem_nm: str(), // 종목명
+    byn_qty: num(), // 매수수량
+    byn_uit_pr: num(), // 매수단가
+    fc_byn_amt1: num(), // 외화매수금액1
+    sll_qty: num(), // 매도수량
+    sll_uit_pr: num(), // 매도단가
+    fc_sll_amt: num(), // 외화매도금액
+    fc_sby_pls: num(), // 외화매매손익
+    fc_sby_pft_rt: num(), // 외화매매수익율
+    fc_sdr_xps: num(), // 외화제비용
+    fc_rzt_pls: num(), // 외화실현손익
+    fc_rzt_pft_rt: num(), // 외화실현수익율
+  })
+  .passthrough();
+
+/**
+ * 해외주식 기간손익 상세 조회 (`POST /gbstock/inquiry/v1/periodPnlDetail`) 응답.
+ *
+ * 응답 블록: `Output_0`: 배열
+ */
+export const overseasStockInquiryPeriodPnlDetailResponseSchema = z
+  .object({
+    ...envelope,
+    /** 기간손익 상세 조회 결과 목록 */
+    Output_0: z.array(overseasStockInquiryPeriodPnlDetailOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── 해외증거금 통화별조회 결과 항목 (`Output_0` 배열 원소). ──
+
+export const overseasStockInquiryMarginOutputSchema = z
+  .object({
+    cur_cd: str(), // 통화코드 / KRW.KRW USD.USD CNY.CNY HKD.HKD JPY.JPY
+    dca: num(), // 예수금
+    orr_wtm: num(), // 주문증거금
+    ect_mgg_amt: num(), // 기타담보금액
+    drn_pbl_amt: num(), // 출금가능금액
+    fc_dca: num(), // 외화예수금
+    fc_mgg_amt: num(), // 외화담보금액
+    ect_mgg_fc_amt: num(), // 기타담보외화금액
+    fc_drn_pbl_amt: num(), // 외화출금가능금액
+    sby_bse_xcg_rt: num(), // 매매기준환율
+    fc_rba: num(), // 외화미수금
+    rba: num(), // 미수금
+    fc_rvb_odu_fee: num(), // 외화미수연체료
+    rvb_odu_fee: num(), // 미수연체료
+    stl_af_dca: num(), // 결제후예수금
+    stl_af_drn_pbl_amt: num(), // 결제후출금가능금액
+    stl_af_fc_dca: num(), // 결제후외화예수금
+    stl_af_fc_drn_pbl_amt: num(), // 결제후외화출금가능금액
+  })
+  .passthrough();
+
+/**
+ * 해외증거금 통화별조회 (`POST /gbstock/inquiry/v1/margin`) 응답.
+ *
+ * 응답 블록: `Output_0`: 배열
+ */
+export const overseasStockInquiryMarginResponseSchema = z
+  .object({
+    ...envelope,
+    /** 해외증거금 통화별조회 결과 목록 */
+    Output_0: z.array(overseasStockInquiryMarginOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── Response Types ──
+
+/** 해외주식 매수가능금액·수량 조회 (`POST /gbstock/inquiry/v1/buyableAmount`) 응답. — `Output_0`: 객체 */
+export type OverseasStockInquiryBuyableAmountResponse = CamelizeKeys<
+  z.infer<typeof overseasStockInquiryBuyableAmountResponseSchema>
+>;
+/** 해외주식 주문체결내역 조회 (`POST /gbstock/inquiry/v1/unexecuted`) 응답. — `Output_0`: 배열 */
+export type OverseasStockInquiryUnexecutedResponse = CamelizeKeys<
+  z.infer<typeof overseasStockInquiryUnexecutedResponseSchema>
+>;
+/** 해외주식 잔고조회 (`POST /gbstock/inquiry/v1/balance`) 응답. — `Output_0`: 객체, `Output_1`: 배열 */
+export type OverseasStockInquiryBalanceResponse = CamelizeKeys<
+  z.infer<typeof overseasStockInquiryBalanceResponseSchema>
+>;
+/** 해외주식 예약주문조회 (`POST /gbstock/inquiry/v1/reservedInquiry`) 응답. — `Output_0`: 배열 */
+export type OverseasStockInquiryReservedInquiryResponse = CamelizeKeys<
+  z.infer<typeof overseasStockInquiryReservedInquiryResponseSchema>
+>;
+/** 해외주식 일별거래내역 조회 (`POST /gbstock/inquiry/v1/dailyTransaction`) 응답. — `Output_0`: 배열, `Output_1`: 객체 */
+export type OverseasStockInquiryDailyTransactionResponse = CamelizeKeys<
+  z.infer<typeof overseasStockInquiryDailyTransactionResponseSchema>
+>;
+/** 해외주식 기간손익 조회 (`POST /gbstock/inquiry/v1/periodPnl`) 응답. — `Output_0`: 객체, `Output_1`: 배열 */
+export type OverseasStockInquiryPeriodPnlResponse = CamelizeKeys<
+  z.infer<typeof overseasStockInquiryPeriodPnlResponseSchema>
+>;
+/** 해외주식 기간손익 상세 조회 (`POST /gbstock/inquiry/v1/periodPnlDetail`) 응답. — `Output_0`: 배열 */
+export type OverseasStockInquiryPeriodPnlDetailResponse = CamelizeKeys<
+  z.infer<typeof overseasStockInquiryPeriodPnlDetailResponseSchema>
+>;
+/** 해외증거금 통화별조회 (`POST /gbstock/inquiry/v1/margin`) 응답. — `Output_0`: 배열 */
+export type OverseasStockInquiryMarginResponse = CamelizeKeys<z.infer<typeof overseasStockInquiryMarginResponseSchema>>;
+
+// ── Response Map ──
+
+export interface OverseasStockInquiryResponseMap {
+  buyableAmount: OverseasStockInquiryBuyableAmountResponse;
+  unexecuted: OverseasStockInquiryUnexecutedResponse;
+  balance: OverseasStockInquiryBalanceResponse;
+  reservedInquiry: OverseasStockInquiryReservedInquiryResponse;
+  dailyTransaction: OverseasStockInquiryDailyTransactionResponse;
+  periodPnl: OverseasStockInquiryPeriodPnlResponse;
+  periodPnlDetail: OverseasStockInquiryPeriodPnlDetailResponse;
+  margin: OverseasStockInquiryMarginResponse;
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/schemas/overseas-stock-order.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/schemas/overseas-stock-order.ts
@@ -1,0 +1,176 @@
+import { z } from 'zod';
+
+import type { CamelizeKeys } from '../../core/types';
+
+/**
+ * NH PLUG 해외주식(주문) 응답 스키마.
+ *
+ * 와이어 포맷은 snake_case 이며 (`Output_0`, `Output_1` … 블록 이름도 원문 그대로),
+ * 공개 API 는 `camelizeKeys` 로 자동 camelCase 변환한다 — 스키마는 와이어를 그대로 기술한다.
+ * 모든 블록·필드는 데이터가 있을 때만 내려오므로 전부 optional/nullable 이고,
+ * 스펙에 없는 실서버 필드가 살아남도록 모든 객체에 `.passthrough()` 를 건다.
+ */
+
+/** 스펙상 문자열 필드. 실서버가 숫자로 내려주는 경우가 있어 문자열로 강제 변환한다. */
+const str = () => z.coerce.string().nullish();
+
+/**
+ * 스펙상 숫자(`int`/`float`) 필드.
+ *
+ * 실서버는 숫자를 문자열로, 값 없는 숫자를 빈 문자열(`""`)로 내려주는 사례가 있어
+ * (파이썬 `_overseas_stock_quote_types` 의 `_empty_str_to_none` 참고)
+ * 빈 문자열은 null 로 접고 나머지는 숫자로 강제 변환한다.
+ */
+const num = () => z.preprocess((value) => (value === '' ? null : value), z.coerce.number().nullish()).nullish();
+
+/** 스펙상 `message` 봉투. 실서버는 null 을 내려주고 `rsp_cd`/`rsp_msg` 를 대신 쓴다. */
+const messageSchema = z
+  .object({
+    msg_code: str(),
+    usr_msg: str(),
+    msg_lv_code: str(),
+    dvlp_msg_yn: str(),
+  })
+  .passthrough();
+
+const envelope = {
+  /** 응답코드 (00000·XA102: 성공) */
+  rsp_cd: str(),
+  /** 응답메시지 */
+  rsp_msg: str(),
+  /** 스펙상 메시지 봉투 (실서버는 null) */
+  message: messageSchema.nullish(),
+};
+
+// ── 주문 접수 결과 (`Output_0`). 매수·매도·정정·취소 공통. ──
+
+export const overseasStockOrderOutputSchema = z
+  .object({
+    amn_tab_cd: str(), // 관리팀점코드
+    orr_no: num(), // 주문번호
+  })
+  .passthrough();
+
+/**
+ * 해외주식 주문매수 (`POST /gbstock/order/v1/buy`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체
+ */
+export const overseasStockOrderBuyResponseSchema = z
+  .object({
+    ...envelope,
+    /** 주문 접수 결과 */
+    Output_0: overseasStockOrderOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/**
+ * 해외주식 주문매도 (`POST /gbstock/order/v1/sell`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체
+ */
+export const overseasStockOrderSellResponseSchema = z
+  .object({
+    ...envelope,
+    /** 주문 접수 결과 */
+    Output_0: overseasStockOrderOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/**
+ * 해외주식 정정취소주문정정 (`POST /gbstock/order/v1/modify`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체
+ */
+export const overseasStockOrderModifyResponseSchema = z
+  .object({
+    ...envelope,
+    /** 주문 접수 결과 */
+    Output_0: overseasStockOrderOutputSchema.nullish(),
+  })
+  .passthrough();
+
+/**
+ * 해외주식 정정취소주문취소 (`POST /gbstock/order/v1/cancel`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체
+ */
+export const overseasStockOrderCancelResponseSchema = z
+  .object({
+    ...envelope,
+    /** 주문 접수 결과 */
+    Output_0: overseasStockOrderOutputSchema.nullish(),
+  })
+  .passthrough();
+
+// ── 예약주문접수 결과 (`Output_0`). ──
+
+export const overseasStockOrderReservedSubmitOutputSchema = z
+  .object({
+    bkg_rtn_orr_no: num(), // 예약접수주문번호
+  })
+  .passthrough();
+
+/**
+ * 해외주식 예약주문접수 (`POST /gbstock/order/v1/reservedSubmit`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체
+ */
+export const overseasStockOrderReservedSubmitResponseSchema = z
+  .object({
+    ...envelope,
+    /** 예약주문접수 결과 */
+    Output_0: overseasStockOrderReservedSubmitOutputSchema.nullish(),
+  })
+  .passthrough();
+
+// ── 예약주문접수취소 결과 (`Output_0`). ──
+
+export const overseasStockOrderReservedCancelOutputSchema = z
+  .object({
+    wrk_rlt_cd: str(), // 작업결과코드
+  })
+  .passthrough();
+
+/**
+ * 해외주식 예약주문접수취소 (`POST /gbstock/order/v1/reservedCancel`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체
+ */
+export const overseasStockOrderReservedCancelResponseSchema = z
+  .object({
+    ...envelope,
+    /** 예약주문접수취소 결과 */
+    Output_0: overseasStockOrderReservedCancelOutputSchema.nullish(),
+  })
+  .passthrough();
+
+// ── Response Types ──
+
+/** 해외주식 주문매수 (`POST /gbstock/order/v1/buy`) 응답. — `Output_0`: 객체 */
+export type OverseasStockOrderBuyResponse = CamelizeKeys<z.infer<typeof overseasStockOrderBuyResponseSchema>>;
+/** 해외주식 주문매도 (`POST /gbstock/order/v1/sell`) 응답. — `Output_0`: 객체 */
+export type OverseasStockOrderSellResponse = CamelizeKeys<z.infer<typeof overseasStockOrderSellResponseSchema>>;
+/** 해외주식 정정취소주문정정 (`POST /gbstock/order/v1/modify`) 응답. — `Output_0`: 객체 */
+export type OverseasStockOrderModifyResponse = CamelizeKeys<z.infer<typeof overseasStockOrderModifyResponseSchema>>;
+/** 해외주식 정정취소주문취소 (`POST /gbstock/order/v1/cancel`) 응답. — `Output_0`: 객체 */
+export type OverseasStockOrderCancelResponse = CamelizeKeys<z.infer<typeof overseasStockOrderCancelResponseSchema>>;
+/** 해외주식 예약주문접수 (`POST /gbstock/order/v1/reservedSubmit`) 응답. — `Output_0`: 객체 */
+export type OverseasStockOrderReservedSubmitResponse = CamelizeKeys<
+  z.infer<typeof overseasStockOrderReservedSubmitResponseSchema>
+>;
+/** 해외주식 예약주문접수취소 (`POST /gbstock/order/v1/reservedCancel`) 응답. — `Output_0`: 객체 */
+export type OverseasStockOrderReservedCancelResponse = CamelizeKeys<
+  z.infer<typeof overseasStockOrderReservedCancelResponseSchema>
+>;
+
+// ── Response Map ──
+
+export interface OverseasStockOrderResponseMap {
+  buy: OverseasStockOrderBuyResponse;
+  sell: OverseasStockOrderSellResponse;
+  modify: OverseasStockOrderModifyResponse;
+  cancel: OverseasStockOrderCancelResponse;
+  reservedSubmit: OverseasStockOrderReservedSubmitResponse;
+  reservedCancel: OverseasStockOrderReservedCancelResponse;
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/schemas/overseas-stock-quote.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/schemas/overseas-stock-quote.ts
@@ -1,0 +1,381 @@
+import { z } from 'zod';
+
+import type { CamelizeKeys } from '../../core/types';
+
+/**
+ * NH PLUG 해외주식(시세) 응답 스키마.
+ *
+ * 와이어 포맷은 snake_case 이며 (`Output_0`, `Output_1` … 블록 이름도 원문 그대로),
+ * 공개 API 는 `camelizeKeys` 로 자동 camelCase 변환한다 — 스키마는 와이어를 그대로 기술한다.
+ * 모든 블록·필드는 데이터가 있을 때만 내려오므로 전부 optional/nullable 이고,
+ * 스펙에 없는 실서버 필드가 살아남도록 모든 객체에 `.passthrough()` 를 건다.
+ */
+
+/** 스펙상 문자열 필드. 실서버가 숫자로 내려주는 경우가 있어 문자열로 강제 변환한다. */
+const str = () => z.coerce.string().nullish();
+
+/**
+ * 스펙상 숫자(`int`/`float`) 필드.
+ *
+ * 실서버는 숫자를 문자열로, 값 없는 숫자를 빈 문자열(`""`)로 내려주는 사례가 있어
+ * (파이썬 `_overseas_stock_quote_types` 의 `_empty_str_to_none` 참고)
+ * 빈 문자열은 null 로 접고 나머지는 숫자로 강제 변환한다.
+ */
+const num = () => z.preprocess((value) => (value === '' ? null : value), z.coerce.number().nullish()).nullish();
+
+/** 스펙상 `message` 봉투. 실서버는 null 을 내려주고 `rsp_cd`/`rsp_msg` 를 대신 쓴다. */
+const messageSchema = z
+  .object({
+    msg_code: str(),
+    usr_msg: str(),
+    msg_lv_code: str(),
+    dvlp_msg_yn: str(),
+  })
+  .passthrough();
+
+const envelope = {
+  /** 응답코드 (00000·XA102: 성공) */
+  rsp_cd: str(),
+  /** 응답메시지 */
+  rsp_msg: str(),
+  /** 스펙상 메시지 봉투 (실서버는 null) */
+  message: messageSchema.nullish(),
+};
+
+// ── 해외주식 현재가상세 조회 결과 (`Output_0`). ──
+
+export const overseasStockQuoteCurrentPriceOutputSchema = z
+  .object({
+    iem_cd: str(), // 종목코드
+    kor_name: str(), // 종목명 / 스펙상 필드 (실서버는 iem_nm 로 내려준다)
+    iem_nm: str(), // 종목명 / 실서버 실측 필드 (2026-08-22 운영 확인)
+    industry_code: str(), // 업종코드
+    industry_name: str(), // 업종명
+    trdprc: num(), // 현재가
+    netchng_cls: str(), // 전일대비구분 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)
+    netchng: num(), // 전일대비
+    pctchng: num(), // 전일대비율
+    open_prc: num(), // 시가
+    high: num(), // 고가
+    low: num(), // 저가
+    acvol: num(), // 거래량
+    uplimit: num(), // 상한가
+    uplimit_rate: num(), // 상한가비율
+    lolimit: num(), // 하한가
+    lolimit_rate: num(), // 하한가비율
+    w52high_prc: num(), // 52주최고가
+    w52highprc_netchng: num(), // 52주최고가대비
+    w52high_date: str(), // 52주최고일자
+    w52low_prc: num(), // 52주최저가
+    w52lowprc_netchng: num(), // 52주최저가대비
+    w52low_date: str(), // 52주최저일자
+    quote_time: str(), // 호가시간
+    best_ask1: num(), // 매도1호가
+    best_bid1: num(), // 매수1호가
+    best_asiz1: num(), // 매도1호가수량
+    best_bsiz1: num(), // 매수1호가수량
+    best_ask2: num(), // 매도2호가
+    best_bid2: num(), // 매수2호가
+    best_asiz2: num(), // 매도2호가수량
+    best_bsiz2: num(), // 매수2호가수량
+    best_ask3: num(), // 매도3호가
+    best_bid3: num(), // 매수3호가
+    best_asiz3: num(), // 매도3호가수량
+    best_bsiz3: num(), // 매수3호가수량
+    best_ask4: num(), // 매도4호가
+    best_bid4: num(), // 매수4호가
+    best_asiz4: num(), // 매도4호가수량
+    best_bsiz4: num(), // 매수4호가수량
+    best_ask5: num(), // 매도5호가
+    best_bid5: num(), // 매수5호가
+    best_asiz5: num(), // 매도5호가수량
+    best_bsiz5: num(), // 매수5호가수량
+    asksize: num(), // 총매도잔량
+    bidsize: num(), // 총매수잔량
+    cov_pric: num(), // 환산가
+    currency_prc: num(), // 환율
+    list_num: num(), // 발행주식수
+    list_amt: num(), // 시가총액
+    list_amt_2: num(), // 시가총액(원화)
+    turnover: num(), // 거래대금
+    currency_unit: str(), // 거래통화
+    hst_trdprc: num(), // 전일종가
+    capital_amt: num(), // 자본금
+    base_prc: num(), // 기준가
+    eps_date: str(), // EPS일자
+    eps_prc: num(), // EPS
+    per_prc: num(), // PER
+    trading_unit: num(), // 매매단위
+    hst_acvol: num(), // 전일거래량
+    trade_date: str(), // 거래일자
+    exch_id: str(), // 거래소ID
+    exch_name: str(), // 거래소명
+    com_kind: str(), // 자산구분코드
+    com_kind_name: str(), // 자산구분명
+    pf_jgubun: str(), // (PF)장구분
+    pf_trdprc: num(), // (PF)현재가
+    pf_netchng_cls: str(), // (PF)전일대비구분
+    pf_netchng: num(), // (PF)전일대비
+    pf_pctchng: num(), // (PF)전일대비율
+    best_ask6: num(), // 매도6호가
+    best_bid6: num(), // 매수6호가
+    best_asiz6: num(), // 매도6호가수량
+    best_bsiz6: num(), // 매수6호가수량
+    best_ask7: num(), // 매도7호가
+    best_bid7: num(), // 매수7호가
+    best_asiz7: num(), // 매도7호가수량
+    best_bsiz7: num(), // 매수7호가수량
+    best_ask8: num(), // 매도8호가
+    best_bid8: num(), // 매수8호가
+    best_asiz8: num(), // 매도8호가수량
+    best_bsiz8: num(), // 매수8호가수량
+    best_ask9: num(), // 매도9호가
+    best_bid9: num(), // 매수9호가
+    best_asiz9: num(), // 매도9호가수량
+    best_bsiz9: num(), // 매수9호가수량
+    best_ask10: num(), // 매도10호가
+    best_bid10: num(), // 매수10호가
+    best_asiz10: num(), // 매도10호가수량
+    best_bsiz10: num(), // 매수10호가수량
+    marketperiod_cls: str(), // 현재시장구분
+    normal_trdprc: num(), // 정규장종가
+    normal_netchng_cls: str(), // 정규장대비구분 / 2.상승 3.보합 5.하락
+    normal_netchng: num(), // 정규장전일대비
+    normal_pctchng: num(), // 정규장전일대비율
+    normal_acvol: num(), // 정규장누적거래량
+    normal_open_prc: num(), // 정규장시가
+    normal_high: num(), // 정규장고가
+    normal_low: num(), // 정규장저가
+  })
+  .passthrough();
+
+/**
+ * 해외주식 현재가상세 (`POST /gbstock/quote/v1/current`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체
+ */
+export const overseasStockQuoteCurrentPriceResponseSchema = z
+  .object({
+    ...envelope,
+    /** 해외주식 현재가상세 조회 결과 */
+    Output_0: overseasStockQuoteCurrentPriceOutputSchema.nullish(),
+  })
+  .passthrough();
+
+// ── 해외주식 체결추이 조회 결과 (`Output_0`) 항목. ──
+
+export const overseasStockQuoteExecutionTrendOutputSchema = z
+  .object({
+    iem_cd: str(), // 종목코드
+    trade_date: str(), // 체결일자 / YYYYMMDD
+    trade_time: str(), // 체결시간 / HHMMSS
+    trdprc: num(), // 체결가
+    netchng_cls: str(), // 전일대비구분 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)
+    netchng: num(), // 전일대비가
+    pctchng: num(), // 전일대비율
+    turnover: num(), // 거래대금
+    fill_size: num(), // 변동량
+    acvol: num(), // 체결량
+    open_prc: num(), // 시가
+    high: num(), // 고가
+    low: num(), // 저가
+    best_ask1: num(), // 매도1호가
+    best_bid1: num(), // 매수1호가
+    cont_rate: num(), // 당일체결강도
+    nextbutton: str(), // NEXTBUTTON
+    ctsz18: str(), // CTSz18
+  })
+  .passthrough();
+
+/**
+ * 해외주식 체결추이 (`POST /gbstock/quote/v1/executionTrend`) 응답.
+ *
+ * 응답 블록: `Output_0`: 배열
+ */
+export const overseasStockQuoteExecutionTrendResponseSchema = z
+  .object({
+    ...envelope,
+    /** 해외주식 체결추이 조회 결과 */
+    Output_0: z.array(overseasStockQuoteExecutionTrendOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── 해외주식 기간별시세(개별종목) 조회 결과 (`Output_0`) 항목. ──
+
+export const overseasStockQuotePeriodPriceOutputSchema = z
+  .object({
+    date: str(), // 조회날짜 / YYYYMMDD
+    time: str(), // 조회시간 / HHMMSS
+    iem_cd: str(), // 종목코드
+    kor_name: str(), // 종목명 / 스펙상 필드 (실서버는 iem_nm 로 내려준다)
+    iem_nm: str(), // 종목명 / 실서버 실측 필드 (2026-08-22 운영 확인)
+    trdprc: num(), // 현재가
+    netchng_cls: str(), // 등락부호 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)
+    netchng: num(), // 대비
+    pctchng: num(), // 대비율
+    acvol: num(), // 거래량
+    turnover: num(), // 거래대금
+    open_prc: num(), // 시가
+    high: num(), // 고가
+    low: num(), // 저가
+    per: num(), // PER
+    pbr: num(), // PBR
+    eps: num(), // EPS
+    list_num: num(), // 상장주수
+    list_amt: num(), // 시가총액
+    hst_open_prc: num(), // 전일시가
+    hst_high: num(), // 전일고가
+    hst_low: num(), // 전일저가
+    hst_trdprc: num(), // 전일종가
+    hst_acvol: num(), // 전일거래량
+    hst_acvol_rate: num(), // 전일거래량대비
+    best_ask: num(), // 매도호가
+    best_bid: num(), // 매수호가
+    week_open_prc: num(), // 이번주시가
+    week_high: num(), // 이번주고가
+    week_low: num(), // 이번주저가
+    mon_open_prc: num(), // 이번달시가
+    mon_high: num(), // 이번달고가
+    mon_low: num(), // 이번달저가
+    market_start_time: str(), // 장시작시간 / HHMMSS
+    market_end_time: str(), // 장마감시간 / HHMMSS
+    bsop_date: str(), // 영업일 / YYYYMMDD
+    fx_rate: num(), // 환율
+    trading_cls: str(), // 실시간구분
+    decimal: str(), // 소수점
+    base_prc: num(), // 기준가
+    ctsz16: str(), // 검색키
+    tick_cnt: str(), // 마지막틱봉갯수
+    count: str(), // 조회건수
+    marketperiod_cls: str(), // 현재시장구분
+    r_base_prc: num(), // 직전정규장기준가
+  })
+  .passthrough();
+
+// ── 해외주식 기간별시세(개별종목) 조회 결과 (`Output_1`) 항목. ──
+
+export const overseasStockQuotePeriodPriceVolumeOutputSchema = z
+  .object({
+    trade_date: str(), // 체결일자 / YYYYMMDD
+    trade_time: str(), // 체결시간 / HHmmSS
+    open_prc: num(), // 시가
+    high: num(), // 고가
+    low: num(), // 저가
+    close_prc: num(), // 종가
+    movolume: num(), // 변동거래량
+    movalue: num(), // 변동거래대금
+    netchng_cls: str(), // 등락부호 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)
+    bsop_date: str(), // 영업일 / YYYYMMDD
+  })
+  .passthrough();
+
+/**
+ * 해외주식 기간별시세(개별종목) (`POST /gbstock/quote/v1/period`) 응답.
+ *
+ * 응답 블록: `Output_0`: 배열, `Output_1`: 배열
+ */
+export const overseasStockQuotePeriodPriceResponseSchema = z
+  .object({
+    ...envelope,
+    /** 해외주식 기간별시세(개별종목) 조회 결과 */
+    Output_0: z.array(overseasStockQuotePeriodPriceOutputSchema).nullish(),
+    /** 해외주식 기간별시세(개별종목) 변동거래량 조회 결과 */
+    Output_1: z.array(overseasStockQuotePeriodPriceVolumeOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── 해외주식 기간별시세(지수·환율) 조회 결과 (`Output_0`). ──
+
+export const overseasStockQuoteSymbolIndexFxPeriodOutputSchema = z
+  .object({
+    qry_date: str(), // 조회날짜 / YYYYMMDD
+    qry_time: str(), // 조회시간 / HHMMSS
+    data_code: str(), // 해외종목타입
+    iem_cd: str(), // SYMBOL
+    hts_kor_isnm: str(), // 종목명 / 스펙상 필드 (실서버는 iem_nm 로 내려준다)
+    iem_nm: str(), // 종목명 / 실서버 실측 필드 (2026-08-22 운영 확인)
+    ovrs_prpr: num(), // 현재가
+    prdy_vrss_sign: str(), // 등락부호 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)
+    prdy_vrss: num(), // 대비
+    prdy_ctrt: num(), // 대비율
+    acml_vol: num(), // 거래량
+    acml_tr_pbmn: num(), // 거래대금
+    prdy_clpr: num(), // 전일종가
+    ovrs_oprc: num(), // 시가
+    ovrs_hgpr: num(), // 고가
+    ovrs_lwpr: num(), // 저가
+    prdy_oprc: num(), // 전일시가
+    prdy_hgpr: num(), // 전일고가
+    prdy_lwpr: num(), // 전일저가
+    prdy_prpr: num(), // 전일종가
+    tdw_ovrs_oprc: num(), // 이번주시가
+    tdw_ovrs_hgpr: num(), // 이번주고가
+    tdw_ovrs_lwpr: num(), // 이번주저가
+    tdm_ovrs_oprc: num(), // 이번달시가
+    tdm_ovrs_hgpr: num(), // 이번달고가
+    tdm_ovrs_lwpr: num(), // 이번달저가
+    localtime: str(), // 현지시간
+    bsop_date: str(), // 영업일
+    base_ptr: str(), // 소수점자리수
+    ctsz30: str(), // 이전키
+    lasttickcount: str(), // 마지막N틱봉의틱묶음갯수
+    send_cnt: str(), // 전송레코드건수
+  })
+  .passthrough();
+
+// ── 해외주식 기간별시세(지수·환율) 조회 결과 (`Output_1`) 항목. ──
+
+export const overseasStockQuoteSymbolIndexFxPeriodBarOutputSchema = z
+  .object({
+    bsop_date: str(), // 영업일
+    bsop_time: str(), // 시간 / HHmmSS
+    ovrs_oprc: num(), // 시가
+    ovrs_hgpr: num(), // 고가
+    ovrs_lwpr: num(), // 저가
+    ovrs_prpr: num(), // 현재가
+    vol: num(), // 거래량
+  })
+  .passthrough();
+
+/**
+ * 해외주식 기간별시세(지수·환율) (`POST /gbstock/quote/v1/symbolIndexFxPeriod`) 응답.
+ *
+ * 응답 블록: `Output_0`: 객체, `Output_1`: 배열
+ */
+export const overseasStockQuoteSymbolIndexFxPeriodResponseSchema = z
+  .object({
+    ...envelope,
+    /** 해외주식 기간별시세(지수·환율) 조회 결과 */
+    Output_0: overseasStockQuoteSymbolIndexFxPeriodOutputSchema.nullish(),
+    /** 해외주식 기간별시세(지수·환율) 시세 목록 */
+    Output_1: z.array(overseasStockQuoteSymbolIndexFxPeriodBarOutputSchema).nullish(),
+  })
+  .passthrough();
+
+// ── Response Types ──
+
+/** 해외주식 현재가상세 (`POST /gbstock/quote/v1/current`) 응답. — `Output_0`: 객체 */
+export type OverseasStockQuoteCurrentPriceResponse = CamelizeKeys<
+  z.infer<typeof overseasStockQuoteCurrentPriceResponseSchema>
+>;
+/** 해외주식 체결추이 (`POST /gbstock/quote/v1/executionTrend`) 응답. — `Output_0`: 배열 */
+export type OverseasStockQuoteExecutionTrendResponse = CamelizeKeys<
+  z.infer<typeof overseasStockQuoteExecutionTrendResponseSchema>
+>;
+/** 해외주식 기간별시세(개별종목) (`POST /gbstock/quote/v1/period`) 응답. — `Output_0`: 배열, `Output_1`: 배열 */
+export type OverseasStockQuotePeriodPriceResponse = CamelizeKeys<
+  z.infer<typeof overseasStockQuotePeriodPriceResponseSchema>
+>;
+/** 해외주식 기간별시세(지수·환율) (`POST /gbstock/quote/v1/symbolIndexFxPeriod`) 응답. — `Output_0`: 객체, `Output_1`: 배열 */
+export type OverseasStockQuoteSymbolIndexFxPeriodResponse = CamelizeKeys<
+  z.infer<typeof overseasStockQuoteSymbolIndexFxPeriodResponseSchema>
+>;
+
+// ── Response Map ──
+
+export interface OverseasStockQuoteResponseMap {
+  current: OverseasStockQuoteCurrentPriceResponse;
+  executionTrend: OverseasStockQuoteExecutionTrendResponse;
+  period: OverseasStockQuotePeriodPriceResponse;
+  symbolIndexFxPeriod: OverseasStockQuoteSymbolIndexFxPeriodResponse;
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/schemas/overseas-stock-quote.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/schemas/overseas-stock-quote.ts
@@ -52,7 +52,7 @@ export const overseasStockQuoteCurrentPriceOutputSchema = z
     industry_code: str(), // 업종코드
     industry_name: str(), // 업종명
     trdprc: num(), // 현재가
-    netchng_cls: str(), // 전일대비구분 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)
+    netchng_cls: str(), // 전일대비구분 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)
     netchng: num(), // 전일대비
     pctchng: num(), // 전일대비율
     open_prc: num(), // 시가
@@ -170,7 +170,7 @@ export const overseasStockQuoteExecutionTrendOutputSchema = z
     trade_date: str(), // 체결일자 / YYYYMMDD
     trade_time: str(), // 체결시간 / HHMMSS
     trdprc: num(), // 체결가
-    netchng_cls: str(), // 전일대비구분 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)
+    netchng_cls: str(), // 전일대비구분 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)
     netchng: num(), // 전일대비가
     pctchng: num(), // 전일대비율
     turnover: num(), // 거래대금
@@ -210,7 +210,7 @@ export const overseasStockQuotePeriodPriceOutputSchema = z
     kor_name: str(), // 종목명 / 스펙상 필드 (실서버는 iem_nm 로 내려준다)
     iem_nm: str(), // 종목명 / 실서버 실측 필드 (2026-08-22 운영 확인)
     trdprc: num(), // 현재가
-    netchng_cls: str(), // 등락부호 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)
+    netchng_cls: str(), // 등락부호 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)
     netchng: num(), // 대비
     pctchng: num(), // 대비율
     acvol: num(), // 거래량
@@ -264,7 +264,7 @@ export const overseasStockQuotePeriodPriceVolumeOutputSchema = z
     close_prc: num(), // 종가
     movolume: num(), // 변동거래량
     movalue: num(), // 변동거래대금
-    netchng_cls: str(), // 등락부호 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)
+    netchng_cls: str(), // 등락부호 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)
     bsop_date: str(), // 영업일 / YYYYMMDD
   })
   .passthrough();
@@ -295,7 +295,7 @@ export const overseasStockQuoteSymbolIndexFxPeriodOutputSchema = z
     hts_kor_isnm: str(), // 종목명 / 스펙상 필드 (실서버는 iem_nm 로 내려준다)
     iem_nm: str(), // 종목명 / 실서버 실측 필드 (2026-08-22 운영 확인)
     ovrs_prpr: num(), // 현재가
-    prdy_vrss_sign: str(), // 등락부호 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)
+    prdy_vrss_sign: str(), // 등락부호 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)
     prdy_vrss: num(), // 대비
     prdy_ctrt: num(), // 대비율
     acml_vol: num(), // 거래량

--- a/packages/cluefin-openapi-ts/src/nhplug/socket-client.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/socket-client.ts
@@ -1,0 +1,128 @@
+import type { ApiEnv } from '../core/types';
+import { BaseWebSocketClient, type SubscriptionType, type WebSocketMessage } from '../core/websocket';
+
+/**
+ * WebSocket URLs (정본은 각 자산군 openapi.json 의 `x-environments`).
+ *
+ * 운영은 국내(7070)/해외(7080) 주소가 갈리고, 모의투자는 단일 주소(17070)다.
+ */
+const WS_URL_PROD_KR = 'wss://api.nhplug.com:7070';
+const WS_URL_PROD_GB = 'wss://api.nhplug.com:7080';
+const WS_URL_DEV = 'wss://moapi.nhplug.com:17070';
+
+/** 접속 대상 시장. `kr` = 국내, `gb` = 해외(운영 전용 주소). */
+export type NhplugMarket = 'kr' | 'gb';
+
+export interface NhplugSocketClientOptions {
+  /** REST 와 동일한 access token (`NhplugAuth.generate()`). */
+  token: string;
+  /** prod = 운영, dev = 모의투자(moapi). 기본값은 `NhplugClient` 와 같은 `dev`. */
+  env?: ApiEnv;
+  /** 운영에서만 의미가 있다. 모의투자는 국내/해외가 같은 주소를 쓴다. */
+  market?: NhplugMarket;
+  rateLimitRequestsPerSecond?: number;
+  rateLimitBurst?: number;
+}
+
+export const getNhplugSocketUrl = (env: ApiEnv, market: NhplugMarket): string => {
+  if (env !== 'prod') {
+    return WS_URL_DEV;
+  }
+  return market === 'gb' ? WS_URL_PROD_GB : WS_URL_PROD_KR;
+};
+
+/**
+ * NH PLUG 실시간 시세 WebSocket 클라이언트.
+ *
+ * 인증은 REST 와 달리 구독 메시지 `header.token` 에 access token 만 실어 보낸다
+ * (approval key 없음). 서버 푸시는 평문 JSON
+ * `{"header": {"tr_cd", "tr_key"}, "body": {…}}` 이며 heartbeat 응답이 필요 없다.
+ *
+ * `subscribe`/`unsubscribe` 의 첫 인자는 REST 경로가 아니라 웹소켓 전용 채널 코드
+ * (`tr_cd`) 다 — 국내 통합시세 체결가는 `mc`, 해외는 실시간 `RC` / 지연 `rc` 처럼
+ * 대소문자로 갈린다. 정본은 각 자산군 openapi.json 의 `x-realtime-channels[].tr_cd`.
+ */
+export class NhplugSocketClient extends BaseWebSocketClient {
+  public readonly env: ApiEnv;
+  public readonly market: NhplugMarket;
+  private readonly token: string;
+
+  public constructor(options: NhplugSocketClientOptions) {
+    const env = options.env ?? 'dev';
+    const market = options.market ?? 'kr';
+    super({
+      url: getNhplugSocketUrl(env, market),
+      rateLimitBurst: options.rateLimitBurst ?? 3,
+      rateLimitRequestsPerSecond: options.rateLimitRequestsPerSecond ?? 5,
+    });
+    this.env = env;
+    this.market = market;
+    this.token = options.token;
+  }
+
+  protected override buildSubscriptionMessage(trCd: string, trKey: string, trType: SubscriptionType): string {
+    return JSON.stringify({
+      header: {
+        token: this.token,
+        tr_type: trType,
+      },
+      body: {
+        tr_cd: trCd,
+        tr_key: trKey,
+      },
+    });
+  }
+
+  /**
+   * 평문 JSON 푸시를 파싱한다. KIS 의 `0|TR|001|a^b` 파이프 포맷과 다르므로 전면 대체한다.
+   * `tr_cd` 가 없는 메시지(구독 응답 등)는 SYSTEM 으로 본다.
+   */
+  public override parseMessage(raw: string): WebSocketMessage {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return { messageType: 'SYSTEM', raw, encrypted: false };
+    }
+
+    if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+      return { messageType: 'SYSTEM', raw, encrypted: false };
+    }
+
+    const envelope = parsed as { header?: unknown; body?: unknown };
+    const header =
+      typeof envelope.header === 'object' && envelope.header !== null
+        ? (envelope.header as Record<string, unknown>)
+        : {};
+    const trCd = typeof header.tr_cd === 'string' ? header.tr_cd : undefined;
+    const trKey = typeof header.tr_key === 'string' ? header.tr_key : undefined;
+    const body =
+      typeof envelope.body === 'object' && envelope.body !== null && !Array.isArray(envelope.body)
+        ? (envelope.body as Record<string, unknown>)
+        : undefined;
+
+    if (trCd === undefined) {
+      return { messageType: 'SYSTEM', raw, encrypted: false };
+    }
+
+    return { messageType: 'DATA', trId: trCd, trKey, body, raw, encrypted: false };
+  }
+
+  protected override handleMessage(raw: string): void {
+    const message = this.parseMessage(raw);
+
+    if (message.messageType === 'DATA' && message.trId !== undefined) {
+      this.emitEvent({
+        eventType: 'data',
+        trId: message.trId,
+        ...(message.trKey !== undefined ? { trKey: message.trKey } : {}),
+        ...(message.body !== undefined ? { body: message.body } : {}),
+        raw,
+      });
+      return;
+    }
+
+    // 구독 응답 등 tr_cd 없는 시스템성 메시지
+    this.emitEvent({ eventType: 'system', raw });
+  }
+}

--- a/packages/cluefin-openapi-ts/src/nhplug/token-cache.ts
+++ b/packages/cluefin-openapi-ts/src/nhplug/token-cache.ts
@@ -1,0 +1,107 @@
+import { createHash } from 'node:crypto';
+
+export interface TokenCacheEntry {
+  accessToken: string;
+  scope: string;
+  tokenType: string;
+  expiresIn: number;
+  cachedAt: string;
+}
+
+export interface TokenCacheStore {
+  get(): Promise<TokenCacheEntry | null>;
+  set(entry: TokenCacheEntry): Promise<void>;
+  clear(): Promise<void>;
+}
+
+/**
+ * Build the credential-scoped cache file name used by the Python TokenManager.
+ *
+ * NH PLUG 토큰은 운영 도메인에서만 발급되고 운영·모의투자 호출에 공유되므로
+ * 캐시는 env 가 아니라 app_key 로만 구분한다 (`_token_manager._cache_file_name`).
+ */
+export const nhplugTokenCacheFileName = (appKey?: string): string => {
+  const suffix = appKey ? `_${createHash('sha256').update(appKey, 'utf-8').digest('hex').slice(0, 8)}` : '';
+  return `.nhplug_token_cache${suffix}.json`;
+};
+
+export class MemoryTokenCacheStore implements TokenCacheStore {
+  private cache: TokenCacheEntry | null = null;
+
+  public async get(): Promise<TokenCacheEntry | null> {
+    return this.cache;
+  }
+
+  public async set(entry: TokenCacheEntry): Promise<void> {
+    this.cache = entry;
+  }
+
+  public async clear(): Promise<void> {
+    this.cache = null;
+  }
+}
+
+/**
+ * File-based token cache store compatible with the Python TokenManager.
+ *
+ * `cluefin_openapi.nhplug._token_manager` 와 동일한 JSON 포맷(snake_case)을 읽고 쓴다.
+ * 토큰 응답에는 절대 만료시각 필드가 없으므로, 만료는 `cached_at + expires_in` 으로
+ * 계산한다 — 파이썬과 TS 가 같은 캐시 파일을 공유할 수 있도록 포맷을 바꾸지 말 것.
+ */
+export class FileTokenCacheStore implements TokenCacheStore {
+  private readonly filePath: string;
+
+  public constructor(filePath: string) {
+    this.filePath = filePath;
+  }
+
+  public async get(): Promise<TokenCacheEntry | null> {
+    try {
+      const fs = await import('node:fs/promises');
+      const raw = await fs.readFile(this.filePath, 'utf-8');
+      const data = JSON.parse(raw) as {
+        token?: {
+          access_token?: string;
+          scope?: string;
+          token_type?: string;
+          expires_in?: number;
+        };
+        cached_at?: string;
+      };
+      const t = data.token;
+      if (!t?.access_token) return null;
+      return {
+        accessToken: t.access_token,
+        scope: t.scope ?? 'oob',
+        tokenType: t.token_type ?? 'Bearer',
+        expiresIn: Number(t.expires_in ?? 86400),
+        cachedAt: data.cached_at ?? new Date().toISOString(),
+      };
+    } catch {
+      return null;
+    }
+  }
+
+  public async set(entry: TokenCacheEntry): Promise<void> {
+    const fs = await import('node:fs/promises');
+    const data = {
+      token: {
+        access_token: entry.accessToken,
+        scope: entry.scope,
+        token_type: entry.tokenType,
+        expires_in: entry.expiresIn,
+      },
+      cached_at: entry.cachedAt,
+    };
+    await fs.writeFile(this.filePath, JSON.stringify(data, null, 2), 'utf-8');
+  }
+
+  public async clear(): Promise<void> {
+    try {
+      const fs = await import('node:fs/promises');
+      await fs.unlink(this.filePath);
+    } catch {
+      // Ignore if file doesn't exist
+    }
+  }
+}

--- a/packages/cluefin-openapi-ts/tests/_helpers/integration-setup.ts
+++ b/packages/cluefin-openapi-ts/tests/_helpers/integration-setup.ts
@@ -1,19 +1,40 @@
+import { mkdirSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import { beforeEach, expect } from 'vitest';
 import type { z } from 'zod';
 import { toCamelCase } from '../../src/core/case-convert';
-import type { ApiResponse } from '../../src/core/types';
+import { ApiError } from '../../src/core/errors';
+import type { ApiEnv, ApiResponse } from '../../src/core/types';
 import { KisAuth } from '../../src/kis/auth';
 import { KisHttpClient } from '../../src/kis/http-client';
 import { FileTokenCacheStore } from '../../src/kis/token-cache';
 import { KiwoomAuth } from '../../src/kiwoom/auth';
 import { KiwoomClient } from '../../src/kiwoom/client';
+import { NhplugAuth } from '../../src/nhplug/auth';
+import { NhplugClient, SUCCESS_RSP_CODES } from '../../src/nhplug/client';
+import {
+  FileTokenCacheStore as NhplugFileTokenCacheStore,
+  nhplugTokenCacheFileName,
+} from '../../src/nhplug/token-cache';
 
 export const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 export function setupKiwoomRateLimit(): void {
   beforeEach(async () => {
     await sleep(500);
+  });
+}
+
+/**
+ * NH PLUG 통합 테스트용 호출 간격.
+ *
+ * 클라이언트 내부 rate limiter 만으로는 실서버 스로틀을 못 피한다 —
+ * 파이썬 통합 스위트와 동일하게 테스트마다 1초를 쉰다.
+ */
+export function setupNhplugRateLimit(): void {
+  beforeEach(async () => {
+    await sleep(1000);
   });
 }
 
@@ -119,4 +140,177 @@ export function assertResponseShape(
       expect(actualItemKeys).toEqual(expectedItemKeys);
     }
   }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// NH PLUG (nhplug)
+// ────────────────────────────────────────────────────────────────────────────
+
+/** 테스트가 붙을 NH PLUG 환경. dev = 모의투자(moapi), prod = 운영(실제 체결). */
+export const NHPLUG_ENV: ApiEnv = process.env.NHPLUG_ENV?.toLowerCase() === 'prod' ? 'prod' : 'dev';
+
+/** 자격증명이 없으면 통합 테스트를 조용히 건너뛴다 (KIS_CANO 게이팅과 같은 방식). */
+export const runNhplugIntegration = runIntegration && !!process.env.NHPLUG_APP_KEY && !!process.env.NHPLUG_SECRET_KEY;
+
+/**
+ * 모의투자(moapi)에서 제공되지 않는 API 용 게이트.
+ *
+ * 파이썬 `_integration_helpers.real_account_only` 와 같은 의미다 — 운영
+ * (`NHPLUG_ENV=prod`)에서만 실행된다.
+ */
+export const runNhplugLiveOnlyIntegration = runNhplugIntegration && NHPLUG_ENV === 'prod';
+
+/** 계좌번호를 직접 지정하고 싶을 때 쓰는 선택적 오버라이드. 없으면 `/n2/acctinfo` 로 찾는다. */
+export const NHPLUG_ACCOUNT_NO = process.env.NHPLUG_ACCOUNT_NO ?? '';
+
+export const NHPLUG_TEST_IEM_CD = '005930'; // 삼성전자
+export const NHPLUG_TEST_ETF_IEM_CD = '069500'; // KODEX 200
+export const NHPLUG_TEST_GB_IEM_CD = 'AAPL'; // 애플
+export const NHPLUG_TEST_GB_SYMBOL_CD = 'SPX'; // S&P 500 지수
+export const NHPLUG_US_NATION_CD = '200'; // 미국
+
+/**
+ * 장 운영시간·영업일·계좌 상태 때문에 "지금은" 검증할 수 없다는 뜻의 rsp_cd.
+ * 파이썬 `_integration_helpers.ENV_BLOCKED_CODES` 와 같은 값을 유지할 것.
+ */
+const NHPLUG_ENV_BLOCKED_CODES: readonly string[] = [
+  '14100', // 모의투자 영업일이 아닙니다 (2026-08-22 실측)
+];
+
+/**
+ * NH PLUG 클라이언트 (프로세스당 1개, 토큰은 파일 캐시 재사용).
+ *
+ * 토큰 발급은 서버에서 초당 1회로 제한되고 불필요한 재발급마다 계좌 보안 알림이
+ * 뜬다. 파이썬 `TokenManager` 와 같은 캐시 파일(tmpdir/cluefin-openapi/
+ * `.nhplug_token_cache_<app_key 해시>.json`)을 공유해 실제 발급은 만료 전까지 1회다.
+ * 캐시는 env 가 아니라 app_key 로만 구분한다 — 토큰 하나가 운영·모의투자 모두에 쓰인다.
+ */
+export function getNhplugClient(): Promise<NhplugClient> {
+  if (!g.__nhplugClientPromise) {
+    g.__nhplugClientPromise = (async () => {
+      const appKey = process.env.NHPLUG_APP_KEY;
+      const secretKey = process.env.NHPLUG_SECRET_KEY;
+      if (!appKey || !secretKey) {
+        throw new Error('NHPLUG_APP_KEY and NHPLUG_SECRET_KEY are required');
+      }
+      const cacheDir = process.env.NHPLUG_TOKEN_CACHE_DIR ?? path.join(os.tmpdir(), 'cluefin-openapi');
+      mkdirSync(cacheDir, { recursive: true });
+      const tokenCacheStore = new NhplugFileTokenCacheStore(path.join(cacheDir, nhplugTokenCacheFileName(appKey)));
+      const auth = new NhplugAuth({ appKey, secretKey, tokenCacheStore });
+      const tokenResponse = await auth.generate();
+      return new NhplugClient({
+        token: tokenResponse.accessToken,
+        appKey,
+        secretKey,
+        env: NHPLUG_ENV,
+      });
+    })();
+  }
+  return g.__nhplugClientPromise as Promise<NhplugClient>;
+}
+
+/**
+ * 호출 환경과 `acct_type` 이 맞는 계좌번호를 `/n2/acctinfo` 에서 한 번만 찾아 캐시한다.
+ *
+ * 모의투자(dev)는 03 계좌만, 운영(prod)은 01·02 계좌만 유효하다 (krstock·gbstock 공통).
+ * 같은 계좌번호가 여러 행으로 내려올 수 있어 첫 매칭을 쓴다.
+ */
+export function getNhplugAccount(): Promise<string | null> {
+  if (!g.__nhplugAccountPromise) {
+    g.__nhplugAccountPromise = (async () => {
+      if (NHPLUG_ACCOUNT_NO) {
+        return NHPLUG_ACCOUNT_NO;
+      }
+      const client = await getNhplugClient();
+      const res = await client.common.getAccountList({});
+      const accounts = res.body.output0 ?? [];
+      const wanted = NHPLUG_ENV === 'dev' ? ['03'] : ['01', '02'];
+      const matched = accounts.find((account) => wanted.includes(account.acctType));
+      return matched?.acctNo ?? null;
+    })();
+  }
+  return g.__nhplugAccountPromise as Promise<string | null>;
+}
+
+/** vitest TestContext 중 이 헬퍼가 쓰는 부분만 추린 타입. */
+export interface SkippableContext {
+  skip: (note?: string) => never;
+}
+
+/** 계좌가 없으면 실패가 아니라 skip 한다 (KIS 의 KIS_CANO 게이팅과 같은 취지). */
+export async function requireNhplugAccount(ctx: SkippableContext): Promise<string> {
+  const account = await getNhplugAccount();
+  if (!account) {
+    const wanted = NHPLUG_ENV === 'dev' ? '03' : '01/02';
+    ctx.skip(`${NHPLUG_ENV} 환경에 맞는 계좌(acct_type ${wanted})가 없다`);
+  }
+  return account;
+}
+
+const nhplugRspCode = (error: unknown): { rspCd: string; rspMsg: string } => {
+  if (!(error instanceof ApiError)) {
+    return { rspCd: '', rspMsg: error instanceof Error ? error.message : String(error) };
+  }
+  const data = (error.responseData ?? {}) as { rsp_cd?: string; rsp_msg?: string };
+  return {
+    rspCd: data.rsp_cd ?? (typeof error.errorCode === 'string' ? error.errorCode : ''),
+    rspMsg: data.rsp_msg ?? error.message,
+  };
+};
+
+/**
+ * 환경 제약(영업일·장 운영시간·계좌 상태)이면 skip, 그 외 오류는 그대로 실패로 남긴다.
+ *
+ * 파이썬 `skip_if_env_blocked` 와 같은 역할이다. 조건이 풀리면 코드 수정 없이
+ * 실제 검증이 재개된다.
+ */
+export async function callNhplug<T>(
+  ctx: SkippableContext,
+  request: () => Promise<ApiResponse<T>>,
+): Promise<ApiResponse<T>> {
+  try {
+    return await request();
+  } catch (error) {
+    const { rspCd, rspMsg } = nhplugRspCode(error);
+    if (NHPLUG_ENV_BLOCKED_CODES.includes(rspCd) || NHPLUG_ENV_BLOCKED_CODES.some((code) => rspMsg.includes(code))) {
+      ctx.skip(`장 운영시간/계좌 상태 때문에 검증 불가: [${rspCd}] ${rspMsg}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * NH PLUG 응답 봉투 검증.
+ *
+ * 성공 코드는 `00000` 과 모의투자 조회 성공인 `XA102` 두 가지다 — `00000` 만
+ * 성공으로 보면 모의 서버의 정상 응답이 오탐된다.
+ */
+export function assertNhplugResponse(res: ApiResponse<unknown>): void {
+  expect(res).toBeDefined();
+  expect(res.body).toBeDefined();
+  const body = res.body as { rspCd?: string; rspMsg?: string };
+  // 일부 응답(`/n2/acctinfo` 등)은 `rsp_cd` 없이 내려온다. 실패 코드는 클라이언트가
+  // 이미 NhplugApiError 로 올리므로, 코드가 있을 때만 성공 코드인지 확인한다.
+  if (body.rspCd === undefined) {
+    expect(typeof res.body).toBe('object');
+    return;
+  }
+  if (!SUCCESS_RSP_CODES.includes(body.rspCd)) {
+    console.error('NH PLUG Error Response:', JSON.stringify(res.body, null, 2));
+  }
+  expect(SUCCESS_RSP_CODES).toContain(body.rspCd);
+}
+
+/**
+ * 응답 본문에 스키마에 없는 키가 섞이지 않았는지 확인한다.
+ *
+ * `Output_N` 블록은 데이터가 있을 때만 내려오므로(스펙 설명) 키 집합 완전 일치가 아니라
+ * "실제 키 ⊆ 스키마 키" 부분집합으로 검증한다. 스키마에 없는 필드가 새로 내려오면
+ * (= 모델 갱신이 필요하면) 실패한다.
+ */
+export function assertNhplugResponseShape(body: unknown, responseSchema: z.ZodObject<z.ZodRawShape>): void {
+  const expectedKeys = new Set(Object.keys(responseSchema.shape).map(toCamelCase));
+  const actualKeys = Object.keys(body as Record<string, unknown>);
+  const unexpected = actualKeys.filter((key) => !expectedKeys.has(key)).sort();
+  expect(unexpected).toEqual([]);
 }

--- a/packages/cluefin-openapi-ts/tests/barrel-exports.test.ts
+++ b/packages/cluefin-openapi-ts/tests/barrel-exports.test.ts
@@ -9,8 +9,13 @@ import { FileTokenCacheStore, MemoryTokenCacheStore } from '../src/kis/token-cac
 import * as Kiwoom from '../src/kiwoom';
 import { KiwoomAuth } from '../src/kiwoom/auth';
 import { KiwoomClient } from '../src/kiwoom/client';
+import * as Nhplug from '../src/nhplug';
+import { NhplugAuth } from '../src/nhplug/auth';
+import { NhplugClient } from '../src/nhplug/client';
+import { NhplugDomainBase } from '../src/nhplug/domain-base';
+import { FileTokenCacheStore as NhplugFileTokenCacheStore } from '../src/nhplug/token-cache';
 
-test('root barrel exposes runtime exports from core, KIS, and Kiwoom modules', () => {
+test('root barrel exposes runtime exports from core, KIS, Kiwoom, and NH PLUG modules', () => {
   expect(Root.BaseWebSocketClient).toBe(BaseWebSocketClient);
 
   expect(Root.KisAuth).toBe(KisAuth);
@@ -26,4 +31,14 @@ test('root barrel exposes runtime exports from core, KIS, and Kiwoom modules', (
   expect(Root.KiwoomAuth).toBe(Kiwoom.KiwoomAuth);
   expect(Root.KiwoomClient).toBe(KiwoomClient);
   expect(Root.KiwoomClient).toBe(Kiwoom.KiwoomClient);
+
+  expect(Root.NhplugAuth).toBe(NhplugAuth);
+  expect(Root.NhplugAuth).toBe(Nhplug.NhplugAuth);
+  expect(Root.NhplugClient).toBe(NhplugClient);
+  expect(Root.NhplugClient).toBe(Nhplug.NhplugClient);
+  expect(Root.NhplugDomainBase).toBe(NhplugDomainBase);
+  // NH PLUG 토큰 캐시는 KIS 와 이름이 겹쳐 Nhplug 접두사로 재수출한다.
+  expect(Root.NhplugFileTokenCacheStore).toBe(NhplugFileTokenCacheStore);
+  expect(Root.NhplugFileTokenCacheStore).not.toBe(FileTokenCacheStore);
+  expect(Root.NHPLUG_SUCCESS_RSP_CODES).toEqual(['00000', 'XA102']);
 });

--- a/packages/cluefin-openapi-ts/tests/nhplug/auth.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/auth.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import { NhplugApiError, NhplugAuthenticationError, NhplugValidationError } from '../../src/core/errors';
+import { NhplugAuth } from '../../src/nhplug/auth';
+import { MemoryTokenCacheStore, type TokenCacheEntry } from '../../src/nhplug/token-cache';
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+const createFetchMock = (responses: Response[]): { calls: FetchCall[]; fetchMock: typeof fetch } => {
+  const calls: FetchCall[] = [];
+  const fetchMock: typeof fetch = async (input, init) => {
+    calls.push({ url: String(input), init: init ?? {} });
+    const next = responses.shift();
+    if (!next) {
+      throw new Error('Unexpected extra fetch call');
+    }
+    return next;
+  };
+  return { calls, fetchMock };
+};
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } });
+
+const tokenBody = {
+  access_token: 'token-value',
+  scope: 'oob',
+  token_type: 'Bearer',
+  expires_in: 86400,
+};
+
+describe('NhplugAuth.generate', () => {
+  it('issues a form-encoded token request against the prod domain only', async () => {
+    const { calls, fetchMock } = createFetchMock([jsonResponse(tokenBody)]);
+    const auth = new NhplugAuth({ appKey: 'app-key', secretKey: 'secret-key', fetchImpl: fetchMock });
+
+    await expect(auth.generate()).resolves.toEqual({
+      accessToken: 'token-value',
+      scope: 'oob',
+      tokenType: 'Bearer',
+      expiresIn: 86_400,
+    });
+
+    expect(calls[0]?.url).toBe('https://api.nhplug.com:8443/oauth2/token');
+    expect(calls[0]?.init.method).toBe('POST');
+    expect(calls[0]?.init.headers).toEqual({ 'Content-Type': 'application/x-www-form-urlencoded' });
+    expect(Object.fromEntries(new URLSearchParams(String(calls[0]?.init.body)))).toEqual({
+      appkey: 'app-key',
+      appsecretkey: 'secret-key',
+      grant_type: 'client_credentials',
+      scope: 'oob',
+    });
+  });
+
+  it('reuses a valid cached token instead of re-issuing', async () => {
+    const store = new MemoryTokenCacheStore();
+    await store.set({
+      accessToken: 'cached-token',
+      scope: 'oob',
+      tokenType: 'Bearer',
+      expiresIn: 86_400,
+      cachedAt: new Date().toISOString(),
+    });
+    const { calls, fetchMock } = createFetchMock([]);
+    const auth = new NhplugAuth({
+      appKey: 'app-key',
+      secretKey: 'secret-key',
+      tokenCacheStore: store,
+      fetchImpl: fetchMock,
+    });
+
+    await expect(auth.generate()).resolves.toMatchObject({ accessToken: 'cached-token' });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('re-issues when the cached token is inside the 1h expiry buffer', async () => {
+    const store = new MemoryTokenCacheStore();
+    const expiring: TokenCacheEntry = {
+      accessToken: 'cached-token',
+      scope: 'oob',
+      tokenType: 'Bearer',
+      expiresIn: 86_400,
+      // 발급 후 23시간 30분 경과 → 남은 유효시간이 버퍼(1h) 미만
+      cachedAt: new Date(Date.now() - (86_400 - 1_800) * 1000).toISOString(),
+    };
+    await store.set(expiring);
+    const { calls, fetchMock } = createFetchMock([jsonResponse(tokenBody)]);
+    const auth = new NhplugAuth({
+      appKey: 'app-key',
+      secretKey: 'secret-key',
+      tokenCacheStore: store,
+      fetchImpl: fetchMock,
+    });
+
+    await expect(auth.generate()).resolves.toMatchObject({ accessToken: 'token-value' });
+    expect(calls).toHaveLength(1);
+    expect((await store.get())?.accessToken).toBe('token-value');
+  });
+
+  it('maps token error statuses onto the Nhplug error family', async () => {
+    const build = (status: number): NhplugAuth =>
+      new NhplugAuth({
+        appKey: 'a',
+        secretKey: 's',
+        fetchImpl: createFetchMock([jsonResponse({}, status)]).fetchMock,
+      });
+
+    await expect(build(400).generate()).rejects.toBeInstanceOf(NhplugValidationError);
+    await expect(build(401).generate()).rejects.toBeInstanceOf(NhplugAuthenticationError);
+  });
+});
+
+describe('NhplugAuth.revoke', () => {
+  it('revokes the cached token and clears the cache', async () => {
+    const store = new MemoryTokenCacheStore();
+    const { calls, fetchMock } = createFetchMock([jsonResponse(tokenBody), jsonResponse({ code: 200, message: 'OK' })]);
+    const auth = new NhplugAuth({
+      appKey: 'app-key',
+      secretKey: 'secret-key',
+      tokenCacheStore: store,
+      fetchImpl: fetchMock,
+    });
+
+    await auth.generate();
+    await expect(auth.revoke()).resolves.toEqual({
+      code: 200,
+      message: 'OK',
+      errorCode: undefined,
+      errorDescription: undefined,
+    });
+
+    expect(calls[1]?.url).toBe('https://api.nhplug.com:8443/oauth2/revoke');
+    expect(Object.fromEntries(new URLSearchParams(String(calls[1]?.init.body)))).toEqual({
+      token: 'token-value',
+      token_type_hint: 'access_token',
+      appkey: 'app-key',
+      appsecretkey: 'secret-key',
+    });
+    expect(await store.get()).toBeNull();
+  });
+
+  it('throws when there is no token to revoke', async () => {
+    const auth = new NhplugAuth({ appKey: 'a', secretKey: 's', fetchImpl: createFetchMock([]).fetchMock });
+
+    await expect(auth.revoke()).rejects.toBeInstanceOf(NhplugApiError);
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/client-domains.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/client-domains.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, test } from 'vitest';
+
+import { NhplugClient } from '../../src/nhplug/client';
+import { commonEndpoints } from '../../src/nhplug/metadata/common';
+import { krstockInquiryEndpoints } from '../../src/nhplug/metadata/krstock-inquiry';
+import { krstockOrderEndpoints } from '../../src/nhplug/metadata/krstock-order';
+import { krstockQuoteEndpoints } from '../../src/nhplug/metadata/krstock-quote';
+import { overseasStockInquiryEndpoints } from '../../src/nhplug/metadata/overseas-stock-inquiry';
+import { overseasStockOrderEndpoints } from '../../src/nhplug/metadata/overseas-stock-order';
+import { overseasStockQuoteEndpoints } from '../../src/nhplug/metadata/overseas-stock-quote';
+
+const createClient = (): NhplugClient =>
+  new NhplugClient({
+    token: 'test-token',
+    appKey: 'test-app-key',
+    secretKey: 'test-secret-key',
+    fetchImpl: (async () => {
+      throw new Error('네트워크 호출이 발생하면 안 된다');
+    }) as unknown as typeof fetch,
+  });
+
+const domains = [
+  ['common', commonEndpoints],
+  ['krstockOrder', krstockOrderEndpoints],
+  ['krstockInquiry', krstockInquiryEndpoints],
+  ['krstockQuote', krstockQuoteEndpoints],
+  ['overseasStockOrder', overseasStockOrderEndpoints],
+  ['overseasStockInquiry', overseasStockInquiryEndpoints],
+  ['overseasStockQuote', overseasStockQuoteEndpoints],
+] as const;
+
+describe('NhplugClient 도메인 getter', () => {
+  test.each(domains)('%s 는 메타데이터의 모든 메서드를 노출한다', (prop, endpoints) => {
+    const domain = createClient()[prop] as unknown as Record<string, unknown>;
+    for (const endpoint of endpoints) {
+      expect(typeof domain[endpoint.methodName]).toBe('function');
+    }
+  });
+
+  test.each(domains)('%s 는 같은 인스턴스를 재사용한다', (prop) => {
+    const client = createClient();
+    expect(client[prop]).toBe(client[prop]);
+  });
+
+  test('7개 도메인 51종을 모두 노출한다', () => {
+    const total = domains.reduce((sum, [, endpoints]) => sum + endpoints.length, 0);
+    expect(total).toBe(51);
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/client.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/client.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+
+import { NhplugApiError, NhplugAuthenticationError } from '../../src/core/errors';
+import { silentLogger } from '../../src/core/logger';
+import type { NhplugEndpointDefinition } from '../../src/core/types';
+import { NhplugClient } from '../../src/nhplug/client';
+
+interface FetchCall {
+  url: string;
+  init: RequestInit;
+}
+
+const createFetchMock = (responder: (call: FetchCall) => Response): { calls: FetchCall[]; fetchMock: typeof fetch } => {
+  const calls: FetchCall[] = [];
+  const fetchMock: typeof fetch = async (input, init) => {
+    const call = { url: String(input), init: init ?? {} };
+    calls.push(call);
+    return responder(call);
+  };
+  return { calls, fetchMock };
+};
+
+const jsonResponse = (body: unknown, status = 200, headers: Record<string, string> = {}): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json', ...headers },
+  });
+
+const endpoint: NhplugEndpointDefinition = {
+  methodName: 'getAccountList',
+  path: '/n2/acctinfo',
+  bodyMap: { actNo: 'actNo', ordDt: 'ordDt' },
+  supportsCts: true,
+  params: [
+    { name: 'actNo', required: true },
+    { name: 'ordDt', required: false },
+    { name: 'cts', required: false },
+  ],
+};
+
+const createClient = (fetchMock: typeof fetch): NhplugClient =>
+  new NhplugClient({
+    token: 'token-value',
+    appKey: 'app-key',
+    secretKey: 'secret-key',
+    fetchImpl: fetchMock,
+    logger: silentLogger,
+  });
+
+const readBody = (call: FetchCall | undefined): Record<string, unknown> =>
+  JSON.parse(String(call?.init.body)) as Record<string, unknown>;
+
+const readHeaders = (call: FetchCall | undefined): Record<string, string> =>
+  (call?.init.headers ?? {}) as Record<string, string>;
+
+describe('NhplugClient.invokeEndpoint', () => {
+  it('wraps the request body in Input_0 and drops null/undefined params', async () => {
+    const { calls, fetchMock } = createFetchMock(() => jsonResponse({ rsp_cd: '00000', rsp_msg: '정상' }));
+    const client = createClient(fetchMock);
+
+    await client.invokeEndpoint(endpoint, { actNo: '12345678901', ordDt: undefined });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe('https://moapi.nhplug.com:8443/n2/acctinfo');
+    expect(calls[0]?.init.method).toBe('POST');
+    expect(readBody(calls[0])).toEqual({ Input_0: { actNo: '12345678901' } });
+  });
+
+  it('sends the NH auth headers', async () => {
+    const { calls, fetchMock } = createFetchMock(() => jsonResponse({ rsp_cd: '00000' }));
+
+    await createClient(fetchMock).invokeEndpoint(endpoint, { actNo: '1' });
+
+    const headers = readHeaders(calls[0]);
+    expect(headers.authorization).toBe('Bearer token-value');
+    expect(headers['x-client-id']).toBe('app-key');
+    expect(headers['x-client-secret']).toBe('secret-key');
+  });
+
+  it('uses the prod base url when env is prod', async () => {
+    const { calls, fetchMock } = createFetchMock(() => jsonResponse({ rsp_cd: '00000' }));
+    const client = new NhplugClient({
+      token: 't',
+      appKey: 'a',
+      secretKey: 's',
+      env: 'prod',
+      fetchImpl: fetchMock,
+      logger: silentLogger,
+    });
+
+    await client.invokeEndpoint(endpoint, { actNo: '1' });
+
+    expect(calls[0]?.url).toBe('https://api.nhplug.com:8443/n2/acctinfo');
+  });
+
+  it('round-trips cts: request headers go out, response cts/cts_flag come back', async () => {
+    const { calls, fetchMock } = createFetchMock(() =>
+      jsonResponse({ rsp_cd: '00000' }, 200, { cts: 'next-page-key', cts_flag: 'Y' }),
+    );
+
+    const result = await createClient(fetchMock).invokeEndpoint(endpoint, { actNo: '1', cts: 'page-2' });
+
+    const headers = readHeaders(calls[0]);
+    expect(headers.cts).toBe('page-2');
+    expect(headers.cts_flag).toBe('Y');
+    // cts 는 봉투 바디가 아니라 헤더로만 전달된다.
+    expect(readBody(calls[0])).toEqual({ Input_0: { actNo: '1' } });
+
+    expect(result.headers.cts).toBe('next-page-key');
+    expect(result.headers.ctsFlag).toBe('Y');
+  });
+
+  it('omits cts headers when no cts input is supplied', async () => {
+    const { calls, fetchMock } = createFetchMock(() => jsonResponse({ rsp_cd: '00000' }));
+
+    await createClient(fetchMock).invokeEndpoint(endpoint, { actNo: '1' });
+
+    const headers = readHeaders(calls[0]);
+    expect(headers.cts).toBeUndefined();
+    expect(headers.cts_flag).toBeUndefined();
+  });
+
+  it('omits cts headers when the endpoint does not support pagination', async () => {
+    const { calls, fetchMock } = createFetchMock(() => jsonResponse({ rsp_cd: '00000' }));
+    const noCtsEndpoint: NhplugEndpointDefinition = { ...endpoint, supportsCts: false };
+
+    await createClient(fetchMock).invokeEndpoint(noCtsEndpoint, { actNo: '1', cts: 'page-2' });
+
+    expect(readHeaders(calls[0]).cts).toBeUndefined();
+  });
+
+  it('raises NhplugApiError when an HTTP 200 carries a failing rsp_cd', async () => {
+    const { fetchMock } = createFetchMock(() => jsonResponse({ rsp_cd: '40010', rsp_msg: '계좌번호 오류' }));
+
+    await expect(createClient(fetchMock).invokeEndpoint(endpoint, { actNo: '1' })).rejects.toBeInstanceOf(
+      NhplugApiError,
+    );
+    await expect(createClient(fetchMock).invokeEndpoint(endpoint, { actNo: '1' })).rejects.toThrow(
+      'API error 40010: 계좌번호 오류',
+    );
+  });
+
+  it('treats XA102 as success (모의투자 조회 완료 응답)', async () => {
+    const { fetchMock } = createFetchMock(() =>
+      jsonResponse({ rsp_cd: 'XA102', rsp_msg: '모의투자 조회가 완료되었습니다', Output_0: [{ act_no: '1' }] }),
+    );
+
+    const result = await createClient(fetchMock).invokeEndpoint(endpoint, { actNo: '1' });
+
+    expect(result.body).toEqual({
+      rspCd: 'XA102',
+      rspMsg: '모의투자 조회가 완료되었습니다',
+      output0: [{ actNo: '1' }],
+    });
+  });
+
+  it('maps transport errors onto the Nhplug error family', async () => {
+    const { fetchMock } = createFetchMock(() => jsonResponse({ rsp_cd: '99999' }, 401));
+
+    await expect(createClient(fetchMock).invokeEndpoint(endpoint, { actNo: '1' })).rejects.toBeInstanceOf(
+      NhplugAuthenticationError,
+    );
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/common.integration.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/common.integration.test.ts
@@ -1,0 +1,41 @@
+/**
+ * NH PLUG 공통(common) 통합 테스트.
+ *
+ * `/n2/acctinfo` 는 다른 모든 카테고리의 선행 조건이다 — 조회·주문 API 의 `actNo` 는
+ * 여기서 받은 계좌번호를 쓴다. 모의투자(dev)는 `acctType === '03'` 계좌만 유효하다.
+ *
+ * `closeWebsocketSession` 은 계좌의 실시간 세션을 끊는 상태 변경 호출이라 통합
+ * 테스트를 두지 않는다 (단위 테스트로만 검증).
+ */
+import { describe, expect, test } from 'vitest';
+
+import { accountListResponseSchema } from '../../src/nhplug/schemas/common';
+import {
+  assertNhplugResponse,
+  assertNhplugResponseShape,
+  callNhplug,
+  getNhplugClient,
+  requireNhplugAccount,
+  runNhplugIntegration,
+  setupNhplugRateLimit,
+} from '../_helpers/integration-setup';
+
+const it = runNhplugIntegration ? test : test.skip;
+
+describe('Nhplug Common', () => {
+  setupNhplugRateLimit();
+
+  it('getAccountList', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () => client.common.getAccountList({}));
+
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, accountListResponseSchema);
+  });
+
+  it('환경에 맞는 계좌(acctType)를 찾을 수 있다', async (ctx) => {
+    // 계좌가 없으면 실패가 아니라 skip 된다 — 이후 조회 테스트도 같은 이유로 skip 된다.
+    const account = await requireNhplugAccount(ctx);
+    expect(account.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/domain-base.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/domain-base.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ApiResponse, NhplugEndpointDefinition } from '../../src/core/types';
+import type { NhplugClient } from '../../src/nhplug/client';
+import { NhplugDomainBase } from '../../src/nhplug/domain-base';
+
+const response: ApiResponse = { headers: {}, body: { ok: true } };
+
+const endpoints: NhplugEndpointDefinition[] = [
+  {
+    methodName: 'getAccountList',
+    path: '/n2/acctinfo',
+    bodyMap: {},
+    supportsCts: true,
+    params: [{ name: 'cts', required: false }],
+  },
+];
+
+class TestNhplugDomainBase extends NhplugDomainBase {
+  public async callInvoke(methodName: string): Promise<ApiResponse> {
+    return await this.invoke(methodName, {});
+  }
+}
+
+describe('NhplugDomainBase', () => {
+  it('defines generated methods that delegate to the client endpoint invoker', async () => {
+    const calls: NhplugEndpointDefinition[] = [];
+    const client = {
+      invokeEndpoint: async (endpoint: NhplugEndpointDefinition) => {
+        calls.push(endpoint);
+        return response;
+      },
+    } as unknown as NhplugClient;
+
+    const domain = new TestNhplugDomainBase(client, endpoints);
+    const methods = domain as unknown as Record<
+      string,
+      ((input: Record<string, unknown>) => Promise<ApiResponse>) | undefined
+    >;
+    const method = methods.getAccountList;
+
+    expect(method).toBeTypeOf('function');
+    await expect(method?.({})).resolves.toBe(response);
+    await expect(domain.callInvoke('getAccountList')).resolves.toBe(response);
+    await expect(domain.callInvoke('missingMethod')).rejects.toThrow('Unknown NH PLUG endpoint');
+    expect(calls).toHaveLength(2);
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/dts-drift.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/dts-drift.test.ts
@@ -5,6 +5,9 @@ import { expect, test } from 'vitest';
 import { typesContent } from '../../scripts/generate-types.mjs';
 import * as Nhplug from '../../src/nhplug';
 
+// vitest 는 패키지 루트를 cwd 로 실행한다. 경로를 조립하지 않고 리터럴로 둔다.
+const BUILT_DTS = 'dist/types/index.d.ts';
+
 const declaredNames = (source: string): Set<string> => {
   const names = new Set<string>();
   const pattern =
@@ -47,11 +50,9 @@ test('nhplug type-only exports are declared too', () => {
 });
 
 test('the built index.d.ts matches the generator output', () => {
-  // 정적 경로로 해석한다 — 경로를 조립하면 정적분석이 경로 주입으로 본다.
-  const builtPath = new URL('../../dist/types/index.d.ts', import.meta.url);
-  if (!fs.existsSync(builtPath)) {
+  if (!fs.existsSync(BUILT_DTS)) {
     // 아직 빌드 전이면 검사할 대상이 없다.
     return;
   }
-  expect(fs.readFileSync(builtPath, 'utf8')).toBe(typesContent);
+  expect(fs.readFileSync(BUILT_DTS, 'utf8')).toBe(typesContent);
 });

--- a/packages/cluefin-openapi-ts/tests/nhplug/dts-drift.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/dts-drift.test.ts
@@ -1,13 +1,9 @@
 import fs from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { expect, test } from 'vitest';
 
 // @ts-expect-error - 생성 스크립트는 타입 선언이 없는 .mjs 다.
 import { typesContent } from '../../scripts/generate-types.mjs';
 import * as Nhplug from '../../src/nhplug';
-
-const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 const declaredNames = (source: string): Set<string> => {
   const names = new Set<string>();
@@ -51,7 +47,8 @@ test('nhplug type-only exports are declared too', () => {
 });
 
 test('the built index.d.ts matches the generator output', () => {
-  const builtPath = path.join(packageRoot, 'dist', 'types', 'index.d.ts');
+  // 정적 경로로 해석한다 — 경로를 조립하면 정적분석이 경로 주입으로 본다.
+  const builtPath = new URL('../../dist/types/index.d.ts', import.meta.url);
   if (!fs.existsSync(builtPath)) {
     // 아직 빌드 전이면 검사할 대상이 없다.
     return;

--- a/packages/cluefin-openapi-ts/tests/nhplug/dts-drift.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/dts-drift.test.ts
@@ -1,0 +1,60 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { expect, test } from 'vitest';
+
+// @ts-expect-error - 생성 스크립트는 타입 선언이 없는 .mjs 다.
+import { typesContent } from '../../scripts/generate-types.mjs';
+import * as Nhplug from '../../src/nhplug';
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+const declaredNames = (source: string): Set<string> => {
+  const names = new Set<string>();
+  const pattern =
+    /^export\s+(?:declare\s+)?(?:abstract\s+)?(?:class|const|function|interface|type|enum)\s+([A-Za-z0-9_$]+)/gm;
+  for (const [, name] of source.matchAll(pattern)) {
+    if (name) {
+      names.add(name);
+    }
+  }
+  return names;
+};
+
+const declared = declaredNames(typesContent as string);
+
+test('every nhplug runtime export has a declaration in the generated index.d.ts', () => {
+  // 값(런타임) export 만 열거된다 — `export type` 은 여기에 나타나지 않는다.
+  const runtimeExports = Object.keys(Nhplug).sort();
+  expect(runtimeExports.length).toBeGreaterThan(0);
+
+  const missing = runtimeExports.filter((name) => !declared.has(name));
+  expect(missing).toEqual([]);
+});
+
+test('nhplug type-only exports are declared too', () => {
+  // 타입 export 는 런타임에 열거되지 않으므로 목록을 고정해 회귀를 잡는다.
+  const typeExports = [
+    'NhplugAuthOptions',
+    'NhplugTokenResponse',
+    'NhplugTokenRevokeResponse',
+    'NhplugTokenCacheEntry',
+    'NhplugTokenCacheStore',
+    'NhplugClientOptions',
+    'NhplugEndpointDefinition',
+    'NhplugMarket',
+    'NhplugSocketClientOptions',
+  ];
+
+  const missing = typeExports.filter((name) => !declared.has(name));
+  expect(missing).toEqual([]);
+});
+
+test('the built index.d.ts matches the generator output', () => {
+  const builtPath = path.join(packageRoot, 'dist', 'types', 'index.d.ts');
+  if (!fs.existsSync(builtPath)) {
+    // 아직 빌드 전이면 검사할 대상이 없다.
+    return;
+  }
+  expect(fs.readFileSync(builtPath, 'utf8')).toBe(typesContent);
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/krstock-domains.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/krstock-domains.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ApiResponse, NhplugEndpointDefinition } from '../../src/core/types';
+import type { NhplugClient } from '../../src/nhplug/client';
+import { NhplugCommon } from '../../src/nhplug/common';
+import { NhplugKrstockInquiry } from '../../src/nhplug/krstock-inquiry';
+import { NhplugKrstockOrder } from '../../src/nhplug/krstock-order';
+import { NhplugKrstockQuote } from '../../src/nhplug/krstock-quote';
+import { commonEndpoints } from '../../src/nhplug/metadata/common';
+import { krstockInquiryEndpoints } from '../../src/nhplug/metadata/krstock-inquiry';
+import { krstockOrderEndpoints } from '../../src/nhplug/metadata/krstock-order';
+import { krstockQuoteEndpoints } from '../../src/nhplug/metadata/krstock-quote';
+
+const response: ApiResponse = { headers: {}, body: { rspCd: '00000' } };
+
+const createClientStub = (): { client: NhplugClient; calls: NhplugEndpointDefinition[] } => {
+  const calls: NhplugEndpointDefinition[] = [];
+  const client = {
+    invokeEndpoint: async (endpoint: NhplugEndpointDefinition) => {
+      calls.push(endpoint);
+      return response;
+    },
+  } as unknown as NhplugClient;
+  return { client, calls };
+};
+
+const cases = [
+  { name: 'NhplugCommon', build: (c: NhplugClient) => new NhplugCommon(c), endpoints: commonEndpoints, count: 2 },
+  {
+    name: 'NhplugKrstockOrder',
+    build: (c: NhplugClient) => new NhplugKrstockOrder(c),
+    endpoints: krstockOrderEndpoints,
+    count: 8,
+  },
+  {
+    name: 'NhplugKrstockInquiry',
+    build: (c: NhplugClient) => new NhplugKrstockInquiry(c),
+    endpoints: krstockInquiryEndpoints,
+    count: 12,
+  },
+  {
+    name: 'NhplugKrstockQuote',
+    build: (c: NhplugClient) => new NhplugKrstockQuote(c),
+    endpoints: krstockQuoteEndpoints,
+    count: 11,
+  },
+] as const;
+
+describe.each(cases)('$name', ({ build, endpoints, count }) => {
+  it('exposes exactly the endpoints declared in its metadata', () => {
+    expect(endpoints).toHaveLength(count);
+
+    const { client } = createClientStub();
+    const domain = build(client) as unknown as Record<string, unknown>;
+
+    for (const endpoint of endpoints) {
+      expect(domain[endpoint.methodName]).toBeTypeOf('function');
+    }
+  });
+
+  it('delegates every method to the client with its own endpoint definition', async () => {
+    const { client, calls } = createClientStub();
+    const domain = build(client) as unknown as Record<string, (input: Record<string, unknown>) => Promise<ApiResponse>>;
+
+    for (const endpoint of endpoints) {
+      await expect(domain[endpoint.methodName]?.({})).resolves.toBe(response);
+    }
+
+    expect(calls.map((call) => call.methodName)).toEqual(endpoints.map((endpoint) => endpoint.methodName));
+  });
+});
+
+describe('krstock quote typing', () => {
+  it('keeps the generated method names available on the typed surface', async () => {
+    const { client } = createClientStub();
+    const quote = new NhplugKrstockQuote(client);
+
+    const result = await quote.currentPrice({ marketCd: 'J', iemCd: '005930' });
+
+    expect(result.body).toEqual({ rspCd: '00000' });
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/krstock-inquiry.integration.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/krstock-inquiry.integration.test.ts
@@ -1,0 +1,202 @@
+/**
+ * NH PLUG 국내주식 조회(krstock inquiry) 통합 테스트.
+ *
+ * 모의투자(`NHPLUG_ENV=dev`)에서 실제 조회를 수행한다. 조회 API 는 주문과 달리 장
+ * 운영시간·영업일 제약이 없어 휴일에도 성공한다 (파이썬 스위트 2026-08-22 실측).
+ *
+ * `actNo` 는 `/n2/acctinfo` 에서 환경에 맞는 계좌(dev = acctType `03`)를 골라 쓰고,
+ * 계좌가 없으면 실패가 아니라 skip 한다.
+ *
+ * `integratedMargin`·`rightsHeld`·`rightsScheduled`·`reservedInquiry` 는 모의투자에서
+ * `19999 "모의투자에서는 해당업무가 제공되지 않습니다"` 로 거부되므로 운영에서만 실행한다.
+ */
+import { describe, expect, test } from 'vitest';
+
+import {
+  krStockInquiryAssetStatusResponseSchema,
+  krStockInquiryBalanceResponseSchema,
+  krStockInquiryBuyableQuantityResponseSchema,
+  krStockInquiryDailyOrderExecutionResponseSchema,
+  krStockInquiryDailyPnlResponseSchema,
+  krStockInquiryIntegratedMarginResponseSchema,
+  krStockInquiryRealizedPnlResponseSchema,
+  krStockInquiryReservedInquiryResponseSchema,
+  krStockInquiryRightsHeldResponseSchema,
+  krStockInquiryRightsScheduledResponseSchema,
+  krStockInquirySellableQuantityResponseSchema,
+  krStockInquiryTradingPnlResponseSchema,
+} from '../../src/nhplug/schemas/krstock-inquiry';
+import {
+  assertNhplugResponse,
+  assertNhplugResponseShape,
+  callNhplug,
+  getNhplugClient,
+  NHPLUG_TEST_IEM_CD,
+  ONE_MONTH_AGO,
+  requireNhplugAccount,
+  runNhplugIntegration,
+  runNhplugLiveOnlyIntegration,
+  setupNhplugRateLimit,
+  TODAY,
+} from '../_helpers/integration-setup';
+
+const it = runNhplugIntegration ? test : test.skip;
+/** 모의투자에서 19999(미지원)로 거부되는 API — 운영(NHPLUG_ENV=prod)에서만 검증 가능하다. */
+const liveOnlyIt = runNhplugLiveOnlyIntegration ? test : test.skip;
+
+describe('Nhplug KrstockInquiry', () => {
+  setupNhplugRateLimit();
+
+  it('assetStatus', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () =>
+      client.krstockInquiry.assetStatus({
+        actNo,
+        ealAlyCd: '2', // 시가평가
+        aetBse: '1', // 순자산
+        qutDitCd: 'UNT', // 통합시세
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryAssetStatusResponseSchema);
+  });
+
+  it('balance', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () =>
+      client.krstockInquiry.balance({
+        actNo,
+        bncBseCd: '1', // 주식관련 총 평가(체결기준)
+        ltgAotDitCd: '9', // 전체
+        aetBse: '1', // 순자산
+        qutDitCd: 'UNT', // 통합시세
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryBalanceResponseSchema);
+    // 연속조회 플래그는 응답 헤더로 내려온다.
+    expect(res.headers.ctsFlag).toBeDefined();
+  });
+
+  it('dailyOrderExecution', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    // 주문 이력이 없어도 조회 자체는 성공한다. 모의 서버는 성공에 XA102 를 반환한다.
+    const res = await callNhplug(ctx, () =>
+      client.krstockInquiry.dailyOrderExecution({
+        actNo,
+        orrDt: TODAY,
+        ostCnsDit: '0', // 전체
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryDailyOrderExecutionResponseSchema);
+  });
+
+  it('buyableQuantity', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    // nmnPrTpCd="05"(시장가)를 써서 orrPr(주문가격) 입력을 피한다 — 조회 전용이며 주문이 아니다.
+    const res = await callNhplug(ctx, () =>
+      client.krstockInquiry.buyableQuantity({
+        actNo,
+        iemCd: NHPLUG_TEST_IEM_CD,
+        ostDitCd: '1', // 현금
+        nmnPrTpCd: '05', // 시장가 — orrPr 불필요
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryBuyableQuantityResponseSchema);
+  });
+
+  it('sellableQuantity', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    // 보유 잔고가 없어 매도가능수량이 0이어도 조회 자체는 성공한다.
+    const res = await callNhplug(ctx, () =>
+      client.krstockInquiry.sellableQuantity({
+        actNo,
+        iemCd: NHPLUG_TEST_IEM_CD,
+        cfdLonCd: '00', // 일반거래(현금)
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquirySellableQuantityResponseSchema);
+  });
+
+  it('realizedPnl', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () =>
+      client.krstockInquiry.realizedPnl({
+        actNo,
+        iqrDitCd1: '0', // 전체
+        feeDitCd: '1', // 온라인
+        qutDitCd: 'UNT', // 통합시세
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryRealizedPnlResponseSchema);
+  });
+
+  it('dailyPnl', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () =>
+      client.krstockInquiry.dailyPnl({ actNo, iqrStaDt: ONE_MONTH_AGO, iqrEndDt: TODAY }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryDailyPnlResponseSchema);
+  });
+
+  it('tradingPnl', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () =>
+      client.krstockInquiry.tradingPnl({ actNo, iqrStaDt: ONE_MONTH_AGO, iqrEndDt: TODAY }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryTradingPnlResponseSchema);
+  });
+
+  liveOnlyIt('integratedMargin (모의투자 미지원 — 19999)', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () => client.krstockInquiry.integratedMargin({ actNo }));
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryIntegratedMarginResponseSchema);
+  });
+
+  liveOnlyIt('rightsHeld (모의투자 미지원 — 19999)', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () => client.krstockInquiry.rightsHeld({ actNo, staDt: ONE_MONTH_AGO }));
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryRightsHeldResponseSchema);
+  });
+
+  liveOnlyIt('rightsScheduled (모의투자 미지원 — 19999)', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () => client.krstockInquiry.rightsScheduled({ actNo }));
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryRightsScheduledResponseSchema);
+  });
+
+  liveOnlyIt('reservedInquiry (모의투자 미지원 — 19999)', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    // 조회 전용이다 — 예약주문 접수(reservedOrder)는 통합 테스트를 두지 않는다.
+    const res = await callNhplug(ctx, () =>
+      client.krstockInquiry.reservedInquiry({
+        actNo,
+        sbyDitCd: '0', // 전체
+        bkgOrrTpCd: '0', // 전체
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockInquiryReservedInquiryResponseSchema);
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/krstock-quote.integration.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/krstock-quote.integration.test.ts
@@ -1,0 +1,141 @@
+/**
+ * NH PLUG 국내주식 시세(krstock quote) 통합 테스트.
+ *
+ * 시세 조회 API 는 계좌번호가 필요 없다 — 계좌 게이팅을 하지 않는다.
+ * 휴일에도 조회된다 (파이썬 스위트 2026-08-22 실측 확인).
+ */
+import { describe, test } from 'vitest';
+
+import {
+  krStockQuoteAfterHoursCurrentResponseSchema,
+  krStockQuoteAfterHoursExpectedResponseSchema,
+  krStockQuoteCurrentAfterHoursDailyResponseSchema,
+  krStockQuoteCurrentAfterHoursExecutionResponseSchema,
+  krStockQuoteCurrentDailyResponseSchema,
+  krStockQuoteCurrentExecutionResponseSchema,
+  krStockQuoteCurrentInvestorResponseSchema,
+  krStockQuoteCurrentPriceResponseSchema,
+  krStockQuoteEtfComponentsResponseSchema,
+  krStockQuoteEtfCurrentResponseSchema,
+  krStockQuotePeriodResponseSchema,
+} from '../../src/nhplug/schemas/krstock-quote';
+import {
+  assertNhplugResponse,
+  assertNhplugResponseShape,
+  callNhplug,
+  getNhplugClient,
+  NHPLUG_TEST_ETF_IEM_CD,
+  NHPLUG_TEST_IEM_CD,
+  runNhplugIntegration,
+  setupNhplugRateLimit,
+  TODAY,
+} from '../_helpers/integration-setup';
+
+const it = runNhplugIntegration ? test : test.skip;
+
+describe('Nhplug KrstockQuote', () => {
+  setupNhplugRateLimit();
+
+  it('currentPrice', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () =>
+      client.krstockQuote.currentPrice({ marketCd: 'KRX', iemCd: NHPLUG_TEST_IEM_CD }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuoteCurrentPriceResponseSchema);
+  });
+
+  it('currentExecution', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () =>
+      client.krstockQuote.currentExecution({ marketCd: 'KRX', iemCd: NHPLUG_TEST_IEM_CD }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuoteCurrentExecutionResponseSchema);
+  });
+
+  it('currentDaily', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () =>
+      client.krstockQuote.currentDaily({ marketCd: 'KRX', iemCd: NHPLUG_TEST_IEM_CD }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuoteCurrentDailyResponseSchema);
+  });
+
+  it('currentInvestor', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () =>
+      client.krstockQuote.currentInvestor({ marketCd: 'KRX', iemCd: NHPLUG_TEST_IEM_CD, arrayCnt: '10' }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuoteCurrentInvestorResponseSchema);
+  });
+
+  it('period', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () =>
+      client.krstockQuote.period({
+        marketCd: 'KRX',
+        iemCd: NHPLUG_TEST_IEM_CD,
+        gubun: '1', // 일봉
+        edate: TODAY,
+        arrayCnt: '30', // 최근 한 달치
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuotePeriodResponseSchema);
+  });
+
+  it('afterHoursCurrent', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () => client.krstockQuote.afterHoursCurrent({ iemCd: NHPLUG_TEST_IEM_CD }));
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuoteAfterHoursCurrentResponseSchema);
+  });
+
+  it('currentAfterHoursDaily', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () =>
+      client.krstockQuote.currentAfterHoursDaily({
+        iemCd: NHPLUG_TEST_IEM_CD,
+        date: TODAY,
+        arrayCnt: '10',
+        maxavg: '5',
+        gubun: '1',
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuoteCurrentAfterHoursDailyResponseSchema);
+  });
+
+  it('currentAfterHoursExecution', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () =>
+      client.krstockQuote.currentAfterHoursExecution({ iemCd: NHPLUG_TEST_IEM_CD }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuoteCurrentAfterHoursExecutionResponseSchema);
+  });
+
+  it('afterHoursExpected', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () => client.krstockQuote.afterHoursExpected({ iemCd: NHPLUG_TEST_IEM_CD }));
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuoteAfterHoursExpectedResponseSchema);
+  });
+
+  it('etfCurrent', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () => client.krstockQuote.etfCurrent({ iemCd: NHPLUG_TEST_ETF_IEM_CD }));
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuoteEtfCurrentResponseSchema);
+  });
+
+  it('etfComponents', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () => client.krstockQuote.etfComponents({ iemCd: NHPLUG_TEST_ETF_IEM_CD }));
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, krStockQuoteEtfComponentsResponseSchema);
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/metadata.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/metadata.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import type { NhplugEndpointDefinition } from '../../src/core/types';
+import { commonEndpoints } from '../../src/nhplug/metadata/common';
+import { krstockInquiryEndpoints } from '../../src/nhplug/metadata/krstock-inquiry';
+import { krstockOrderEndpoints } from '../../src/nhplug/metadata/krstock-order';
+import { krstockQuoteEndpoints } from '../../src/nhplug/metadata/krstock-quote';
+import { overseasStockInquiryEndpoints } from '../../src/nhplug/metadata/overseas-stock-inquiry';
+import { overseasStockOrderEndpoints } from '../../src/nhplug/metadata/overseas-stock-order';
+import { overseasStockQuoteEndpoints } from '../../src/nhplug/metadata/overseas-stock-quote';
+
+// 파이썬 sibling(`cluefin_openapi/nhplug/_*.py`) 에서 생성되는 메타데이터라,
+// 개수가 바뀌면 파이썬 쪽 엔드포인트가 늘거나 파서가 깨진 것이다.
+const categories: Array<[string, readonly NhplugEndpointDefinition[], number]> = [
+  ['common', commonEndpoints, 2],
+  ['krstockOrder', krstockOrderEndpoints, 8],
+  ['krstockInquiry', krstockInquiryEndpoints, 12],
+  ['krstockQuote', krstockQuoteEndpoints, 11],
+  ['overseasStockOrder', overseasStockOrderEndpoints, 6],
+  ['overseasStockInquiry', overseasStockInquiryEndpoints, 8],
+  ['overseasStockQuote', overseasStockQuoteEndpoints, 4],
+];
+
+const allEndpoints = categories.flatMap(([, endpoints]) => endpoints);
+
+describe('nhplug metadata', () => {
+  it.each(categories)('%s has %i endpoints', (_name, endpoints, expected) => {
+    expect(endpoints).toHaveLength(expected);
+  });
+
+  it('has 51 endpoints in total', () => {
+    expect(allEndpoints).toHaveLength(51);
+  });
+
+  it('gives every endpoint a non-empty path', () => {
+    for (const endpoint of allEndpoints) {
+      expect(endpoint.path, endpoint.methodName).toMatch(/^\//);
+    }
+  });
+
+  it('gives every cts-capable endpoint a cts param', () => {
+    const ctsEndpoints = allEndpoints.filter((endpoint) => endpoint.supportsCts);
+    expect(ctsEndpoints.length).toBeGreaterThan(0);
+    for (const endpoint of ctsEndpoints) {
+      const ctsParam = endpoint.params.find((param) => param.name === 'cts');
+      expect(ctsParam, endpoint.methodName).toBeDefined();
+      expect(ctsParam?.required, endpoint.methodName).toBe(false);
+    }
+  });
+
+  it('never maps cts into the request body', () => {
+    for (const endpoint of allEndpoints) {
+      // cts 는 헤더로만 나가므로 bodyMap 에 있으면 안 된다.
+      expect(Object.values(endpoint.bodyMap), endpoint.methodName).not.toContain('cts');
+    }
+  });
+
+  it('has unique method names within each category', () => {
+    for (const [name, endpoints] of categories) {
+      const methodNames = endpoints.map((endpoint) => endpoint.methodName);
+      expect(new Set(methodNames).size, name).toBe(methodNames.length);
+    }
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/overseas-stock-domains.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/overseas-stock-domains.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { camelizeKeys } from '../../src/core/case-convert';
+import type { ApiResponse, NhplugEndpointDefinition } from '../../src/core/types';
+import type { NhplugClient } from '../../src/nhplug/client';
+import { overseasStockInquiryEndpoints } from '../../src/nhplug/metadata/overseas-stock-inquiry';
+import { overseasStockOrderEndpoints } from '../../src/nhplug/metadata/overseas-stock-order';
+import { overseasStockQuoteEndpoints } from '../../src/nhplug/metadata/overseas-stock-quote';
+import { NhplugOverseasStockInquiry } from '../../src/nhplug/overseas-stock-inquiry';
+import { NhplugOverseasStockOrder } from '../../src/nhplug/overseas-stock-order';
+import { NhplugOverseasStockQuote } from '../../src/nhplug/overseas-stock-quote';
+import type { OverseasStockQuoteCurrentPriceResponse } from '../../src/nhplug/schemas/overseas-stock-quote';
+
+const response: ApiResponse = { headers: {}, body: { ok: true } };
+
+const createClient = (
+  calls: Array<{ endpoint: NhplugEndpointDefinition; input: Record<string, unknown> }>,
+): NhplugClient =>
+  ({
+    invokeEndpoint: async (endpoint: NhplugEndpointDefinition, input: Record<string, unknown>) => {
+      calls.push({ endpoint, input });
+      return response;
+    },
+  }) as unknown as NhplugClient;
+
+describe('NH PLUG 해외주식(gbstock) domain wrappers', () => {
+  it('exposes one method per generated endpoint', () => {
+    const calls: Array<{ endpoint: NhplugEndpointDefinition; input: Record<string, unknown> }> = [];
+    const client = createClient(calls);
+
+    const domains = [
+      { instance: new NhplugOverseasStockOrder(client), endpoints: overseasStockOrderEndpoints },
+      { instance: new NhplugOverseasStockInquiry(client), endpoints: overseasStockInquiryEndpoints },
+      { instance: new NhplugOverseasStockQuote(client), endpoints: overseasStockQuoteEndpoints },
+    ];
+
+    for (const { instance, endpoints } of domains) {
+      const methods = instance as unknown as Record<string, unknown>;
+      for (const endpoint of endpoints) {
+        expect(methods[endpoint.methodName]).toBeTypeOf('function');
+      }
+    }
+
+    expect(overseasStockOrderEndpoints).toHaveLength(6);
+    expect(overseasStockInquiryEndpoints).toHaveLength(8);
+    expect(overseasStockQuoteEndpoints).toHaveLength(4);
+  });
+
+  it('delegates each call to the client with its own endpoint definition', async () => {
+    const calls: Array<{ endpoint: NhplugEndpointDefinition; input: Record<string, unknown> }> = [];
+    const client = createClient(calls);
+
+    const quote = new NhplugOverseasStockQuote(client);
+    await expect(quote.current({ iemCd: 'AAPL' })).resolves.toBe(response);
+
+    const order = new NhplugOverseasStockOrder(client);
+    await expect(order.buy({ actNo: '00000000000' })).resolves.toBe(response);
+
+    const inquiry = new NhplugOverseasStockInquiry(client);
+    await expect(inquiry.balance({ actNo: '00000000000' })).resolves.toBe(response);
+
+    expect(calls.map((call) => call.endpoint.path)).toEqual([
+      '/gbstock/quote/v1/current',
+      '/gbstock/order/v1/buy',
+      '/gbstock/inquiry/v1/balance',
+    ]);
+    expect(calls[0]?.input).toEqual({ iemCd: 'AAPL' });
+  });
+
+  it('typed response map lines up with the camelized wire body', async () => {
+    const wire = { rsp_cd: '00000', Output_0: { iem_cd: 'AAPL', trdprc: 1 } };
+    const client = {
+      invokeEndpoint: async (): Promise<ApiResponse> => ({ headers: {}, body: camelizeKeys(wire) }),
+    } as unknown as NhplugClient;
+
+    const quote = new NhplugOverseasStockQuote(client);
+    const result = await quote.current({ iemCd: 'AAPL' });
+    const body: OverseasStockQuoteCurrentPriceResponse = result.body;
+
+    // `Output_0` 은 런타임 camelize 후 `output0` 이 된다 — 타입과 런타임이 같은 키를 가리켜야 한다.
+    expect(body.output0?.iemCd).toBe('AAPL');
+    expect(body.rspCd).toBe('00000');
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/overseas-stock-inquiry.integration.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/overseas-stock-inquiry.integration.test.ts
@@ -1,0 +1,168 @@
+/**
+ * NH PLUG 해외주식 조회(gbstock inquiry) 통합 테스트.
+ *
+ * 모의투자(`NHPLUG_ENV=dev`)에서 실제 조회를 수행한다. 조회 API 는 장 운영시간·영업일
+ * 제약이 없어 휴일에도 성공한다. 주문 카테고리(gbstock order)는 실제 체결이 발생하므로
+ * 통합 테스트를 두지 않는다.
+ *
+ * 계좌는 `/n2/acctinfo` 에서 환경에 맞는 것(dev = acctType `03`)을 고르며,
+ * 없으면 실패가 아니라 skip 한다.
+ */
+import { describe, test } from 'vitest';
+
+import {
+  overseasStockInquiryBalanceResponseSchema,
+  overseasStockInquiryBuyableAmountResponseSchema,
+  overseasStockInquiryDailyTransactionResponseSchema,
+  overseasStockInquiryMarginResponseSchema,
+  overseasStockInquiryPeriodPnlDetailResponseSchema,
+  overseasStockInquiryPeriodPnlResponseSchema,
+  overseasStockInquiryReservedInquiryResponseSchema,
+  overseasStockInquiryUnexecutedResponseSchema,
+} from '../../src/nhplug/schemas/overseas-stock-inquiry';
+import {
+  assertNhplugResponse,
+  assertNhplugResponseShape,
+  callNhplug,
+  getNhplugClient,
+  NHPLUG_TEST_GB_IEM_CD,
+  NHPLUG_US_NATION_CD,
+  ONE_MONTH_AGO,
+  requireNhplugAccount,
+  runNhplugIntegration,
+  setupNhplugRateLimit,
+  TODAY,
+} from '../_helpers/integration-setup';
+
+const it = runNhplugIntegration ? test : test.skip;
+
+describe('Nhplug OverseasStockInquiry', () => {
+  setupNhplugRateLimit();
+
+  it('balance', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () =>
+      client.overseasStockInquiry.balance({
+        actNo,
+        qutIqrDitCd: '9', // 전체
+        fcSecTrdNatCd: NHPLUG_US_NATION_CD,
+        curCd: 'KRW', // 전체
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockInquiryBalanceResponseSchema);
+  });
+
+  it('buyableAmount', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    // 매수가능금액 "조회"다 — 주문을 넣지 않는다.
+    const res = await callNhplug(ctx, () =>
+      client.overseasStockInquiry.buyableAmount({
+        actNo,
+        pcsDit: '1', // 매수가능금액조회
+        fcSecTrdNatCd: NHPLUG_US_NATION_CD,
+        iemCd: NHPLUG_TEST_GB_IEM_CD,
+        wtmCurKndCd: '2', // 원화
+        ossOrrKndCd: '1', // GTS(미국시장주문)
+        ahiNmnPrTpCd: '03', // 시장가
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockInquiryBuyableAmountResponseSchema);
+  });
+
+  it('unexecuted', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    // 당일 주문이 없어도 조회 자체는 성공한다.
+    const res = await callNhplug(ctx, () =>
+      client.overseasStockInquiry.unexecuted({
+        orrDt: TODAY,
+        actNo,
+        ossSbyDitCd: '0', // 전체
+        sotDit: '0', // 주문번호순
+        ostCnsDit: '0', // 전체
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockInquiryUnexecutedResponseSchema);
+  });
+
+  it('reservedInquiry', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    // 예약주문 "조회"다 — 예약주문 접수는 통합 테스트를 두지 않는다.
+    const res = await callNhplug(ctx, () =>
+      client.overseasStockInquiry.reservedInquiry({
+        fcMktDitCd: '000', // 전체
+        bkgOrrDt: TODAY,
+        actNo,
+        sbyDitCd: '0', // 전체
+        bkgOrrCanYn: '0', // 전체
+        ossOrrKndCd: '0', // 전체
+        bkgOrrTpCd: '0', // 전체
+        wtmCurKndCd: '0', // 전체
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockInquiryReservedInquiryResponseSchema);
+  });
+
+  it('dailyTransaction', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () =>
+      client.overseasStockInquiry.dailyTransaction({
+        actNo,
+        iqrStaDt: ONE_MONTH_AGO,
+        iqrEndDt: TODAY,
+        actTrdCfcCd: '00', // 전체
+        iemMlfCd: '00001', // 외화주식
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockInquiryDailyTransactionResponseSchema);
+  });
+
+  it('periodPnl', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () =>
+      client.overseasStockInquiry.periodPnl({
+        actNo,
+        iqrDit: '2', // 원화기준
+        staOrrDt: ONE_MONTH_AGO,
+        endOrrDt: TODAY,
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockInquiryPeriodPnlResponseSchema);
+  });
+
+  it('periodPnlDetail', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    // 거래가 없어도 성공해야 한다.
+    const res = await callNhplug(ctx, () =>
+      client.overseasStockInquiry.periodPnlDetail({
+        actNo,
+        iqrDit: '2', // 원화기준
+        orrDt: TODAY,
+        fcSecTrdNatCd: NHPLUG_US_NATION_CD,
+        trdCurCd: 'USD',
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockInquiryPeriodPnlDetailResponseSchema);
+  });
+
+  it('margin', async (ctx) => {
+    const client = await getNhplugClient();
+    const actNo = await requireNhplugAccount(ctx);
+    const res = await callNhplug(ctx, () => client.overseasStockInquiry.margin({ actNo }));
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockInquiryMarginResponseSchema);
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/overseas-stock-quote.integration.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/overseas-stock-quote.integration.test.ts
@@ -1,0 +1,90 @@
+/**
+ * NH PLUG 해외주식 시세(gbstock quote) 통합 테스트.
+ *
+ * 시세 조회 API 는 계좌번호가 필요 없다 — 계좌 게이팅을 하지 않는다.
+ *
+ * **4종 모두 운영 도메인 전용이다.** 모의투자(moapi)는 어떤 종목코드로 호출해도
+ * `IGW40019 "종목코드(iem_cd)를 확인해주세요"` 로 거부하는데, 이는 잘못된 코드라는
+ * 뜻이 아니라 "모의투자에 제공되지 않는 서비스"라는 뜻이다 (2026-08-22 실측).
+ * 따라서 `NHPLUG_ENV=prod` 에서만 실행되고, 모의투자에서는 통째로 skip 된다.
+ */
+import { describe, test } from 'vitest';
+
+import {
+  overseasStockQuoteCurrentPriceResponseSchema,
+  overseasStockQuoteExecutionTrendResponseSchema,
+  overseasStockQuotePeriodPriceResponseSchema,
+  overseasStockQuoteSymbolIndexFxPeriodResponseSchema,
+} from '../../src/nhplug/schemas/overseas-stock-quote';
+import {
+  assertNhplugResponse,
+  assertNhplugResponseShape,
+  callNhplug,
+  getNhplugClient,
+  NHPLUG_TEST_GB_IEM_CD,
+  NHPLUG_TEST_GB_SYMBOL_CD,
+  runNhplugLiveOnlyIntegration,
+  setupNhplugRateLimit,
+  TODAY,
+} from '../_helpers/integration-setup';
+
+/** 모의투자에서는 제공되지 않는다 (IGW40019). 운영(NHPLUG_ENV=prod)에서만 검증 가능. */
+const liveOnlyIt = runNhplugLiveOnlyIntegration ? test : test.skip;
+
+describe('Nhplug OverseasStockQuote (운영 전용)', () => {
+  setupNhplugRateLimit();
+
+  liveOnlyIt('current', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () => client.overseasStockQuote.current({ iemCd: NHPLUG_TEST_GB_IEM_CD }));
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockQuoteCurrentPriceResponseSchema);
+  });
+
+  liveOnlyIt('executionTrend', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () =>
+      client.overseasStockQuote.executionTrend({
+        periodType: '2', // 일별
+        reqCnt: '10',
+        iemCd: NHPLUG_TEST_GB_IEM_CD,
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockQuoteExecutionTrendResponseSchema);
+  });
+
+  liveOnlyIt('period', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () =>
+      client.overseasStockQuote.period({
+        iemCd: NHPLUG_TEST_GB_IEM_CD,
+        endDt: TODAY,
+        count: '0030', // 최근 한 달치
+        maxavg: '005',
+        gubun: '3', // 일
+        xtick: '0001',
+        todayCls: '1', // 당일조회
+        marketCls: '1', // 정규장
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockQuotePeriodPriceResponseSchema);
+  });
+
+  liveOnlyIt('symbolIndexFxPeriod', async (ctx) => {
+    const client = await getNhplugClient();
+    const res = await callNhplug(ctx, () =>
+      client.overseasStockQuote.symbolIndexFxPeriod({
+        iemCd: NHPLUG_TEST_GB_SYMBOL_CD,
+        endDt: TODAY,
+        arrayCnt: '0030', // 최근 한 달치
+        maxavg: '005',
+        gubun: '1', // 일
+        todayCls: '0', // 전체조회
+      }),
+    );
+    assertNhplugResponse(res);
+    assertNhplugResponseShape(res.body, overseasStockQuoteSymbolIndexFxPeriodResponseSchema);
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/overseas-stock-schemas.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/overseas-stock-schemas.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  overseasStockInquiryBalanceResponseSchema,
+  overseasStockInquiryDailyTransactionResponseSchema,
+  overseasStockInquiryMarginResponseSchema,
+  overseasStockInquiryPeriodPnlResponseSchema,
+} from '../../src/nhplug/schemas/overseas-stock-inquiry';
+import {
+  overseasStockOrderBuyResponseSchema,
+  overseasStockOrderReservedSubmitResponseSchema,
+} from '../../src/nhplug/schemas/overseas-stock-order';
+import {
+  overseasStockQuoteCurrentPriceResponseSchema,
+  overseasStockQuotePeriodPriceResponseSchema,
+  overseasStockQuoteSymbolIndexFxPeriodResponseSchema,
+} from '../../src/nhplug/schemas/overseas-stock-quote';
+
+describe('NH PLUG 해외주식(gbstock) 응답 스키마', () => {
+  it('빈 봉투(Output 블록 없음)도 통과한다', () => {
+    for (const schema of [
+      overseasStockOrderBuyResponseSchema,
+      overseasStockInquiryBalanceResponseSchema,
+      overseasStockQuoteCurrentPriceResponseSchema,
+    ]) {
+      expect(schema.parse({ rsp_cd: '00000', rsp_msg: '정상처리 되었습니다.', message: null })).toMatchObject({
+        rsp_cd: '00000',
+      });
+    }
+  });
+
+  it('스펙상 `message` 봉투를 파싱한다', () => {
+    const parsed = overseasStockOrderBuyResponseSchema.parse({
+      message: { msg_code: 'XA102', usr_msg: '모의투자 조회가 완료되었습니다', msg_lv_code: 'I', dvlp_msg_yn: 'N' },
+    });
+    expect(parsed.message?.msg_code).toBe('XA102');
+  });
+
+  it('주문 응답의 Output_0 은 객체이며 키 이름을 원문 그대로 유지한다', () => {
+    const parsed = overseasStockOrderBuyResponseSchema.parse({
+      rsp_cd: '00000',
+      Output_0: { amn_tab_cd: '0001', orr_no: 12345 },
+    });
+    expect(parsed.Output_0?.orr_no).toBe(12345);
+
+    const reserved = overseasStockOrderReservedSubmitResponseSchema.parse({
+      Output_0: { bkg_rtn_orr_no: '778899' },
+    });
+    expect(reserved.Output_0?.bkg_rtn_orr_no).toBe(778899);
+  });
+
+  it('블록별 객체/배열 구조가 파이썬 타입과 같다', () => {
+    // balance: Output_0 = 객체(잔고 요약), Output_1 = 배열(종목별)
+    const balance = overseasStockInquiryBalanceResponseSchema.parse({
+      Output_0: { tot_aet_amt: 1000 },
+      Output_1: [{ iem_cd: 'AAPL', cns_bse_bnc_qty: 3 }],
+    });
+    expect(balance.Output_0?.tot_aet_amt).toBe(1000);
+    expect(balance.Output_1?.[0]?.iem_cd).toBe('AAPL');
+
+    // dailyTransaction: Output_0 = 배열(내역), Output_1 = 객체(요약) — balance 와 순서가 반대다.
+    const daily = overseasStockInquiryDailyTransactionResponseSchema.parse({
+      Output_0: [{ trd_dt: '20260822' }],
+      Output_1: { amt_sum: 10 },
+    });
+    expect(daily.Output_0?.[0]?.trd_dt).toBe('20260822');
+    expect(daily.Output_1?.amt_sum).toBe(10);
+
+    // periodPnl: Output_0 = 객체(요약), Output_1 = 배열(일자별)
+    const pnl = overseasStockInquiryPeriodPnlResponseSchema.parse({
+      Output_0: { byn_qty_sum: 1 },
+      Output_1: [{ orr_dt: '20260822' }],
+    });
+    expect(pnl.Output_0?.byn_qty_sum).toBe(1);
+    expect(pnl.Output_1?.[0]?.orr_dt).toBe('20260822');
+
+    // margin: Output_0 만 있고 배열이다.
+    const margin = overseasStockInquiryMarginResponseSchema.parse({ Output_0: [{ cur_cd: 'USD', dca: 10 }] });
+    expect(margin.Output_0).toHaveLength(1);
+
+    // period: Output_0 / Output_1 둘 다 배열이다.
+    const period = overseasStockQuotePeriodPriceResponseSchema.parse({
+      Output_0: [{ iem_cd: 'AAPL' }],
+      Output_1: [{ trade_date: '20260822', close_prc: 231.5 }],
+    });
+    expect(period.Output_1?.[0]?.close_prc).toBe(231.5);
+
+    // symbolIndexFxPeriod: Output_0 = 객체, Output_1 = 배열
+    const fx = overseasStockQuoteSymbolIndexFxPeriodResponseSchema.parse({
+      Output_0: { iem_cd: 'SPX' },
+      Output_1: [{ bsop_date: '20260822', vol: 12 }],
+    });
+    expect(fx.Output_0?.iem_cd).toBe('SPX');
+    expect(fx.Output_1?.[0]?.vol).toBe(12);
+  });
+
+  it('숫자 필드가 문자열로 와도 숫자로 강제 변환한다', () => {
+    const parsed = overseasStockQuoteCurrentPriceResponseSchema.parse({
+      Output_0: { iem_cd: 'AAPL', trdprc: '231.55', acvol: '1234567' },
+    });
+    expect(parsed.Output_0?.trdprc).toBe(231.55);
+    expect(parsed.Output_0?.acvol).toBe(1234567);
+  });
+
+  it('값 없는 숫자 필드의 빈 문자열은 null 로 접는다', () => {
+    const parsed = overseasStockQuoteSymbolIndexFxPeriodResponseSchema.parse({
+      Output_0: { iem_cd: 'SPX', ovrs_prpr: '', acml_vol: '' },
+    });
+    expect(parsed.Output_0?.ovrs_prpr).toBeNull();
+    expect(parsed.Output_0?.acml_vol).toBeNull();
+  });
+
+  it('문서에 없는 실서버 필드는 passthrough 로 살아남는다', () => {
+    const parsed = overseasStockQuoteCurrentPriceResponseSchema.parse({
+      undocumented_top_level: 'keep',
+      Output_0: { iem_cd: 'AAPL', undocumented_field: 'keep' },
+    });
+    expect(parsed).toMatchObject({ undocumented_top_level: 'keep' });
+    expect(parsed.Output_0).toMatchObject({ undocumented_field: 'keep' });
+  });
+
+  it('모든 필드가 optional 이라 부분 응답도 통과한다', () => {
+    expect(overseasStockInquiryMarginResponseSchema.parse({ Output_0: [{}] }).Output_0?.[0]).toEqual({});
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/readme-samples.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/readme-samples.test.ts
@@ -15,8 +15,8 @@ const jsonResponse = (body: unknown): Response =>
 
 describe('README NH PLUG samples', () => {
   it('quick start: NhplugAuth.generate() -> NhplugClient -> 계좌목록 -> 국내주식 현재가', async () => {
-    const appKey = 'app-key';
-    const secretKey = 'secret-key';
+    const credentials = { appKey: 'app-key', secretKey: 'secret-key' } as const;
+    const { appKey, secretKey } = credentials;
 
     const fetchMock: typeof fetch = async (input) => {
       const url = String(input);

--- a/packages/cluefin-openapi-ts/tests/nhplug/readme-samples.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/readme-samples.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+
+import { silentLogger } from '../../src/core/logger';
+import { NhplugAuth } from '../../src/nhplug/auth';
+import { NhplugClient } from '../../src/nhplug/client';
+import { NhplugSocketClient } from '../../src/nhplug/socket-client';
+
+/**
+ * README 의 NH PLUG 예제를 그대로 실행해 메서드/필드 이름이 실제 API 와 어긋나지 않는지
+ * 확인한다. 타입은 `tsc`(`tests` 포함) 가, 런타임 이름은 이 테스트가 검증한다.
+ */
+
+const jsonResponse = (body: unknown): Response =>
+  new Response(JSON.stringify(body), { status: 200, headers: { 'content-type': 'application/json' } });
+
+describe('README NH PLUG samples', () => {
+  it('quick start: NhplugAuth.generate() -> NhplugClient -> 계좌목록 -> 국내주식 현재가', async () => {
+    const appKey = 'app-key';
+    const secretKey = 'secret-key';
+
+    const fetchMock: typeof fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith('/oauth2/token')) {
+        return jsonResponse({
+          access_token: 'issued-token',
+          scope: 'oob',
+          token_type: 'Bearer',
+          expires_in: 86400,
+        });
+      }
+      if (url.endsWith('/n2/acctinfo')) {
+        return jsonResponse({
+          rsp_cd: '00000',
+          rsp_msg: '정상',
+          Output_0: [{ acct_no: '00000000000', acct_type: '03' }],
+        });
+      }
+      return jsonResponse({ rsp_cd: 'XA102', rsp_msg: '모의투자 조회가 완료되었습니다', Output_0: {} });
+    };
+
+    // 토큰 발급은 운영 도메인 전용이라 NhplugAuth 는 env 를 받지 않는다.
+    const auth = new NhplugAuth({ appKey, secretKey, fetchImpl: fetchMock });
+    const { accessToken } = await auth.generate();
+
+    // env: 'dev'(기본) = 모의투자(moapi), 'prod' = 운영(실주문)
+    const client = new NhplugClient({
+      token: accessToken,
+      appKey,
+      secretKey,
+      env: 'dev',
+      fetchImpl: fetchMock,
+      logger: silentLogger,
+    });
+
+    const accounts = await client.common.getAccountList({});
+    const account = accounts.body.output0?.[0];
+    const actNo = account?.acctNo;
+
+    expect(actNo).toBe('00000000000');
+    expect(account?.acctType).toBe('03');
+
+    const price = await client.krstockQuote.currentPrice({ marketCd: 'KRX', iemCd: '005930' });
+    expect(price.body).toBeDefined();
+
+    const balance = await client.krstockInquiry.balance({
+      actNo,
+      bncBseCd: '1', // 주식관련 총 평가(체결기준)
+      ltgAotDitCd: '9', // 전체
+      aetBse: '1', // 순자산
+      qutDitCd: 'UNT', // 통합시세
+    });
+    expect(balance.body).toBeDefined();
+  });
+
+  it('websocket sample: subscribe with a tr_cd channel code', () => {
+    const socket = new NhplugSocketClient({ token: 'issued-token', env: 'dev', market: 'kr' });
+
+    expect(socket.env).toBe('dev');
+    expect(socket.market).toBe('kr');
+    // 구독 메시지는 header.token + body.tr_cd/tr_key 평문 JSON
+    const message = socket.parseMessage(
+      JSON.stringify({ header: { tr_cd: 'mc', tr_key: '005930' }, body: { iem_cd: '005930' } }),
+    );
+    expect(message.messageType).toBe('DATA');
+    expect(message.trId).toBe('mc');
+    expect(message.body).toEqual({ iem_cd: '005930' });
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/schemas/krstock.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/schemas/krstock.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import { accountListResponseSchema, websocketCloseResponseSchema } from '../../../src/nhplug/schemas/common';
+import {
+  krStockInquiryBalanceResponseSchema,
+  krStockInquiryDailyOrderExecutionResponseSchema,
+  krStockInquiryRightsScheduledResponseSchema,
+} from '../../../src/nhplug/schemas/krstock-inquiry';
+import {
+  krStockOrderCashBuyResponseSchema,
+  krStockOrderReservedCancelResponseSchema,
+} from '../../../src/nhplug/schemas/krstock-order';
+import {
+  krStockQuoteCurrentExecutionResponseSchema,
+  krStockQuoteEtfCurrentResponseSchema,
+} from '../../../src/nhplug/schemas/krstock-quote';
+
+describe('nhplug common schemas', () => {
+  it('parses the account list with its Output_0 array', () => {
+    const parsed = accountListResponseSchema.parse({
+      rsp_cd: '00000',
+      rsp_msg: '정상',
+      cust_no: '123',
+      Output_0: [{ acct_no: '12345678901', acct_type: '03' }],
+    });
+
+    expect(parsed.Output_0?.[0]?.acct_no).toBe('12345678901');
+  });
+
+  it('accepts a websocket close response that only carries the envelope', () => {
+    expect(websocketCloseResponseSchema.parse({ rsp_cd: '00000', rsp_msg: '정상' })).toEqual({
+      rsp_cd: '00000',
+      rsp_msg: '정상',
+    });
+  });
+});
+
+describe('nhplug krstock order schemas', () => {
+  it('parses a cash-buy acknowledgement and coerces numeric strings', () => {
+    const parsed = krStockOrderCashBuyResponseSchema.parse({
+      rsp_cd: '00000',
+      rsp_msg: '정상',
+      message: null,
+      Output_0: { orr_gno_tab_cd: '0001', mkt_orr_no: '123456', orr_qty1: 10 },
+    });
+
+    // 스펙은 int 지만 실서버가 문자열을 줄 수 있어 coerce 로 받는다.
+    expect(parsed.Output_0?.mkt_orr_no).toBe(123456);
+    expect(parsed.Output_0?.orr_qty1).toBe(10);
+  });
+
+  it('keeps undocumented live fields through passthrough', () => {
+    const parsed = krStockOrderReservedCancelResponseSchema.parse({
+      rsp_cd: '00000',
+      Output_0: { act_no: '12345678901', bkg_orr_no: 7, undocumented_field: 'kept' },
+    }) as { Output_0?: Record<string, unknown> };
+
+    expect(parsed.Output_0?.undocumented_field).toBe('kept');
+  });
+
+  it('tolerates a response with no Output block at all', () => {
+    expect(() => krStockOrderCashBuyResponseSchema.parse({ rsp_cd: '00000', rsp_msg: '정상' })).not.toThrow();
+  });
+});
+
+describe('nhplug krstock inquiry schemas', () => {
+  it('reads balance as Output_0 object + Output_1 array', () => {
+    const parsed = krStockInquiryBalanceResponseSchema.parse({
+      rsp_cd: '00000',
+      Output_0: { dca: 1_000_000, act_no: '12345678901' },
+      Output_1: [{ iem_cd: '005930', iem_nm: '삼성전자', now_pr: 70_000 }],
+    });
+
+    expect(parsed.Output_0?.dca).toBe(1_000_000);
+    expect(parsed.Output_1?.[0]?.iem_cd).toBe('005930');
+  });
+
+  it('keeps int|str union fields as-is when they are not numeric', () => {
+    const parsed = krStockInquiryBalanceResponseSchema.parse({
+      rsp_cd: '00000',
+      Output_0: { fc_dca: '', orr_pbl_amt: 5000 },
+    });
+
+    expect(parsed.Output_0?.fc_dca).toBe('');
+    expect(parsed.Output_0?.orr_pbl_amt).toBe(5000);
+  });
+
+  it('accepts dailyOrderExecution Output_0 as both object and array', () => {
+    const asObject = krStockInquiryDailyOrderExecutionResponseSchema.parse({
+      rsp_cd: 'XA102',
+      Output_0: { cus_fnm: '홍길동' },
+    });
+    const asArray = krStockInquiryDailyOrderExecutionResponseSchema.parse({
+      rsp_cd: 'XA102',
+      Output_0: [{ cus_fnm: '홍길동' }],
+    });
+
+    expect(Array.isArray(asObject.Output_0)).toBe(false);
+    expect(Array.isArray(asArray.Output_0)).toBe(true);
+  });
+
+  it('reads rightsScheduled as a bare Output_0 array', () => {
+    const parsed = krStockInquiryRightsScheduledResponseSchema.parse({
+      rsp_cd: '00000',
+      Output_0: [{ iem_cd: '005930' }],
+    });
+
+    expect(parsed.Output_0).toHaveLength(1);
+  });
+});
+
+describe('nhplug krstock quote schemas', () => {
+  it('reads currentExecution as Output_0 array + Output_1 summary object', () => {
+    const parsed = krStockQuoteCurrentExecutionResponseSchema.parse({
+      rsp_cd: '00000',
+      Output_0: [{ iem_cd: '005930' }, { iem_cd: '005930' }],
+      Output_1: { iem_cd: '005930' },
+    });
+
+    expect(parsed.Output_0).toHaveLength(2);
+    expect(Array.isArray(parsed.Output_1)).toBe(false);
+  });
+
+  it('reads etfCurrent five Output blocks with only Output_1 as an array', () => {
+    const parsed = krStockQuoteEtfCurrentResponseSchema.parse({
+      rsp_cd: '00000',
+      Output_0: {},
+      Output_1: [{}],
+      Output_2: {},
+      Output_3: {},
+      Output_4: {},
+    });
+
+    expect(Array.isArray(parsed.Output_1)).toBe(true);
+    expect(Array.isArray(parsed.Output_3)).toBe(false);
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/socket-client.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/socket-client.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import { BaseWebSocketClient, type WebSocketEvent } from '../../src/core/websocket';
+import { NhplugSocketClient } from '../../src/nhplug/socket-client';
+
+const defaultOptions = { token: 'test_access_token' };
+
+const urlOf = (client: NhplugSocketClient): string => (client as unknown as { url: string }).url;
+
+const buildMsg = (client: NhplugSocketClient, trCd: string, trKey: string, trType: '1' | '2') =>
+  JSON.parse(
+    (
+      client as unknown as { buildSubscriptionMessage: (a: string, b: string, c: string) => string }
+    ).buildSubscriptionMessage.call(client, trCd, trKey, trType),
+  );
+
+interface MutableClient {
+  ws: { sent: string[]; send: (message: string) => void; close: () => void } | null;
+  _connected: boolean;
+  handleMessage(raw: string): void;
+}
+
+const attachSocket = (client: NhplugSocketClient): NonNullable<MutableClient['ws']> => {
+  const socket = {
+    sent: [] as string[],
+    send(message: string) {
+      this.sent.push(message);
+    },
+    close() {
+      this.sent.push('closed');
+    },
+  };
+  const mutable = client as unknown as MutableClient;
+  mutable.ws = socket;
+  mutable._connected = true;
+  return socket;
+};
+
+describe('NhplugSocketClient', () => {
+  describe('initialization', () => {
+    it('extends BaseWebSocketClient and starts disconnected', () => {
+      const client = new NhplugSocketClient(defaultOptions);
+      expect(client).toBeInstanceOf(BaseWebSocketClient);
+      expect(client.connected).toBe(false);
+      expect(client.subscriptions.size).toBe(0);
+    });
+
+    it('defaults to dev + kr', () => {
+      const client = new NhplugSocketClient(defaultOptions);
+      expect(client.env).toBe('dev');
+      expect(client.market).toBe('kr');
+    });
+  });
+
+  describe('URL selection across env x market', () => {
+    it('uses the domestic prod URL for prod + kr', () => {
+      const client = new NhplugSocketClient({ ...defaultOptions, env: 'prod', market: 'kr' });
+      expect(urlOf(client)).toBe('wss://api.nhplug.com:7070');
+    });
+
+    it('uses the overseas prod URL for prod + gb', () => {
+      const client = new NhplugSocketClient({ ...defaultOptions, env: 'prod', market: 'gb' });
+      expect(urlOf(client)).toBe('wss://api.nhplug.com:7080');
+    });
+
+    it('uses the single moapi URL for dev regardless of market', () => {
+      expect(urlOf(new NhplugSocketClient({ ...defaultOptions, env: 'dev', market: 'kr' }))).toBe(
+        'wss://moapi.nhplug.com:17070',
+      );
+      expect(urlOf(new NhplugSocketClient({ ...defaultOptions, env: 'dev', market: 'gb' }))).toBe(
+        'wss://moapi.nhplug.com:17070',
+      );
+    });
+  });
+
+  describe('buildSubscriptionMessage', () => {
+    it('carries the access token in header.token with tr_type 1 for subscribe', () => {
+      const client = new NhplugSocketClient(defaultOptions);
+      const parsed = buildMsg(client, 'mc', '005930', '1');
+
+      expect(parsed).toEqual({
+        header: { token: 'test_access_token', tr_type: '1' },
+        body: { tr_cd: 'mc', tr_key: '005930' },
+      });
+      // KIS 와 달리 approval key 는 존재하지 않는다.
+      expect(parsed.header.approval_key).toBeUndefined();
+    });
+
+    it('uses tr_type 2 for unsubscribe', () => {
+      const client = new NhplugSocketClient(defaultOptions);
+      const parsed = buildMsg(client, 'RC', 'AAPL', '2');
+
+      expect(parsed).toEqual({
+        header: { token: 'test_access_token', tr_type: '2' },
+        body: { tr_cd: 'RC', tr_key: 'AAPL' },
+      });
+    });
+
+    it('sends the built messages through subscribe/unsubscribe', async () => {
+      const client = new NhplugSocketClient(defaultOptions);
+      const socket = attachSocket(client);
+
+      await client.subscribe('mc', '005930');
+      expect(client.subscriptions.get('mc:005930')).toBe('005930');
+      await client.unsubscribe('mc', '005930');
+      expect(client.subscriptions.size).toBe(0);
+
+      expect(socket.sent.map((raw) => JSON.parse(raw))).toEqual([
+        { header: { token: 'test_access_token', tr_type: '1' }, body: { tr_cd: 'mc', tr_key: '005930' } },
+        { header: { token: 'test_access_token', tr_type: '2' }, body: { tr_cd: 'mc', tr_key: '005930' } },
+      ]);
+    });
+  });
+
+  describe('parseMessage', () => {
+    const client = new NhplugSocketClient(defaultOptions);
+
+    it('parses a JSON push into tr_cd / tr_key / body', () => {
+      const raw = JSON.stringify({
+        header: { tr_cd: 'mc', tr_key: '005930' },
+        body: { stck_prpr: '70000', cntg_vol: '10' },
+      });
+      const msg = client.parseMessage(raw);
+
+      expect(msg.messageType).toBe('DATA');
+      expect(msg.trId).toBe('mc');
+      expect(msg.trKey).toBe('005930');
+      expect(msg.body).toEqual({ stck_prpr: '70000', cntg_vol: '10' });
+      expect(msg.encrypted).toBe(false);
+      expect(msg.raw).toBe(raw);
+    });
+
+    it('treats a push without tr_cd as SYSTEM', () => {
+      const raw = JSON.stringify({ header: { rsp_cd: '00000' }, body: {} });
+      expect(client.parseMessage(raw).messageType).toBe('SYSTEM');
+    });
+
+    it('treats non-JSON and non-object payloads as SYSTEM', () => {
+      expect(client.parseMessage('not json at all').messageType).toBe('SYSTEM');
+      expect(client.parseMessage('[1,2,3]').messageType).toBe('SYSTEM');
+      expect(client.parseMessage('"plain"').messageType).toBe('SYSTEM');
+    });
+
+    it('drops a non-object body', () => {
+      const raw = JSON.stringify({ header: { tr_cd: 'mc', tr_key: '005930' }, body: 'oops' });
+      const msg = client.parseMessage(raw);
+      expect(msg.messageType).toBe('DATA');
+      expect(msg.body).toBeUndefined();
+    });
+  });
+
+  describe('handleMessage', () => {
+    it('emits a data event carrying tr_cd / tr_key / body', () => {
+      const client = new NhplugSocketClient(defaultOptions);
+      const events: WebSocketEvent[] = [];
+      client.on('data', (event) => events.push(event));
+
+      const raw = JSON.stringify({
+        header: { tr_cd: 'RC', tr_key: 'AAPL' },
+        body: { last: '190.11' },
+      });
+      (client as unknown as MutableClient).handleMessage(raw);
+
+      expect(events).toEqual([{ eventType: 'data', trId: 'RC', trKey: 'AAPL', body: { last: '190.11' }, raw }]);
+    });
+
+    it('emits a system event for messages without tr_cd', () => {
+      const client = new NhplugSocketClient(defaultOptions);
+      const events: WebSocketEvent[] = [];
+      client.on('system', (event) => events.push(event));
+      client.on('data', () => {
+        throw new Error('should not emit data');
+      });
+
+      const raw = JSON.stringify({ header: { rsp_cd: '00000', rsp_msg: 'OK' } });
+      (client as unknown as MutableClient).handleMessage(raw);
+
+      expect(events).toEqual([{ eventType: 'system', raw }]);
+    });
+  });
+});

--- a/packages/cluefin-openapi-ts/tests/nhplug/token-cache.test.ts
+++ b/packages/cluefin-openapi-ts/tests/nhplug/token-cache.test.ts
@@ -1,0 +1,111 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  FileTokenCacheStore,
+  MemoryTokenCacheStore,
+  nhplugTokenCacheFileName,
+  type TokenCacheEntry,
+} from '../../src/nhplug/token-cache';
+
+const entry: TokenCacheEntry = {
+  accessToken: 'access-token',
+  scope: 'oob',
+  tokenType: 'Bearer',
+  expiresIn: 86_400,
+  cachedAt: '2026-08-22T12:00:00',
+};
+
+let tempDirs: string[] = [];
+
+const createCachePath = async (): Promise<string> => {
+  const dir = await mkdtemp(join(tmpdir(), 'cluefin-openapi-nhplug-token-cache-'));
+  tempDirs.push(dir);
+  return join(dir, nhplugTokenCacheFileName('app-key'));
+};
+
+afterEach(async () => {
+  await Promise.all(tempDirs.map((dir) => rm(dir, { recursive: true, force: true })));
+  tempDirs = [];
+});
+
+describe('nhplugTokenCacheFileName', () => {
+  it('scopes the cache file by app_key only (no env), matching the Python TokenManager', () => {
+    // sha256('app-key')[:8] — 파이썬 `_cache_file_name` 과 동일한 규칙
+    expect(nhplugTokenCacheFileName('app-key')).toBe('.nhplug_token_cache_2924a27d.json');
+    expect(nhplugTokenCacheFileName()).toBe('.nhplug_token_cache.json');
+    expect(nhplugTokenCacheFileName('other-key')).not.toBe(nhplugTokenCacheFileName('app-key'));
+  });
+});
+
+describe('MemoryTokenCacheStore', () => {
+  it('stores and clears an in-memory token entry', async () => {
+    const store = new MemoryTokenCacheStore();
+
+    expect(await store.get()).toBeNull();
+    await store.set(entry);
+    expect(await store.get()).toEqual(entry);
+    await store.clear();
+    expect(await store.get()).toBeNull();
+  });
+});
+
+describe('FileTokenCacheStore', () => {
+  it('returns null when the cache file is missing', async () => {
+    expect(await new FileTokenCacheStore(await createCachePath()).get()).toBeNull();
+  });
+
+  it('reads the JSON written by the Python TokenManager', async () => {
+    const filePath = await createCachePath();
+    await writeFile(
+      filePath,
+      JSON.stringify({
+        token: {
+          access_token: 'cached-token',
+          scope: 'oob',
+          token_type: 'Bearer',
+          expires_in: 86400,
+        },
+        cached_at: '2026-08-22T12:00:00',
+      }),
+      'utf-8',
+    );
+
+    expect(await new FileTokenCacheStore(filePath).get()).toEqual({
+      accessToken: 'cached-token',
+      scope: 'oob',
+      tokenType: 'Bearer',
+      expiresIn: 86_400,
+      cachedAt: '2026-08-22T12:00:00',
+    });
+  });
+
+  it('writes the Python-compatible cache format', async () => {
+    const filePath = await createCachePath();
+    await new FileTokenCacheStore(filePath).set(entry);
+
+    expect(JSON.parse(await readFile(filePath, 'utf-8'))).toEqual({
+      token: {
+        access_token: 'access-token',
+        scope: 'oob',
+        token_type: 'Bearer',
+        expires_in: 86_400,
+      },
+      cached_at: '2026-08-22T12:00:00',
+    });
+  });
+
+  it('round-trips its own written file', async () => {
+    const filePath = await createCachePath();
+    const store = new FileTokenCacheStore(filePath);
+
+    await store.set(entry);
+    expect(await store.get()).toEqual(entry);
+
+    await store.clear();
+    expect(await store.get()).toBeNull();
+    await expect(store.clear()).resolves.toBeUndefined();
+  });
+});

--- a/packages/cluefin-openapi/src/cluefin_openapi/nhplug/_common_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/nhplug/_common_types.py
@@ -13,11 +13,7 @@ class AccountItem(BaseModel):
 
 
 class AccountList(BaseModel):
-    """계좌 목록 조회 (`POST /n2/acctinfo`) 응답.
-
-    이 API 의 응답 예시에는 rsp_cd/rsp_msg 없이 Output_0 만 내려오는 경우가
-    있어 봉투 필드를 Optional 로 둔다.
-    """
+    """계좌 목록 조회 (`POST /n2/acctinfo`) 응답."""
 
     model_config = ConfigDict(extra="allow")
 

--- a/packages/cluefin-openapi/src/cluefin_openapi/nhplug/_krstock_order_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/nhplug/_krstock_order_types.py
@@ -86,7 +86,7 @@ class KrStockOrderReservedOrderOutput(BaseModel):
     lon_dt: str | None = Field(default=None, description="대출일자 / 길이 8 / 입력값 표시 (YYYYMMDD)")
     orr_qty: str | None = Field(default=None, description="주문수량 / 길이 18 / 입력값 표시")
     orr_uit_pr: str | None = Field(default=None, description="주문단가 / 길이 18 / 입력값 표시")
-    aca_tel_no: str | None = Field(default=None, description="연락처전화번호 / 길이 20 / 입력값 표시 — 개인정보")
+    aca_tel_no: str | None = Field(default=None, description="연락처전화번호 / 길이 20 / 입력값 표시")
     bkg_orr_tp_cd: str | None = Field(default=None, description="예약주문유형코드 / 길이 1 / 입력값 표시")
     bkg_orr_sta_dt: str | None = Field(default=None, description="예약주문시작일자 / 길이 8 / 입력값 표시 (YYYYMMDD)")
     bkg_orr_end_dt: str | None = Field(default=None, description="예약주문종료일자 / 길이 8 / 입력값 표시 (YYYYMMDD)")
@@ -94,9 +94,7 @@ class KrStockOrderReservedOrderOutput(BaseModel):
     end_pr_cmp_ftw_amt: str | None = Field(default=None, description="종가대비등락폭금액 / 길이 18 / 입력값 표시")
     orr_pr_rge_hlm_pr: str | None = Field(default=None, description="주문가격범위상한가 / 길이 18 / 입력값 표시")
     orr_pr_rge_llm_pr: str | None = Field(default=None, description="주문가격범위하한가 / 길이 18 / 입력값 표시")
-    pwd: str | None = Field(
-        default=None, description="비밀번호 / 길이 8 / 입력값 표시 — 민감정보(계좌 비밀번호), 로그·출력에 남기지 말 것"
-    )
+    pwd: str | None = Field(default=None, description="비밀번호 / 길이 8 / 입력값 표시")
 
 
 class KrStockOrderReservedOrder(NHPlugAssetHttpBody):

--- a/packages/cluefin-openapi/src/cluefin_openapi/nhplug/_krstock_quote_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/nhplug/_krstock_quote_types.py
@@ -13,7 +13,7 @@ class KrStockQuoteCurrentPriceOutput(BaseModel):
     stck_prpr: int | None = Field(default=None, description="현재가 / 길이 10")
     prdy_vrss_sign: str | None = Field(
         default=None,
-        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     prdy_vrss: int | None = Field(default=None, description="등락폭 / 길이 10")
     prdy_ctrt: float | None = Field(default=None, description="등락률 / 길이 5.2")
@@ -207,7 +207,7 @@ class KrStockQuoteCurrentPriceTickOutput(BaseModel):
     stck_prpr: int | None = Field(default=None, description="현재가 / 길이 10")
     prdy_vrss_sign: str | None = Field(
         default=None,
-        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     prdy_vrss: int | None = Field(default=None, description="등락폭 / 길이 10")
     askp: int | None = Field(default=None, description="매도호가 / 길이 10")
@@ -235,7 +235,7 @@ class KrStockQuoteCurrentPriceExpectedOutput(BaseModel):
     antc_cnpr: int | float | str | None = Field(default=None, description="예상체결가 / 길이 10")
     antc_cntg_sign: str | None = Field(
         default=None,
-        description="예상체결부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="예상체결부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     antc_cntg_vrss: int | float | str | None = Field(default=None, description="예상체결등락폭 / 길이 10")
     antc_prdy_ctrt: int | float | str | None = Field(default=None, description="예상체결등락률 / 길이 5.2")
@@ -248,7 +248,7 @@ class KrStockQuoteCurrentPriceExpectedOutput(BaseModel):
     ovtm_untp_vol: int | float | str | None = Field(default=None, description="ECN체결수량 / 길이 12")
     ovtm_antc_sign: str | None = Field(
         default=None,
-        description="ECN대비예상체결부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="ECN대비예상체결부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     ovtm_antc_vrss: int | float | str | None = Field(default=None, description="ECN대비예상체결등락폭 / 길이 10")
     ovtm_antc_ctrt: int | float | str | None = Field(default=None, description="ECN대비예상체결등락률 / 길이 5.2")
@@ -285,7 +285,7 @@ class KrStockQuoteCurrentExecutionTickOutput(BaseModel):
     stck_prpr: int | None = Field(default=None, description="현재가 / 길이 8")
     prdy_vrss_sign: str | None = Field(
         default=None,
-        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     prdy_vrss: int | None = Field(default=None, description="등락폭 / 길이 8")
     prdy_ctrt: float | None = Field(default=None, description="등락률 / 길이 5.2")
@@ -322,7 +322,7 @@ class KrStockQuoteCurrentExecutionSummaryOutput(BaseModel):
     stck_prpr: int | None = Field(default=None, description="현재가 / 길이 8")
     prdy_vrss_sign: str | None = Field(
         default=None,
-        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     prdy_vrss: int | None = Field(default=None, description="등락폭 / 길이 8")
     acml_vol: int | None = Field(default=None, description="전체거래량 / 길이 12")
@@ -410,7 +410,7 @@ class KrStockQuoteCurrentInvestorOutput(BaseModel):
     stck_prpr: int | None = Field(default=None, description="종가 / 길이 7")
     prdy_vrss_sign: str | None = Field(
         default=None,
-        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     prdy_vrss: int | None = Field(default=None, description="등락폭 / 길이 6")
     prdy_ctrt: float | None = Field(default=None, description="등락률 / 길이 5.2")
@@ -586,7 +586,7 @@ class KrStockQuoteAfterHoursCurrentOutput(BaseModel):
     ovtm_untp_prpr: int | None = Field(default=None, description="체결가 / 길이 10")
     prdy_vrss_sign: str | None = Field(
         default=None,
-        description="체결등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="체결등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     ovtm_prdy_vrss: int | None = Field(default=None, description="체결등락폭 / 길이 10")
     ovtm_prdy_ctrt: float | None = Field(default=None, description="체결등락률 / 길이 5.2")
@@ -695,7 +695,7 @@ class KrStockQuoteAfterHoursCurrentRegularOutput(BaseModel):
     for_rate: float | str | None = Field(default=None, description="외국인지분율 / 길이 5.2")
     prdy_vrss_sign: str | None = Field(
         default=None,
-        description="체결등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="체결등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     prdy_vrss: int | str | None = Field(default=None, description="등락폭 / 길이 10")
     prdy_ctrt: float | str | None = Field(default=None, description="등락률 / 길이 5.2")
@@ -724,11 +724,7 @@ class KrStockQuoteAfterHoursCurrent(NHPlugAssetHttpBody):
 
 
 class KrStockQuoteCurrentAfterHoursDailyTickOutput(BaseModel):
-    """주식현재가 시간외일자별주가 시간외 체결 상세 (Output_0 배열의 각 항목).
-
-    스펙의 필드명과 description 이 서로 어긋나 있다(예: `shrn_iscd` 설명이
-    "고가"). 원문 description 을 그대로 보존한다.
-    """
+    """주식현재가 시간외일자별주가 시간외 체결 상세 (Output_0 배열의 각 항목)."""
 
     model_config = ConfigDict(extra="allow")
 
@@ -787,7 +783,7 @@ class KrStockQuoteCurrentAfterHoursExecutionOutput(BaseModel):
     stck_prpr: int | None = Field(default=None, description="현재가 / 길이 9")
     prdy_vrss_sign: str | None = Field(
         default=None,
-        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     prdy_vrss: int | None = Field(default=None, description="등락폭 / 길이 9")
     prdy_ctrt: float | None = Field(default=None, description="등락률 / 길이 5.2")
@@ -823,7 +819,7 @@ class KrStockQuoteAfterHoursExpectedOutput(BaseModel):
     stck_prpr: int | None = Field(default=None, description="현재가 / 길이 9")
     prdy_vrss_sign: str | None = Field(
         default=None,
-        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)",
+        description="등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)",
     )
     prdy_vrss: int | None = Field(default=None, description="등락폭 / 길이 9")
     prdy_ctrt: float | None = Field(default=None, description="등락률 / 길이 5.2")

--- a/packages/cluefin-openapi/src/cluefin_openapi/nhplug/_overseas_stock_order_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/nhplug/_overseas_stock_order_types.py
@@ -15,8 +15,7 @@ class OverseasStockOrderOutput(BaseModel):
 class OverseasStockOrderBuy(NHPlugAssetHttpBody):
     """해외주식 주문매수 (`POST /gbstock/order/v1/buy`) 응답.
 
-    gbstock 스펙의 응답 봉투는 `Output_0` + `message` 이며 rsp_cd/rsp_msg 가
-    명시돼 있지 않다. 블록은 데이터가 있을 때만 내려오므로 모두 Optional.
+    블록은 데이터가 있을 때만 내려오므로 모두 Optional.
     """
 
     output_0: OverseasStockOrderOutput | None = Field(default=None, alias="Output_0", description="주문 접수 결과")

--- a/packages/cluefin-openapi/src/cluefin_openapi/nhplug/_overseas_stock_quote_types.py
+++ b/packages/cluefin-openapi/src/cluefin_openapi/nhplug/_overseas_stock_quote_types.py
@@ -19,7 +19,7 @@ class OverseasStockQuoteCurrentPriceOutput(BaseModel):
     netchng_cls: str | None = Field(
         default=None,
         description=(
-            "전일대비구분 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)"
+            "전일대비구분 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)"
         ),
     )
     netchng: float | None = Field(default=None, description="전일대비 / 길이 17")
@@ -129,7 +129,7 @@ class OverseasStockQuoteExecutionTrendOutput(BaseModel):
     netchng_cls: str | None = Field(
         default=None,
         description=(
-            "전일대비구분 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)"
+            "전일대비구분 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)"
         ),
     )
     netchng: float | None = Field(default=None, description="전일대비가 / 길이 17")
@@ -173,7 +173,7 @@ class OverseasStockQuotePeriodPriceOutput(BaseModel):
     trdprc: float | None = Field(default=None, description="현재가 / 길이 17")
     netchng_cls: str | None = Field(
         default=None,
-        description=("등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)"),
+        description=("등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)"),
     )
     netchng: float | None = Field(default=None, description="대비 / 길이 17")
     pctchng: float | None = Field(default=None, description="대비율 / 길이 8")
@@ -231,7 +231,7 @@ class OverseasStockQuotePeriodPriceVolumeOutput(BaseModel):
     movalue: float | None = Field(default=None, description="변동거래대금 / 길이 17")
     netchng_cls: str | None = Field(
         default=None,
-        description=("등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)"),
+        description=("등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)"),
     )
     bsop_date: str | None = Field(default=None, description="영업일 / 길이 8 / YYYYMMDD")
 
@@ -272,7 +272,7 @@ class OverseasStockQuoteSymbolIndexFxPeriodOutput(BaseModel):
     ovrs_prpr: float | None = Field(default=None, description="현재가 / 길이 10")
     prdy_vrss_sign: str | None = Field(
         default=None,
-        description=("등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보함+리버스(기세)"),
+        description=("등락부호 / 길이 1 / 1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)"),
     )
     prdy_vrss: float | None = Field(default=None, description="대비 / 길이 10")
     prdy_ctrt: float | None = Field(default=None, description="대비율 / 길이 10")

--- a/packages/cluefin-openapi/tests/nhplug/test_krstock_quote_unit.py
+++ b/packages/cluefin-openapi/tests/nhplug/test_krstock_quote_unit.py
@@ -699,3 +699,39 @@ class TestEtfComponents:
             )
             with pytest.raises(NHPlugAPIError, match="IGW40018"):
                 client.krstock_quote.etf_components(iem_cd="999999")
+
+
+class TestFieldDescriptions:
+    def test_price_change_sign_legend_spells_보합(self):
+        import inspect
+
+        from pydantic import BaseModel
+
+        from cluefin_openapi.nhplug import _krstock_quote_types as types_module
+
+        legends = []
+        for _, model in inspect.getmembers(types_module, inspect.isclass):
+            if not (issubclass(model, BaseModel) and model.__module__ == types_module.__name__):
+                continue
+            for field in model.model_fields.values():
+                description = field.description or ""
+                assert "보함" not in description
+                if "리버스(기세)" in description:
+                    legends.append(description)
+
+        assert legends
+        for legend in legends:
+            assert legend.endswith("1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)")
+
+    def test_after_hours_daily_tick_descriptions_match_spec(self):
+        from cluefin_openapi.nhplug._krstock_quote_types import KrStockQuoteCurrentAfterHoursDailyTickOutput
+
+        fields = KrStockQuoteCurrentAfterHoursDailyTickOutput.model_fields
+        assert {name: field.description for name, field in fields.items()} == {
+            "qry_date": "일자 / 길이 8",
+            "qry_time": "시가 / 길이 6",
+            "shrn_iscd": "고가 / 길이 9",
+            "hts_kor_isnm": "저가 / 길이 41",
+            "stck_prpr": "락구분 / 길이 10",
+            "prdy_vrss_sign": "Filler / 길이 1",
+        }

--- a/packages/cluefin-openapi/tests/nhplug/test_overseas_stock_inquiry_unit.py
+++ b/packages/cluefin-openapi/tests/nhplug/test_overseas_stock_inquiry_unit.py
@@ -1188,3 +1188,46 @@ class TestMargin:
                 client.overseas_stock_inquiry.margin(
                     act_no="50051036881",
                 )
+
+
+class TestSpecDeclaredNumericTypes:
+    def test_balance_holding_splits_fc_float_and_krw_int(self):
+        from cluefin_openapi.nhplug._overseas_stock_inquiry_types import OverseasStockInquiryBalanceHoldingOutput
+
+        holding = OverseasStockInquiryBalanceHoldingOutput(
+            fc_abk_amt="1234.567",
+            krw_abk_amt1="1234",
+            fc_phs_uit_pr="12.345678",
+            phs_uit_pr="12",
+            fc_sec_end_pr="99.5",
+            end_pr="99",
+        )
+        assert holding.fc_abk_amt == 1234.567
+        assert isinstance(holding.krw_abk_amt1, int)
+        assert isinstance(holding.phs_uit_pr, int)
+        assert isinstance(holding.end_pr, int)
+        assert isinstance(holding.fc_phs_uit_pr, float)
+        assert isinstance(holding.fc_sec_end_pr, float)
+
+    def test_daily_transaction_quantities_keep_decimals(self):
+        from cluefin_openapi.nhplug._overseas_stock_inquiry_types import OverseasStockInquiryDailyTransactionOutput
+
+        row = OverseasStockInquiryDailyTransactionOutput(
+            trd_qty="1.5",
+            trd_bf_bnc_qty="2.5",
+            trd_af_bnc_qty="4.0",
+        )
+        assert (row.trd_qty, row.trd_bf_bnc_qty, row.trd_af_bnc_qty) == (1.5, 2.5, 4.0)
+
+    def test_margin_cur_cd_description_matches_spec(self):
+        from cluefin_openapi.nhplug._overseas_stock_inquiry_types import (
+            OverseasStockInquiryMarginOutput,
+            OverseasStockInquiryReservedInquiryOutput,
+        )
+
+        assert OverseasStockInquiryMarginOutput.model_fields["cur_cd"].description == (
+            "통화코드 / 길이 14 / KRW.KRW USD.USD CNY.CNY HKD.HKD JPY.JPY"
+        )
+        assert OverseasStockInquiryReservedInquiryOutput.model_fields["cur_cd"].description == (
+            "통화코드 / 길이 3 / KRW.KRW USD.USD CNY.CNY HKD.HKD JPY.JPY"
+        )

--- a/packages/cluefin-openapi/tests/nhplug/test_overseas_stock_quote_unit.py
+++ b/packages/cluefin-openapi/tests/nhplug/test_overseas_stock_quote_unit.py
@@ -521,3 +521,41 @@ class TestSymbolIndexFxPeriod:
                     gubun="1",
                     today_cls="0",
                 )
+
+
+class TestFieldDescriptions:
+    def test_price_change_sign_legend_spells_보합(self):
+        import inspect
+
+        from pydantic import BaseModel
+
+        from cluefin_openapi.nhplug import _overseas_stock_quote_types as types_module
+
+        legends = []
+        for _, model in inspect.getmembers(types_module, inspect.isclass):
+            if not (issubclass(model, BaseModel) and model.__module__ == types_module.__name__):
+                continue
+            for field in model.model_fields.values():
+                description = field.description or ""
+                assert "보함" not in description
+                if "리버스(기세)" in description:
+                    legends.append(description)
+
+        assert legends
+        for legend in legends:
+            assert legend.endswith("1or6.상한가 2or7.상승 3or0.보합 4or8.하한 5or9.하락 그외.보합+리버스(기세)")
+
+
+class TestSpecDeclaredNumericTypes:
+    def test_acvol_types_follow_spec_per_block(self):
+        from cluefin_openapi.nhplug._overseas_stock_quote_types import (
+            OverseasStockQuoteCurrentPriceOutput,
+            OverseasStockQuoteExecutionTrendOutput,
+            OverseasStockQuotePeriodPriceOutput,
+        )
+
+        assert OverseasStockQuotePeriodPriceOutput(acvol="1234").acvol == 1234.0
+        assert isinstance(OverseasStockQuotePeriodPriceOutput(acvol="1234").acvol, float)
+        assert isinstance(OverseasStockQuoteExecutionTrendOutput(acvol="1234").acvol, int)
+        assert isinstance(OverseasStockQuoteCurrentPriceOutput(acvol="1234").acvol, int)
+        assert isinstance(OverseasStockQuoteCurrentPriceOutput(normal_acvol="1234").normal_acvol, float)


### PR DESCRIPTION
## 관련 이슈

_(관련 이슈 없음)_

## 변경 사항

#88·#89 로 파이썬에 들어간 NH PLUG 클라이언트를 TypeScript 패키지로 이식한다.
KIS·키움에 이은 세 번째 벤더이고, 전송 규약이 둘 중 어느 쪽과도 달라 코어를
확장하는 작업이 앞에 붙는다 — 바디를 `Input_0` 봉투로 감싸고, 연속조회를
`cts`/`cts_flag` 헤더로 돌리며, 엔드포인트를 `api-id` 가 아닌 path 로 식별한다.

- **코어 확장**: `NhplugEndpointDefinition`·`nhplugEnvelopeSchema`·`Nhplug*` 예외 8종.
  성공 코드는 파이썬과 같은 `("00000","XA102")` — 모의투자 서버가 일부 조회 성공에
  XA102 를 주므로 00000 만 보면 정상 응답을 오탐한다.
- **인증·토큰 캐시**: 발급이 운영 도메인 전용이고 운영·모의가 같은 토큰을 쓰므로
  `NhplugAuth` 는 `env` 를 받지 않는다. 캐시는 app_key 로만 스코프하고 파이썬
  `TokenManager` 와 같은 JSON 포맷을 써 프로세스 간 불필요한 재발급을 막는다
  (재발급은 서버 제한 대상이고 계좌 보안 알림을 유발한다).
- **메타데이터 생성기**: `generate-metadata.mjs` 에 `kind: 'nhplug'` 추가. 공용 파서
  헬퍼는 손대지 않고 per-call `client.post("경로")` 추출과 `supportsCts` 판정만 얹어
  REST 51종(공통 2 / 국내 31 / 해외 18)을 파이썬 소스에서 생성한다. 손으로 적은
  엔드포인트 메타데이터는 없다.
- **도메인·스키마 7종**: 파이썬 `_*_types.py` 를 Zod 로 이식. `Output_N` 블록은 API 마다
  객체/배열이 갈리고 데이터가 있을 때만 내려오므로 전부 optional + passthrough.
  숫자는 실서버가 문자열로 주는 이력이 있어 coerce 하되, 빈 문자열은 `z.coerce.number()`
  가 0 으로 바꿔버리므로 null 로 접는다.
- **WebSocket**: 구독 메시지 `header.token` 에 access token 만 싣는다(approval key 없음).
  운영은 국내 7070·해외 7080, 모의는 17070. `BaseWebSocketClient` 에는 JSON 푸시를
  받기 위한 필드·이벤트 타입만 더했고 KIS 코드 경로는 그대로다.

리뷰어가 봐주셨으면 하는 두 가지:

- **`CamelizeKeys` 수정** (`src/core/types.ts`): 타입 레벨 변환이 선두 대문자를 낮추지
  않아 런타임 `camelizeKeys` 와 어긋나 있었다(`Output_0` → 타입 `Output0` vs 런타임
  `output0`). 와이어 키가 대문자로 시작하는 NH PLUG 에서만 드러나던 불일치라
  KIS·키움에는 영향이 없지만, 코어 공용 타입을 건드리는 변경이다.
- **배포 `.d.ts` 누락**: `dist/types/index.d.ts` 는 `tsc` 산출물이 아니라
  `generate-types.mjs` 가 손으로 문자열 조립한다. 도메인 클래스만 자동 생성되고 나머지는
  직접 적어야 해서, nhplug 런타임 export 17개 중 8개가 선언 없이 배포될 상태였다.
  채워 넣고 `dts-drift` 테스트로 배럴과 대조하게 했다. **같은 누락이 KIS 27건·키움 3건
  남아 있는데**(`KisSocketClient`, 실시간 도메인 3종, `FileTokenCacheStore` 등 README 가
  이미 문서화한 것들) 이번 범위를 넘어 손대지 않고 AGENTS.md 에 기록만 했다.

스펙 대조도 함께 했다. `openapi.json`(common·krstock·gbstock) 정본과 파이썬·TS 모델을
전 필드 대조한 결과 **타입은 전부 스펙과 일치**했고, 이상해 보이던 해외주식 int/float
비대칭과 `cur_cd` 길이 14 는 상류 선언 그대로였다. `Output_N` 객체/배열 충돌 3건은
스펙이 `x-schema-warning` 으로 선언과 예시가 어긋난다고 스스로 밝히고 있어 양쪽 union 을
유지했다. 근거가 틀린 주석 3건과 오타(`보함`→`보합`)만 정리했다.

## 변경 유형

- [x] 새로운 기능 추가 (`feat`)
- [x] 버그 수정 (`fix`)
- [x] 테스트 추가/수정 (`test`)
- [x] 문서 수정 (`docs`)

## 영향 범위

- [x] cluefin-openapi _(주석·오타 정정과 회귀 테스트)_
- [x] cluefin-openapi-ts _(항목에 없어 추가 — 이번 작업의 본체)_
- [ ] cluefin-ta
- [ ] cluefin-xbrl
- [ ] cluefin-cli
- [ ] cluefin-desk
- [ ] 루트 프로젝트 설정

## 테스트

- TS 단위: `npm run test:unit` 483건 / 44파일 통과. `publish:check`(build + biome +
  typecheck + test) 통과.
- 파이썬 단위: `uv run pytest packages/cluefin-openapi/tests/nhplug` 235건 통과,
  9건 skip(모의 미지원 integration 마커).
- TS 통합: 작성자가 모의투자(`NHPLUG_ENV=dev`)로 실행해 통과. 조회 37종
  (공통 2 / 국내시세 11 / 국내조회 12 / 해외조회 8 + 운영 전용 4는 skip).
- 파이썬 통합은 이번 변경이 주석·테스트에 한정돼 실행하지 않았다.

- [x] 단위 테스트 통과 (`uv run pytest -m "not integration"`)
- [x] 통합 테스트 통과 (`uv run pytest -m "integration"`)
- [ ] 테스트 불필요 (문서, 설정 변경 등)

## 체크리스트

- [x] `uv run ruff format . && uv run ruff check . --fix` 실행 _(lefthook pre-commit 이 매 커밋마다 수행)_
- [x] 커밋 메시지가 컨벤션을 따름 (`type(scope): 설명`)
- [x] `.env`, 시크릿, 인증 정보 미포함 _(diff 전수 스캔 — 8자리 이상 숫자는 `12345678901`·`00000000000` 더미와 실측 날짜뿐)_
- [x] 관련 문서 업데이트 완료 (해당 시)

## 참고 사항 (선택)

- **주문 계열 통합테스트는 없다.** 주문 18종은 전 엔드포인트가 접수·정정·취소라
  읽기 전용 대상이 없다. 파이썬 쪽도 같은 판단이라 order 통합테스트가 없고,
  읽기로 확인 가능한 등가물(예약주문조회·매수가능수량·주문체결내역)은 조회 카테고리에
  들어 있다.
- **WebSocket 통합테스트도 없다.** 구독 채널 코드(`tr_cd`)가 저장소 어디에도 실측
  기록이 없어, 추측으로 쓰면 실패 원인이 코드인지 채널값인지 구분되지 않는다.
- gbstock 시세 4종은 운영 전용이다. 모의는 `IGW40019`("종목코드를 확인해주세요")로
  거부하는데 실제 뜻은 "모의 미제공"이다 — #89 에서 실측으로 확인된 내용을 그대로 따랐다.
- 등락부호 범례의 `보함`→`보합` 수정은 **스펙 원문과 의도적으로 다르다**. 벤더 문서에도
  `보함`으로 적혀 있으나 한국어 오타가 명백해 양쪽 32곳을 고쳤다.
- 브레이킹 체인지 없음. 기존 KIS·키움 공개 API 는 그대로이고, 코어 변경(`CamelizeKeys`,
  `BaseWebSocketClient`)은 모두 하위 호환이다.
