### PR TITLE
fix(openapi-cli): 삭제된 cluefin-cli ta 안내 수정과 AGENTS.md 프롬프트 감사 반영

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,3 +1,0 @@
-
-[features]
-hooks = true

--- a/.gitignore
+++ b/.gitignore
@@ -85,4 +85,3 @@ CLAUDE.local.md
 .uv-cache/
 data/
 
-.entire/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,9 +31,3 @@ its non-obvious constraints.
 - `packages/*/examples/*.ipynb` 노트북은 커밋 전에 output·execution_count 를 지운다
   (출력에 계좌번호가 섞일 수 있다):
   `uv run --with jupyter jupyter nbconvert --clear-output --inplace <노트북>.ipynb`
-
-## Local agent files
-
-- `.entire/` is local Entire state and is git-ignored.
-- Don't commit `.codex/`, or add repo-local `.pi/` / `SYSTEM.md`, unless a task explicitly
-  asks to make those part of the project workflow.

--- a/apps/cluefin-desk/AGENTS.md
+++ b/apps/cluefin-desk/AGENTS.md
@@ -26,8 +26,8 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 ## Panel conventions
 
 - A tab that fails must say so **in that tab**. Loaders that only `logger.error(...)`
-  leave the panel on its `Loading ...` placeholder forever, which reads as a hang — the
-  bug class that shipped in the cli→desk port. `financial_analysis` /  `stock_detail`
+  leave the panel on its `Loading ...` placeholder forever, which reads as a hang.
+  `financial_analysis` / `stock_detail`
   show the pattern: a `_guarded(selector, label, fn)` wrapper per tab, `_update_panel`
   for the write, and pure `_format_*_lines(...)` staticmethods that return `list[str]`
   (that is what unit tests exercise — the loaders themselves only do I/O).

--- a/apps/cluefin-desk/AGENTS.md
+++ b/apps/cluefin-desk/AGENTS.md
@@ -27,10 +27,10 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 
 - A tab that fails must say so **in that tab**. Loaders that only `logger.error(...)`
   leave the panel on its `Loading ...` placeholder forever, which reads as a hang.
-  `financial_analysis` / `stock_detail`
-  show the pattern: a `_guarded(selector, label, fn)` wrapper per tab, `_update_panel`
-  for the write, and pure `_format_*_lines(...)` staticmethods that return `list[str]`
-  (that is what unit tests exercise — the loaders themselves only do I/O).
+  `financial_analysis` / `stock_detail` show the pattern: a `_guarded(selector, label, fn)`
+  wrapper per tab, `_update_panel` for the write, and pure `_format_*_lines(...)`
+  staticmethods that return `list[str]` (that is what unit tests exercise — the loaders
+  themselves only do I/O).
 - Screen-level `load_all_data` workers are `exclusive=True` with their own `group`;
   without it, `r` mashing runs overlapping workers into the same panels.
 - DART 정기보고서 조회는 `_fetch_with_year_fallback` 로 직전 사업연도부터 뒤로 물러난다

--- a/apps/cluefin-openapi-cli/AGENTS.md
+++ b/apps/cluefin-openapi-cli/AGENTS.md
@@ -24,8 +24,8 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 
 ## Tests that break on unrelated-looking changes
 
-- `test_rpc_registry.py` hardcodes the total command count (`len(registry) == 183`) —
-  bump it when adding/removing any handler.
+- `test_rpc_registry.py` hardcodes the total command count — bump it when adding or
+  removing any handler.
 - New auto-derived domains/tags must also be added to `_DOMAIN_TAXONOMY`/`_TAG_TAXONOMY`
   or the taxonomy-coverage test fails.
 - Recipe → command references are validated only by a test, not at runtime; renaming a

--- a/apps/cluefin-openapi-cli/README.md
+++ b/apps/cluefin-openapi-cli/README.md
@@ -57,7 +57,7 @@ Agent용 분류 기준:
   "name": "chart",
   "description": "Price, volume, and OHLCV time-series lookup commands.",
   "when_to_use": "Use before technical analysis, price trend review, or volume analysis.",
-  "avoid_when": "Use `cluefin-cli ta <stock_code>` when a full technical-indicator report is already sufficient.",
+  "avoid_when": "Skip when OHLCV arrays are already in hand; compute indicators from them with the cluefin-ta package.",
   "related_tags": ["ohlcv", "daily", "minute", "tick"],
   "example_filter": "uv run cluefin-openapi-cli list --domain chart --json",
   "command_count": 8
@@ -180,7 +180,6 @@ uv run cluefin-openapi-cli dart company-overview --corp-code 00126380 --json
 - 실제 broker client 생성은 `cluefin_openapi.client_factory`를 사용
 - KIS, Kiwoom은 토큰 캐시를 사용하고, DART는 stateless client로 동작
 - Agent integration은 이 CLI의 JSON discovery를 직접 사용합니다
-- `cluefin-cli` 삭제 또는 정리는 별도 후속 작업이며, 이 CLI는 wrapper 없이 독립적으로 사용됩니다
 
 ## 주의사항
 

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/metadata.py
@@ -41,7 +41,7 @@ _DOMAIN_TAXONOMY: dict[str, TaxonomyMetadata] = {
         name="chart",
         description="Price, volume, and OHLCV time-series lookup commands.",
         when_to_use="Use before technical analysis, price trend review, or volume analysis.",
-        avoid_when="Use `cluefin-cli ta <stock_code>` when a full technical-indicator report is already sufficient.",
+        avoid_when="Skip when OHLCV arrays are already in hand; compute indicators from them with the cluefin-ta package.",
         related_tags=("ohlcv", "daily", "minute", "tick"),
     ),
     "corporate-actions": TaxonomyMetadata(
@@ -236,7 +236,7 @@ _TAG_TAXONOMY: dict[str, TaxonomyMetadata] = {
         name="ohlcv",
         description="Open, high, low, close, and volume price series data.",
         when_to_use="Use to collect source arrays for technical indicators and price/volume analysis.",
-        avoid_when="Use `cluefin-cli ta <stock_code>` when OHLCV arrays are already available and a full report is enough.",
+        avoid_when="Skip when OHLCV arrays are already available; compute indicators with the cluefin-ta package instead of re-fetching.",
         related_domains=("chart",),
     ),
     "order-book": TaxonomyMetadata(

--- a/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/recipes.py
+++ b/apps/cluefin-openapi-cli/src/cluefin_openapi_cli/recipes.py
@@ -77,7 +77,7 @@ _RECIPES: tuple[WorkflowRecipe, ...] = (
                 title="Fetch daily OHLCV",
                 command=("kis", "chart", "period"),
                 purpose="Retrieve period chart data suitable for daily indicators.",
-                agent_notes="Run `cluefin-cli ta <stock_code>` for the corresponding technical-indicator report (SMA/EMA/RSI/MACD/Bollinger/Stochastic/ADX/ATR/OBV plus risk metrics).",
+                agent_notes="Compute SMA/EMA/RSI/MACD/Bollinger/Stochastic/ADX/ATR/OBV from the returned OHLCV arrays with the cluefin-ta package; the CLI has no indicator command.",
             ),
             RecipeStep(
                 title="Fetch intraday OHLCV",
@@ -92,7 +92,7 @@ _RECIPES: tuple[WorkflowRecipe, ...] = (
                 agent_notes="Normalize provider response shape before TA calculation.",
             ),
         ),
-        agent_notes="Recipes do not run TA indicators directly; use `cluefin-cli ta <stock_code>` after collecting OHLCV arrays.",
+        agent_notes="Recipes do not run TA indicators; compute them with the cluefin-ta package after collecting OHLCV arrays.",
     ),
     WorkflowRecipe(
         name="market-scan",

--- a/apps/cluefin-openapi-cli/tests/test_readme_smoke.py
+++ b/apps/cluefin-openapi-cli/tests/test_readme_smoke.py
@@ -19,7 +19,7 @@ def test_readme_mentions_agent_discovery_commands() -> None:
     assert "recipes --json" in content
     assert "recipe stock-research --json" in content
     assert "agent_notes" in content
-    assert "cluefin-cli" in content
+    assert "cluefin-ta" in content
     assert "`domains`: 업무 영역" in content
     assert "`tags`: 세부 기능" in content
     assert "`recipes`: 여러 command를 조합하는 workflow guide" in content

--- a/apps/cluefin-openapi-cli/tests/test_readme_smoke.py
+++ b/apps/cluefin-openapi-cli/tests/test_readme_smoke.py
@@ -19,7 +19,6 @@ def test_readme_mentions_agent_discovery_commands() -> None:
     assert "recipes --json" in content
     assert "recipe stock-research --json" in content
     assert "agent_notes" in content
-    assert "cluefin-ta" in content
     assert "`domains`: 업무 영역" in content
     assert "`tags`: 세부 기능" in content
     assert "`recipes`: 여러 command를 조합하는 workflow guide" in content
@@ -44,6 +43,17 @@ def test_readme_discovery_examples_execute() -> None:
         result = run_cli(argv)
         assert result.exit_code == 0, argv
         assert result.stdout.strip().startswith("{"), argv
+
+
+def test_agent_guidance_does_not_point_at_deleted_commands() -> None:
+    """README 와 discovery JSON(avoid_when/agent_notes)은 에이전트가 그대로 따르는 안내다.
+    cluefin-cli 는 desk 로 흡수돼 삭제됐다 — 다시 등장하면 에이전트를 실패 경로로 보낸다."""
+    set_registry_provider(RpcRegistry)
+    assert "cluefin-cli" not in README.read_text(encoding="utf-8")
+    # `recipes --json` 은 요약만 낸다 — agent_notes 는 레시피 상세에만 있다
+    recipe_names = [r["name"] for r in json.loads(run_cli(["recipes", "--json"]).stdout)["recipes"]]
+    for argv in [["domains", "--json"], ["tags", "--json"], *(["recipe", n, "--json"] for n in recipe_names)]:
+        assert "cluefin-cli" not in run_cli(argv).stdout, argv
 
 
 def test_readme_taxonomy_examples_match_json_shape() -> None:

--- a/packages/cluefin-openapi-ts/AGENTS.md
+++ b/packages/cluefin-openapi-ts/AGENTS.md
@@ -33,9 +33,9 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 ## Declaration output (`dist/types`)
 
 - `build:types` is `tsc -p tsconfig.build.json` — a real `--emitDeclarationOnly` pass over
-  `src` only. It emits a 112-file tree mirroring `src`; `dist/types/index.d.ts` is the
-  entry and re-exports the rest. There is **no** hand-written declaration template any
-  more (`scripts/generate-types.mjs` is gone; `scripts/generate-metadata.mjs` stays).
+  `src` only. It emits a tree mirroring `src`; `dist/types/index.d.ts` is the entry and
+  re-exports the rest. Declarations come from `tsc`, not from a template — the only
+  generator script is `scripts/generate-metadata.mjs`.
 - `tsconfig.build.json` turns off `declarationMap`/`sourceMap` that the base config sets —
   turning them back on doubles the shipped file count with maps pointing at absent `src`.
 - The base `tsconfig.json` includes `tests`, which has ~61 pre-existing type errors. They
@@ -52,15 +52,14 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
   `exports["."].types`. That fixture is excluded from the root `tsconfig.json` — it only
   resolves after a build. The test builds `dist/types` itself if it's missing.
   It compiles the fixture **twice**, under `tsconfig.json` (Bundler) and
-  `tsconfig.nodenext.json` (NodeNext) — a single-mode check is exactly how the
-  extensionless-specifier regression above shipped past review once. The NodeNext project
+  `tsconfig.nodenext.json` (NodeNext) — a Bundler-only check cannot see the
+  extensionless-specifier failure described above. The NodeNext project
   deliberately sets `skipLibCheck: false` (that is what surfaces TS2834 across all 112
   declaration files rather than only on names the fixture happens to import), which in
   turn needs `types: ["node"]`. Don't "simplify" either setting.
 - `npx @arethetypeswrong/cli --pack` reports **`node16 (from CJS)`: Masquerading as ESM**.
-  Pre-existing, not caused by the declaration migration (verified by running it against
-  the pre-migration commit): the package is `"type": "module"` with a dual ESM/CJS build
-  but a single `types` field, so `require` gets an ESM-flavoured `.d.ts`. Fixing it means
+  Known and accepted: the package is `"type": "module"` with a dual ESM/CJS build but a
+  single `types` field, so `require` gets an ESM-flavoured `.d.ts`. Fixing it means
   emitting a `.d.cts` and adding `exports.require.types` — a distribution-shape change.
 - **KIS `schemas/*` (166 names) are emitted but unreachable**: `src/kis/index.ts` re-exports
   zero schema modules, while `src/kiwoom/index.ts` re-exports 9 and `src/nhplug/index.ts` 7.
@@ -75,6 +74,8 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
   responses. A new field must be handled with this asymmetry in mind.
 - KIS `custtype` is hardcoded to `'P'` (personal) in the HTTP and socket clients —
   corporate-account calls aren't possible without changing that.
+- Kiwoom's auth API is `generateToken()`/`revokeToken()`, while KIS and NH PLUG use
+  `generate()`/`revoke()` — the asymmetry is real, not a typo.
 - `CamelizeKeys` in `src/core/types.ts` deliberately wraps its key mapping in
   `Uncapitalize` because the runtime `toCamelCase` lowercases the first character. This is
   invisible for KIS/Kiwoom (lowercase snake_case wire keys) and only shows up on NH PLUG's
@@ -99,7 +100,3 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 
 - `docs/api-coverage-gap.md` is a snapshot: its "미구현" rows for KIS realtime quotes
   are outdated (those files exist now), and it predates NH PLUG entirely.
-- (The README's KIS quick-start used to call a non-existent `auth.generateToken()`; it now
-  correctly says `generate()`. Note that Kiwoom really does use `generateToken()`/
-  `revokeToken()` while KIS and NH PLUG use `generate()`/`revoke()` — the asymmetry is
-  real, not a typo.)

--- a/packages/cluefin-openapi-ts/AGENTS.md
+++ b/packages/cluefin-openapi-ts/AGENTS.md
@@ -54,8 +54,8 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
   It compiles the fixture **twice**, under `tsconfig.json` (Bundler) and
   `tsconfig.nodenext.json` (NodeNext) — a Bundler-only check cannot see the
   extensionless-specifier failure described above. The NodeNext project
-  deliberately sets `skipLibCheck: false` (that is what surfaces TS2834 across all 112
-  declaration files rather than only on names the fixture happens to import), which in
+  deliberately sets `skipLibCheck: false` (that is what surfaces TS2834 across every
+  emitted declaration file rather than only on names the fixture happens to import), which in
   turn needs `types: ["node"]`. Don't "simplify" either setting.
 - `npx @arethetypeswrong/cli --pack` reports **`node16 (from CJS)`: Masquerading as ESM**.
   Known and accepted: the package is `"type": "module"` with a dual ESM/CJS build but a

--- a/packages/cluefin-openapi/AGENTS.md
+++ b/packages/cluefin-openapi/AGENTS.md
@@ -40,9 +40,8 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 - One token serves both live (`api.nhplug.com`) and mock (`moapi.nhplug.com`) calls, which
   is why the nhplug token cache is scoped by app_key only (no env) — don't "fix" it to
   match kis/kiwoom.
-- `TokenManager` is now a **third** copy (kis/kiwoom/nhplug) — mirror cache-behavior
-  changes by hand in all three. nhplug deliberately has no `MAX_CACHE_AGE` (no early
-  server-side invalidation) and computes expiry from `cached_at + expires_in`.
+- nhplug's `TokenManager` deliberately has no `MAX_CACHE_AGE` (no early server-side
+  invalidation) and computes expiry from `cached_at + expires_in`.
 - All four gbstock 시세 APIs (`/gbstock/quote/v1/*`) are **live-domain only**. moapi rejects
   `current` with `IGW40019 "종목코드(iem_cd)를 확인해주세요"` for every ticker format —
   a misleading message that means "not provided on mock", not a bad code (2026-08-22 실측).
@@ -61,8 +60,8 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 
 ## Conventions that are easy to mis-infer
 
-- The two `TokenManager` classes (kis/kiwoom) are copy-pasted, not shared — mirror
-  cache-behavior changes by hand in both.
+- The three `TokenManager` classes (kis/kiwoom/nhplug) are copy-pasted, not shared —
+  mirror cache-behavior changes by hand in all three.
 - Unit-test styles are per-broker and not interchangeable: Kiwoom uses the table-driven
   `EndpointCase`/`run_post_case` harness (`tests/kiwoom/_helpers.py`), KIS uses JSON
   fixture case files (`tests/kis/*_cases.json`).

--- a/packages/cluefin-ta/AGENTS.md
+++ b/packages/cluefin-ta/AGENTS.md
@@ -24,6 +24,6 @@ AGENTS.md for repo-wide rules.
 ## Stale docs
 
 - The package README still advertises Numba acceleration and its benchmark table;
-  Numba support was removed (#26). Don't trust README performance claims — verify
+  Numba support was removed. Don't trust README performance claims — verify
   against `pyproject.toml` and `_core/`. Leftover `__pycache__` bytecode also references
   deleted modules (`dow`, `numba_impl`); the source tree is the truth.

--- a/packages/cluefin-xbrl/AGENTS.md
+++ b/packages/cluefin-xbrl/AGENTS.md
@@ -5,8 +5,8 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
 ## Scope
 
 - This package is a **pure local-file parser** — it never talks to DART. The download
-  path (ZIP fetch + unzip) lives in cluefin-cli / cluefin-openapi's dart module. A
-  missing download function here is intentional, not a gap.
+  path (ZIP fetch + unzip) lives in cluefin-openapi's dart module. A missing download
+  function here is intentional, not a gap.
 
 ## DART/Arelle quirks baked into the code
 
@@ -28,5 +28,3 @@ Non-obvious constraints only; see the root AGENTS.md for repo-wide rules.
   real-looking DART entity ids). There is no tooling to regenerate them from a live
   filing; realistic test data must be hand-crafted or manually trimmed from a download.
 - `tests/__init__.py` was deliberately deleted to fix a pytest collision — don't re-add.
-- Notes-extraction / consolidated-vs-separate filtering work already exists on the
-  unmerged branch `feat/xbrl-extract-notes-design`; check it before building either.


### PR DESCRIPTION
## 관련 이슈

_(관련 이슈 없음)_

## 변경 사항

에이전트 지시 표면(AGENTS.md 7개, CLI 의 `--json` 도구 설명)을 프롬프트 감사로
훑어, 코드와 어긋난 사실과 사건 서사를 정리한다. 이 PR 은 "에이전트가 읽는 문서를
현재 코드와 일치시키는" 작업이다.

- **CLI 도구 설명이 삭제된 명령을 안내했다.** `avoid_when`/`agent_notes` 4곳이
  #93 에서 없어진 `cluefin-cli ta` 를 가리켜 에이전트를 실패 경로로 보냈다.
  cluefin-ta 패키지로 계산하라는 문구로 교체
- **코드와 모순되는 사실 정정.** 명령 수 183(테스트는 182), TokenManager 가 2개라는
  문장과 3개라는 문장의 공존, xbrl 의 삭제된 cluefin-cli·존재하지 않는 브랜치 참조
- **사건 서사 제거.** "예전엔 X 였는데 지금은 Y", 검증 경위, PR 번호를 현재 규칙만
  남기는 형태로. 규칙의 이유는 그대로 둠

## 변경 유형

- [x] 버그 수정 (`fix`)
- [ ] 새로운 기능 추가 (`feat`)
- [ ] 기존 기능 개선 (`feat`)
- [ ] 리팩토링 (`refactor`)
- [ ] 테스트 추가/수정 (`test`)
- [x] 문서 수정 (`docs`)
- [ ] 의존성 업데이트 (`chore`)
- [ ] CI/CD (`ci`)

## 영향 범위

- [x] cluefin-openapi
- [x] cluefin-ta
- [x] cluefin-xbrl
- [x] cluefin-desk
- [ ] 루트 프로젝트 설정

추가로 cluefin-openapi-cli(코드·README·테스트), cluefin-openapi-ts(AGENTS.md).

## 테스트

`uv run pytest apps/cluefin-openapi-cli/tests/test_readme_smoke.py
apps/cluefin-openapi-cli/tests/test_rpc_registry.py` 14건 통과. 그 외 변경은
AGENTS.md 문서만이라 전체 단위 스위트는 돌리지 않았다.

- [ ] 단위 테스트 통과 (`uv run pytest -m "not integration"`)
- [ ] 통합 테스트 통과 (`uv run pytest -m "integration"`)
- [x] 테스트 불필요 (문서, 설정 변경 등)

## 체크리스트

- [x] `uv run ruff format . && uv run ruff check . --fix` 실행
- [x] 커밋 메시지가 컨벤션을 따름 (`type(scope): 설명`)
- [x] `.env`, 시크릿, 인증 정보 미포함
- [x] 관련 문서 업데이트 완료 (해당 시)

## 참고 사항 (선택)

감사에서 나왔지만 이 PR 에 넣지 않은 것 두 가지.
- cluefin-openapi AGENTS.md 의 `max_length` 절(사건 날짜·제거 건수)은
  `fix/drop-max-length` 에만 있어 그 브랜치에서 다듬어야 한다.
- 루트 AGENTS.md 는 `.codex/` 를 커밋하지 말라고 하는데 `.codex/config.toml` 이
  추적 중이다. 파일을 untrack 할지 규칙을 지울지 결정이 필요하다.
