### PR TITLE
feat(desk): 종목 상세에 뉴스·공시 탭 추가 (KIS 종합 시황/공시)

### DIFF
--- a/apps/cluefin-desk/src/cluefin_desk/data/fetcher.py
+++ b/apps/cluefin-desk/src/cluefin_desk/data/fetcher.py
@@ -421,6 +421,33 @@ class DomesticDataFetcher:
             logger.debug(f"investment opinion unavailable for {stock_code}: {exc}")
             return []
 
+    def get_stock_news(self, stock_code: str) -> list:
+        """종목 뉴스·공시 제목 (KIS 종합 시황/공시, FHKST01011800) — Kiwoom/DART 에는
+        종목 단위 뉴스 피드가 없다. 한 페이지 40건, 최신순.
+
+        `fid_input_iscd` 는 "관련 종목" 필터다: iscd1~10 어딘가에 해당 종목이 태깅된
+        기사가 오고 일부는 연관 기사다 (2026-09-02 실측: 40건 중 28건 직접 태깅).
+        Items: data_dt·data_tm, dorg(제공사명), hts_pbnt_titl_cntt(제목),
+        news_ofer_entp_code(F/G/H/I/N 이면 공시). 나머지 공백 파라미터는 문서상 필수.
+        """
+        try:
+            return (
+                self.kis_client.domestic_issue_other.get_market_announcement_schedule(
+                    fid_news_ofer_entp_code="",
+                    fid_cond_mrkt_cls_code="",
+                    fid_input_iscd=stock_code,
+                    fid_titl_cntt="",
+                    fid_input_date_1="",
+                    fid_input_hour_1="",
+                    fid_rank_sort_cls_code="",
+                    fid_input_srno="",
+                ).body.output
+                or []
+            )
+        except (KISAPIError, ValidationError) as exc:
+            logger.debug(f"stock news unavailable for {stock_code}: {exc}")
+            return []
+
     # ──────────────────────────────────────
     # KIS: 종목 수급 추이 (stock detail 수급 탭)
     # ──────────────────────────────────────

--- a/apps/cluefin-desk/src/cluefin_desk/screens/stock_detail.py
+++ b/apps/cluefin-desk/src/cluefin_desk/screens/stock_detail.py
@@ -49,6 +49,9 @@ class StockDetailScreen(Screen):
                     yield Static("", id="kis-supply-content")
             with TabPane("투자의견", id="tab-opinion"):
                 yield Static("Loading investment opinions...", id="opinion-detail-content")
+            with TabPane("뉴스", id="tab-news"):
+                with VerticalScroll():
+                    yield Static("Loading news...", id="news-detail-content")
             with TabPane("ML예측", id="tab-ml"):
                 yield Static(
                     "M 키를 누르면 익일 등락 예측을 실행합니다.\n(LightGBM 인메모리 학습 — 수 초에서 수십 초 걸립니다)",
@@ -84,6 +87,7 @@ class StockDetailScreen(Screen):
         self._guarded("#supply-detail-content", "신용거래", self._load_supply_data)
         self._guarded("#kis-supply-content", "KIS 수급", self._load_kis_supply_data)
         self._guarded("#opinion-detail-content", "투자의견", self._load_kis_opinion_data)
+        self._guarded("#news-detail-content", "뉴스", self._load_kis_news_data)
 
     def _guarded(self, selector: str | None, label: str, fn) -> None:
         """탭 하나가 실패해도 나머지는 계속 로드하고, 실패는 그 탭에 남긴다.
@@ -328,6 +332,51 @@ class StockDetailScreen(Screen):
                 f"{pad(item.stck_bsop_date, 10)} {pad(item.mbcr_name, 12)} {pad(item.invt_opnn, 8)} "
                 f"{pad(item.rgbf_invt_opnn, 10)} {pad(item.hts_goal_prc, 10, 'right')} "
                 f"{pad((item.dprt or '-') + '%', 8, 'right')}"
+            )
+        return lines
+
+    def _load_kis_news_data(self) -> None:
+        """종목 뉴스·공시 제목 탭 (KIS 전용)."""
+        fetcher = self.app.fetcher
+        if not fetcher.has_kis:
+            self._update_panel(
+                "#news-detail-content",
+                ["KIS API keys not configured.", "Set KIS_APP_KEY / KIS_SECRET_KEY in .env to see 뉴스."],
+            )
+            return
+
+        items = fetcher.get_stock_news(self.stock_code)
+        self._update_panel("#news-detail-content", self._format_news_lines(items))
+
+    # 뉴스 제공업체 코드 중 공시 채널 — F 장내공시, G 코스닥공시, H 프리보드공시, I 기타공시, N 코넥스공시.
+    # 뉴스와 공시가 한 피드로 오므로 이 코드로만 둘을 구분할 수 있다.
+    _DISCLOSURE_PROVIDER_CODES = frozenset("FGHIN")
+
+    @staticmethod
+    def _format_news_when(data_dt: str | None, data_tm: str | None) -> str:
+        """YYYYMMDD + HHMMSS → 'MM-DD HH:MM'. 형식이 어긋나면 원문을 그대로 둔다."""
+        dt, tm = data_dt or "", data_tm or ""
+        if len(dt) == 8 and len(tm) >= 4:
+            return f"{dt[4:6]}-{dt[6:8]} {tm[:2]}:{tm[2:4]}"
+        return f"{dt} {tm}".strip() or "-"
+
+    @classmethod
+    def _format_news_lines(cls, items) -> list[str]:
+        items = list(items or [])
+        if not items:
+            return ["최근 뉴스·공시가 없습니다."]
+
+        lines = [
+            "[bold]뉴스·공시 (KIS, 최신순)[/bold]",
+            "",
+            f"{pad('일시', 12)} {pad('제공', 14)} 제목",
+            "-" * 80,
+        ]
+        for item in items[:40]:
+            tag = r"[cyan]\[공시][/cyan] " if item.news_ofer_entp_code in cls._DISCLOSURE_PROVIDER_CODES else ""
+            lines.append(
+                f"{pad(cls._format_news_when(item.data_dt, item.data_tm), 12)} "
+                f"{pad(item.dorg or '-', 14)} {tag}{item.hts_pbnt_titl_cntt or '-'}"
             )
         return lines
 

--- a/apps/cluefin-desk/src/cluefin_desk/screens/stock_detail.py
+++ b/apps/cluefin-desk/src/cluefin_desk/screens/stock_detail.py
@@ -1,5 +1,6 @@
 import asyncio
 
+from rich.markup import escape
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -12,6 +13,10 @@ from cluefin_desk.widgets.company_info import CompanyInfoWidget
 from cluefin_desk.widgets.indicator_panel import IndicatorPanel
 from cluefin_desk.widgets.nav_footer import NavFooter
 from cluefin_desk.widgets.price_chart import PriceChartWidget
+
+# KIS 뉴스 제공업체 코드 중 공시 채널 — F 장내공시, G 코스닥공시, H 프리보드공시, I 기타공시, N 코넥스공시.
+# 뉴스와 공시가 한 피드로 오므로 이 코드로만 둘을 구분할 수 있다.
+_DISCLOSURE_PROVIDER_CODES = frozenset("FGHIN")
 
 
 class StockDetailScreen(Screen):
@@ -348,10 +353,6 @@ class StockDetailScreen(Screen):
         items = fetcher.get_stock_news(self.stock_code)
         self._update_panel("#news-detail-content", self._format_news_lines(items))
 
-    # 뉴스 제공업체 코드 중 공시 채널 — F 장내공시, G 코스닥공시, H 프리보드공시, I 기타공시, N 코넥스공시.
-    # 뉴스와 공시가 한 피드로 오므로 이 코드로만 둘을 구분할 수 있다.
-    _DISCLOSURE_PROVIDER_CODES = frozenset("FGHIN")
-
     @staticmethod
     def _format_news_when(data_dt: str | None, data_tm: str | None) -> str:
         """YYYYMMDD + HHMMSS → 'MM-DD HH:MM'. 형식이 어긋나면 원문을 그대로 둔다."""
@@ -360,8 +361,8 @@ class StockDetailScreen(Screen):
             return f"{dt[4:6]}-{dt[6:8]} {tm[:2]}:{tm[2:4]}"
         return f"{dt} {tm}".strip() or "-"
 
-    @classmethod
-    def _format_news_lines(cls, items) -> list[str]:
+    @staticmethod
+    def _format_news_lines(items) -> list[str]:
         items = list(items or [])
         if not items:
             return ["최근 뉴스·공시가 없습니다."]
@@ -373,10 +374,12 @@ class StockDetailScreen(Screen):
             "-" * 80,
         ]
         for item in items[:40]:
-            tag = r"[cyan]\[공시][/cyan] " if item.news_ofer_entp_code in cls._DISCLOSURE_PROVIDER_CODES else ""
+            tag = r"[cyan]\[공시][/cyan] " if item.news_ofer_entp_code in _DISCLOSURE_PROVIDER_CODES else ""
+            # 제목은 Rich 마크업으로 해석되면 안 된다 — "[fnRASSI]" 같은 접두어는 태그로 먹혀 사라지고,
+            # "[/...]" 는 MarkupError 로 탭 전체를 실패시킨다.
+            when = StockDetailScreen._format_news_when(item.data_dt, item.data_tm)
             lines.append(
-                f"{pad(cls._format_news_when(item.data_dt, item.data_tm), 12)} "
-                f"{pad(item.dorg or '-', 14)} {tag}{item.hts_pbnt_titl_cntt or '-'}"
+                f"{pad(when, 12)} {pad(escape(item.dorg or '-'), 14)} {tag}{escape(item.hts_pbnt_titl_cntt or '-')}"
             )
         return lines
 

--- a/apps/cluefin-desk/tests/unit/test_fetcher.py
+++ b/apps/cluefin-desk/tests/unit/test_fetcher.py
@@ -279,6 +279,23 @@ class TestKisPhase2Wrappers:
         kis.domestic_stock_info.get_investment_opinion.side_effect = KISAPIError("none")
         assert fetcher.get_investment_opinions("005930") == []
 
+    def test_stock_news_filters_by_code_and_degrades(self, monkeypatch):
+        fetcher, kis = self._fetcher(monkeypatch)
+        api = kis.domestic_issue_other.get_market_announcement_schedule
+        api.return_value.body.output = [SimpleNamespace(hts_pbnt_titl_cntt="삼성전자, 신규 공장")]
+
+        rows = fetcher.get_stock_news("005930")
+
+        assert rows[0].hts_pbnt_titl_cntt == "삼성전자, 신규 공장"
+        kwargs = api.call_args.kwargs
+        assert kwargs["fid_input_iscd"] == "005930"
+        # 문서상 "공백 필수" 인 파라미터들 — 값을 넣으면 빈 응답이 온다
+        for key in ("fid_news_ofer_entp_code", "fid_cond_mrkt_cls_code", "fid_titl_cntt", "fid_rank_sort_cls_code"):
+            assert kwargs[key] == ""
+
+        api.side_effect = KISAPIError("none")
+        assert fetcher.get_stock_news("005930") == []
+
     def test_stock_supply_trends_degrade_to_empty(self, monkeypatch):
         fetcher, kis = self._fetcher(monkeypatch)
         kis.domestic_market_analysis.get_short_selling_trend_daily.side_effect = KISAPIError("x")

--- a/apps/cluefin-desk/tests/unit/test_stock_detail.py
+++ b/apps/cluefin-desk/tests/unit/test_stock_detail.py
@@ -80,6 +80,36 @@ class TestFormatOpinionLines:
         assert "None" not in text
 
 
+def _news_item(title="TCL, 삼성전자 제소", provider="9", dorg="뉴스핌", dt="20260902", tm="212221"):
+    return SimpleNamespace(data_dt=dt, data_tm=tm, dorg=dorg, hts_pbnt_titl_cntt=title, news_ofer_entp_code=provider)
+
+
+class TestFormatNewsLines:
+    def test_empty_says_so(self):
+        assert StockDetailScreen._format_news_lines(None) == ["최근 뉴스·공시가 없습니다."]
+
+    def test_row_has_compact_time_provider_and_title(self):
+        text = "\n".join(StockDetailScreen._format_news_lines([_news_item()]))
+        assert "09-02 21:22" in text
+        assert "뉴스핌" in text
+        assert "TCL, 삼성전자 제소" in text
+
+    def test_disclosure_provider_codes_get_a_tag(self):
+        """뉴스와 공시가 한 피드로 온다 — 제공업체 코드 F/G/H/I/N 만 공시다."""
+        lines = StockDetailScreen._format_news_lines(
+            [
+                _news_item(provider="F", dorg="거래소", title="주요사항보고서"),
+                _news_item(provider="2", dorg="한국경제신문"),
+            ]
+        )
+        assert "[공시]" in lines[4] and "주요사항보고서" in lines[4]
+        assert "[공시]" not in lines[5]
+
+    def test_malformed_timestamp_falls_back_to_raw(self):
+        assert StockDetailScreen._format_news_when("2026", None) == "2026"
+        assert StockDetailScreen._format_news_when(None, None) == "-"
+
+
 def _kis_supply_args(**overrides):
     args = {
         "trend_df": pd.DataFrame(),
@@ -186,6 +216,9 @@ class FakeFetcher:
     def get_program_trading_trend(self, stock_code):
         return []
 
+    def get_stock_news(self, stock_code):
+        return [_news_item(), _news_item(provider="F", dorg="거래소", title="기업설명회(IR) 개최 안내")]
+
     def get_investment_opinions(self, stock_code):
         return [
             SimpleNamespace(
@@ -237,6 +270,7 @@ class TestStockDetailScreen:
                 "#broker-detail-content",
                 "#supply-detail-content",
                 "#opinion-detail-content",
+                "#news-detail-content",
             ):
                 assert "Loading" not in _panel_text(screen, selector), f"{selector} 가 Loading 에서 멈췄다"
 
@@ -250,6 +284,8 @@ class TestStockDetailScreen:
             assert "신용거래 추이" in _panel_text(screen, "#supply-detail-content")
             assert "투자자별 일별 순매수" in _panel_text(screen, "#kis-supply-content")
             assert "미래에셋증권" in _panel_text(screen, "#opinion-detail-content")
+            news = _panel_text(screen, "#news-detail-content")
+            assert "TCL, 삼성전자 제소" in news and "[공시]" in news
 
     async def test_one_failing_tab_does_not_block_the_others(self):
         app = HarnessApp(FakeFetcher(broker_error=True))
@@ -265,5 +301,6 @@ class TestStockDetailScreen:
         async with app.run_test() as pilot:
             screen = await _loaded(app, pilot)
             assert "KIS_APP_KEY" in _panel_text(screen, "#opinion-detail-content")
+            assert "KIS_APP_KEY" in _panel_text(screen, "#news-detail-content")
             assert _panel_text(screen, "#kis-supply-content") == ""
             assert "신용거래 추이" in _panel_text(screen, "#supply-detail-content")

--- a/apps/cluefin-desk/tests/unit/test_stock_detail.py
+++ b/apps/cluefin-desk/tests/unit/test_stock_detail.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import pandas as pd
 import pytest
+from rich.text import Text
 from textual.app import App
 from textual.widgets import DataTable, Static
 
@@ -104,6 +105,15 @@ class TestFormatNewsLines:
         )
         assert "[공시]" in lines[4] and "주요사항보고서" in lines[4]
         assert "[공시]" not in lines[5]
+
+    def test_bracketed_title_is_not_eaten_as_markup(self):
+        """KIS 제목에는 "[fnRASSI]", "[e공시]" 같은 접두어가 흔하다 — Rich 태그로 해석되면 사라진다."""
+        lines = StockDetailScreen._format_news_lines(
+            [_news_item(title="[fnRASSI]삼성전자, 3.2% 상승"), _news_item(title="실적 [/전망] 상향")]
+        )
+        rendered = [Text.from_markup(line).plain for line in lines]
+        assert "[fnRASSI]삼성전자, 3.2% 상승" in rendered[4]
+        assert "실적 [/전망] 상향" in rendered[5]
 
     def test_malformed_timestamp_falls_back_to_raw(self):
         assert StockDetailScreen._format_news_when("2026", None) == "2026"


### PR DESCRIPTION
## 관련 이슈

_(관련 이슈 없음)_

## 변경 사항

종목 상세에 **뉴스** 탭을 추가한다. Kiwoom/DART 에는 종목 단위 뉴스 피드가 없어
KIS 종합 시황/공시(FHKST01011800)를 `fid_input_iscd` 로 종목 필터해 쓴다.

- fetcher `get_stock_news` — 다른 KIS 래퍼와 같은 degrade-to-empty. 문서상 "공백 필수"
  파라미터 7개는 빈 문자열 고정
- 탭: `일시 · 제공사(dorg) · 제목` 40건 최신순. 뉴스와 공시가 한 피드로 오므로 제공업체
  코드 F/G/H/I/N(장내·코스닥·프리보드·기타·코넥스 공시)에만 `[공시]` 태그
- 실측(2026-09-02, 005930): 응답 필드명은 모델과 **일치**, 40건 중 28건 직접 태깅 —
  나머지는 연관 기사라 KIS 의 "관련 종목" 판단을 그대로 보여준다. 페이지네이션과
  본문은 없음(API 가 제목만 제공)

## 변경 유형

- [x] 새로운 기능 추가 (`feat`)
- [x] 테스트 추가/수정 (`test`)

## 영향 범위

- [ ] cluefin-openapi
- [ ] cluefin-ta
- [ ] cluefin-xbrl
- [x] cluefin-desk
- [ ] 루트 프로젝트 설정

## 테스트

`uv run pytest -m "not integration and not realtime"` 2485 passed (fetcher 파라미터·
degrade 1, 포매터 4, Pilot 3곳). 실키로 응답 모양은 확인했지만 desk 화면에서 눈으로
본 것은 아니다 — 종목 상세(005930) → 뉴스 탭에 40건과 `[공시]` 태그가 보이면 끝.
통합 테스트는 돌리지 않았다.

- [x] 단위 테스트 통과 (`uv run pytest -m "not integration"`)
- [ ] 통합 테스트 통과 (`uv run pytest -m "integration"`)
- [ ] 테스트 불필요 (문서, 설정 변경 등)

## 체크리스트

- [x] `uv run ruff format . && uv run ruff check . --fix` 실행
- [x] 커밋 메시지가 컨벤션을 따름 (`type(scope): 설명`)
- [x] `.env`, 시크릿, 인증 정보 미포함
- [ ] 관련 문서 업데이트 완료 (해당 시) _(README 에 탭 목록이 없어 갱신 대상 없음)_

## 참고 사항 (선택)

- `_domestic_issue_other_types.py` 의 뉴스 모델에 `max_length`(제목 400·자료원 20)가
  아직 있다 — 실측 최대 55·6 이라 지금은 안전하고, #94 가 머지되면 사라진다
- `tests/kis/domestic_issue_other_cases.json` 의 뉴스 픽스처 키(`news_titl` 등)는 실서버와
  다르다. 요청 매핑만 검사해 통과하고 있어 이 PR 에선 손대지 않았다
