### PR TITLE
fix(desk): 화면 포매터 외부 문자열 마크업 이스케이프와 KIS 강등 로그 승격

### DIFF
--- a/apps/cluefin-desk/src/cluefin_desk/data/fetcher.py
+++ b/apps/cluefin-desk/src/cluefin_desk/data/fetcher.py
@@ -245,8 +245,10 @@ class DomesticDataFetcher:
                 ).body.output
                 or []
             )
+        # ValidationError 도 [] 로 강등되면 화면은 '데이터 없음'과 구분하지 못한다(#94 이전에
+        # max_length 가 실서버 값을 거부한 사례). 로그에서라도 구분되게 warning 으로 남긴다.
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"financial ratio unavailable for {stock_code}: {exc}")
+            logger.warning(f"financial ratio unavailable for {stock_code}: {exc}")
             return []
 
     def get_income_statement_series(self, stock_code: str) -> list:
@@ -264,7 +266,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"income statement unavailable for {stock_code}: {exc}")
+            logger.warning(f"income statement unavailable for {stock_code}: {exc}")
             return []
 
     @staticmethod
@@ -331,7 +333,7 @@ class DomesticDataFetcher:
                 fid_org_adj_prc="0",
             ).body.output2
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"period quote unavailable for {stock_code}: {exc}")
+            logger.warning(f"period quote unavailable for {stock_code}: {exc}")
             return pd.DataFrame()
 
         rows = [
@@ -378,7 +380,7 @@ class DomesticDataFetcher:
                 fid_input_date_1=base_date,
             ).body.output2
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"daily investor trend unavailable for {stock_code}: {exc}")
+            logger.warning(f"daily investor trend unavailable for {stock_code}: {exc}")
             return pd.DataFrame()
 
         rows = [
@@ -418,7 +420,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"investment opinion unavailable for {stock_code}: {exc}")
+            logger.warning(f"investment opinion unavailable for {stock_code}: {exc}")
             return []
 
     def get_stock_news(self, stock_code: str) -> list:
@@ -445,7 +447,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"stock news unavailable for {stock_code}: {exc}")
+            logger.warning(f"stock news unavailable for {stock_code}: {exc}")
             return []
 
     # ──────────────────────────────────────
@@ -468,7 +470,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"short selling trend unavailable for {stock_code}: {exc}")
+            logger.warning(f"short selling trend unavailable for {stock_code}: {exc}")
             return []
 
     def get_credit_balance_trend(self, stock_code: str) -> list:
@@ -485,7 +487,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"credit balance trend unavailable for {stock_code}: {exc}")
+            logger.warning(f"credit balance trend unavailable for {stock_code}: {exc}")
             return []
 
     def get_program_trading_trend(self, stock_code: str) -> list:
@@ -501,7 +503,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"program trading trend unavailable for {stock_code}: {exc}")
+            logger.warning(f"program trading trend unavailable for {stock_code}: {exc}")
             return []
 
     # ──────────────────────────────────────
@@ -527,7 +529,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"market investor trend unavailable for {market}: {exc}")
+            logger.warning(f"market investor trend unavailable for {market}: {exc}")
             return []
 
     def get_market_fund_summary(self) -> list:
@@ -540,7 +542,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"market fund summary unavailable: {exc}")
+            logger.warning(f"market fund summary unavailable: {exc}")
             return []
 
     # ──────────────────────────────────────
@@ -567,7 +569,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"dividend yield top unavailable: {exc}")
+            logger.warning(f"dividend yield top unavailable: {exc}")
             return []
 
     def get_short_selling_top(self, market: str = "0001") -> list:
@@ -589,7 +591,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"short selling top unavailable: {exc}")
+            logger.warning(f"short selling top unavailable: {exc}")
             return []
 
     def get_credit_balance_top(self, market: str = "0001") -> list:
@@ -606,7 +608,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"credit balance top unavailable: {exc}")
+            logger.warning(f"credit balance top unavailable: {exc}")
             return []
 
     def get_disparity_index_rank(self, market: str = "0001", hour: str = "20") -> list:
@@ -629,7 +631,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"disparity index rank unavailable: {exc}")
+            logger.warning(f"disparity index rank unavailable: {exc}")
             return []
 
     # ──────────────────────────────────────
@@ -651,7 +653,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"etf nav trend unavailable for {stk_cd}: {exc}")
+            logger.warning(f"etf nav trend unavailable for {stk_cd}: {exc}")
             return []
 
     def get_etf_component_prices(self, stk_cd: str) -> list:
@@ -665,7 +667,7 @@ class DomesticDataFetcher:
                 or []
             )
         except (KISAPIError, ValidationError) as exc:
-            logger.debug(f"etf components unavailable for {stk_cd}: {exc}")
+            logger.warning(f"etf components unavailable for {stk_cd}: {exc}")
             return []
 
     async def get_stock_data(self, stock_code: str) -> pd.DataFrame:

--- a/apps/cluefin-desk/src/cluefin_desk/screens/_guard.py
+++ b/apps/cluefin-desk/src/cluefin_desk/screens/_guard.py
@@ -1,5 +1,6 @@
 """워커 스레드에서 UI 를 만지는 공통 도우미 — 실패는 화면에 남기고, 화면 전환은 취소로 본다."""
 
+from rich.markup import escape
 from textual.message_pump import NoActiveAppError
 from textual.widgets import Static
 
@@ -39,4 +40,5 @@ def guarded(screen, selector: str | None, label: str, fn, *args) -> None:
 
         logger.error(f"Failed to load {label}: {e}")
         if selector is not None:
-            set_text(screen, selector, f"{label} 로딩 실패: {e}")
+            # 예외 메시지에는 pydantic 의 "[type=...]" 처럼 태그로 읽히는 대괄호가 흔하다.
+            set_text(screen, selector, f"{label} 로딩 실패: {escape(str(e))}")

--- a/apps/cluefin-desk/src/cluefin_desk/screens/etf_analysis.py
+++ b/apps/cluefin-desk/src/cluefin_desk/screens/etf_analysis.py
@@ -1,3 +1,4 @@
+from rich.markup import escape
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -171,7 +172,7 @@ class EtfAnalysisScreen(Screen):
             lines += ["", "[bold]구성종목 상위 (비중순, KIS)[/bold]"]
             for item in components[:10]:
                 lines.append(
-                    f"  {pad(item.hts_kor_isnm, 16)} {pad(item.stck_prpr, 10, 'right')} "
+                    f"  {pad(escape(item.hts_kor_isnm or '-'), 16)} {pad(item.stck_prpr, 10, 'right')} "
                     f"({item.prdy_ctrt}%)  비중 {item.etf_cnfg_issu_rlim}%"
                 )
         else:

--- a/apps/cluefin-desk/src/cluefin_desk/screens/financial_analysis.py
+++ b/apps/cluefin-desk/src/cluefin_desk/screens/financial_analysis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Callable, Iterable, Sequence
 
+from rich.markup import escape
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -237,7 +238,7 @@ class FinancialAnalysisScreen(Screen):
             self.query_one("#disclosure-status", Static).update("" if items else "최근 공시가 없습니다.")
             if items:
                 title = self.query_one("#financial-title-bar", Static)
-                title.update(f"[bold]{items[0].corp_name}[/bold] ({self.stock_code}) — 재무 분석  [Esc·뒤로]")
+                title.update(f"[bold]{escape(items[0].corp_name)}[/bold] ({self.stock_code}) — 재무 분석  [Esc·뒤로]")
 
         self.app.call_from_thread(_update_disclosure_table)
 
@@ -309,7 +310,7 @@ class FinancialAnalysisScreen(Screen):
             lines.append("-" * 54)
             for item in selected:
                 lines.append(
-                    f"{pad(item.account_nm, 14)} {pad(item.thstrm_amount or '-', 18, 'right')} "
+                    f"{pad(escape(item.account_nm), 14)} {pad(item.thstrm_amount or '-', 18, 'right')} "
                     f"{pad(item.frmtrm_amount or '-', 18, 'right')}"
                 )
         else:
@@ -319,7 +320,7 @@ class FinancialAnalysisScreen(Screen):
         if indicators:
             lines += ["", "[bold]주요 재무지표 (DART)[/bold]", ""]
             for category, name, value in indicators:
-                lines.append(f"  [{category}] {name}: {value}")
+                lines.append(f"  [{category}] {escape(name)}: {escape(str(value))}")
         return lines
 
     def _load_dividend_info(self, dart_client, corp_code: str) -> None:
@@ -346,7 +347,7 @@ class FinancialAnalysisScreen(Screen):
             "-" * 76,
         ]
         for item in items[:20]:
-            label = (item.se or "-") + (f" ({item.stock_knd})" if item.stock_knd else "")
+            label = escape((item.se or "-") + (f" ({item.stock_knd})" if item.stock_knd else ""))
             lines.append(
                 f"{pad(label, 28)} {pad(item.thstrm or '-', 14, 'right')} "
                 f"{pad(item.frmtrm or '-', 14, 'right')} {pad(item.lwfr or '-', 14, 'right')}"
@@ -382,7 +383,7 @@ class FinancialAnalysisScreen(Screen):
         ]
         for item in items[:20]:
             lines.append(
-                f"{pad(item.nm, 20)} {pad(item.relate or '-', 12)} "
+                f"{pad(escape(item.nm or '-'), 20)} {pad(escape(item.relate or '-'), 12)} "
                 f"{pad(item.trmend_posesn_stock_co or '-', 16, 'right')} "
                 f"{pad((item.trmend_posesn_stock_qota_rt or '-') + '%', 8, 'right')}"
             )
@@ -433,7 +434,7 @@ class FinancialAnalysisScreen(Screen):
             ]
             for item in totals[:10]:
                 lines.append(
-                    f"{pad(item.se, 14)} {pad(item.istc_totqy or '-', 18, 'right')} "
+                    f"{pad(escape(item.se or '-'), 14)} {pad(item.istc_totqy or '-', 18, 'right')} "
                     f"{pad(item.tesstk_co or '-', 16, 'right')} {pad(item.distb_stock_co or '-', 18, 'right')}"
                 )
 
@@ -449,8 +450,8 @@ class FinancialAnalysisScreen(Screen):
             ]
             for item in changes[:20]:
                 lines.append(
-                    f"{pad(item.isu_dcrs_de, 12)} {pad(item.isu_dcrs_stle, 16)} "
-                    f"{pad(item.isu_dcrs_stock_knd, 12)} {pad(item.isu_dcrs_qy or '-', 16, 'right')} "
+                    f"{pad(item.isu_dcrs_de, 12)} {pad(escape(item.isu_dcrs_stle or '-'), 16)} "
+                    f"{pad(escape(item.isu_dcrs_stock_knd or '-'), 12)} {pad(item.isu_dcrs_qy or '-', 16, 'right')} "
                     f"{pad(item.isu_dcrs_mstvdv_amount or '-', 14, 'right')}"
                 )
         else:
@@ -518,7 +519,7 @@ class FinancialAnalysisScreen(Screen):
             lines += ["", f"[bold cyan]{cls._XBRL_STATEMENT_LABELS.get(stmt_key, stmt_key)}[/bold cyan]"]
             for item in stmt.line_items[:25]:
                 indent = "  " * item.depth
-                label = item.label_ko or item.concept_local_name
+                label = escape(item.label_ko or item.concept_local_name)
                 if item.is_abstract:
                     lines.append(f"{indent}[bold]{label}[/bold]")
                 else:
@@ -533,7 +534,7 @@ class FinancialAnalysisScreen(Screen):
         if notes:
             lines += ["", f"[bold cyan]주석 목차 ({len(notes)}건)[/bold cyan]"]
             for note in notes[:30]:
-                lines.append(f"  {note.role_code}  {note.title or '-'}  ({len(note.line_items)} items)")
+                lines.append(f"  {note.role_code}  {escape(note.title or '-')}  ({len(note.line_items)} items)")
         return lines
 
     def _find_corp_code(self, dart_client) -> str | None:

--- a/apps/cluefin-desk/src/cluefin_desk/screens/market_overview.py
+++ b/apps/cluefin-desk/src/cluefin_desk/screens/market_overview.py
@@ -1,3 +1,4 @@
+from rich.markup import escape
 from textual import work
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -142,7 +143,7 @@ class MarketOverviewScreen(Screen):
             sign = "+" if rate > 0 else ""
             rate_str = pad(f"{sign}{rate:.2f}%", 8, align="right")
             lines.append(
-                f"  {pad(item.stock_name, 16)} {pad(price_str, 10, align='right')}  [{color}]{rate_str}[/{color}]"
+                f"  {pad(escape(item.stock_name or '-'), 16)} {pad(price_str, 10, align='right')}  [{color}]{rate_str}[/{color}]"
             )
         return lines
 
@@ -167,7 +168,7 @@ class MarketOverviewScreen(Screen):
             from loguru import logger
 
             logger.error(f"Failed to load top movers: {e}")
-            err_msg = str(e)
+            err_msg = escape(str(e))
 
             def _update_error():
                 # 실패를 로그에만 남기면 두 패널이 영구히 "Loading..." 으로 남는다.
@@ -252,7 +253,7 @@ class MarketOverviewScreen(Screen):
                 from loguru import logger
 
                 logger.error(f"Failed to load KIS {label}: {e}")
-                set_text(self, selector, f"[bold]{label} (KIS)[/bold]\n  로드 실패: {e}")
+                set_text(self, selector, f"[bold]{label} (KIS)[/bold]\n  로드 실패: {escape(str(e))}")
 
     def action_refresh(self) -> None:
         self.load_all_data()

--- a/apps/cluefin-desk/src/cluefin_desk/screens/stock_detail.py
+++ b/apps/cluefin-desk/src/cluefin_desk/screens/stock_detail.py
@@ -21,7 +21,7 @@ _DISCLOSURE_PROVIDER_CODES = frozenset("FGHIN")
 
 
 class StockDetailScreen(Screen):
-    """Screen 6: Stock detail with 4 tabs (chart, investor, broker, supply-demand)."""
+    """Screen 6: Stock detail with 7 tabs (차트·투자자·매매원·수급·투자의견·뉴스·ML예측)."""
 
     BINDINGS = [
         Binding("escape", "go_back", "Back"),

--- a/apps/cluefin-desk/src/cluefin_desk/screens/stock_detail.py
+++ b/apps/cluefin-desk/src/cluefin_desk/screens/stock_detail.py
@@ -116,7 +116,7 @@ class StockDetailScreen(Screen):
             if not basic_df.empty:
                 row = basic_df.iloc[0]
                 title.update(
-                    f"[bold]{row.get('stock_name', 'N/A')}[/bold] ({self.stock_code})  "
+                    f"[bold]{escape(str(row.get('stock_name', 'N/A')))}[/bold] ({self.stock_code})  "
                     f"{row.get('market_name', '')}  [F\u00b7재무] [Esc\u00b7뒤로]"
                 )
 
@@ -167,7 +167,7 @@ class StockDetailScreen(Screen):
     @staticmethod
     def _format_broker_lines(body) -> list[str]:
         lines = [
-            f"[bold]매매원 현황 — {body.stk_nm} ({body.stk_cd})[/bold]",
+            f"[bold]매매원 현황 — {escape(str(body.stk_nm))} ({body.stk_cd})[/bold]",
             f"현재가: {body.cur_prc}  등락률: {body.flu_rt}%",
         ]
         for title, prefix in [("매수 상위", "buy"), ("매도 상위", "sel")]:
@@ -175,7 +175,7 @@ class StockDetailScreen(Screen):
             for i in range(1, 6):
                 nm = getattr(body, f"{prefix}_trde_ori_nm_{i}", "-")
                 qty = getattr(body, f"{prefix}_trde_qty_{i}", "-")
-                lines.append(f"  {i}. {pad(nm, 16)}  {pad(qty, 12, 'right')}")
+                lines.append(f"  {i}. {pad(escape(str(nm)), 16)}  {pad(qty, 12, 'right')}")
         return lines
 
     def _load_supply_data(self) -> None:
@@ -286,7 +286,7 @@ class StockDetailScreen(Screen):
         if not actions_df.empty:
             lines += ["", "[bold]최근 권리락/배당락 (KIS)[/bold]", ""]
             for date, row in actions_df.sort_index(ascending=False).iterrows():
-                lines.append(f"  {date.strftime('%Y-%m-%d')}  {row['event']}")
+                lines.append(f"  {date.strftime('%Y-%m-%d')}  {escape(str(row['event']))}")
 
         return lines
 
@@ -318,8 +318,10 @@ class StockDetailScreen(Screen):
         ]
         for item in opinions[:20]:
             lines.append(
-                f"{pad(item.stck_bsop_date, 10)} {pad(item.mbcr_name, 12)} {pad(item.invt_opnn, 8)} "
-                f"{pad(item.rgbf_invt_opnn, 10)} {pad(item.hts_goal_prc, 10, 'right')} "
+                # 증권사명·의견은 외부 문자열 — 뉴스 제목과 같은 이유로 마크업 이스케이프.
+                f"{pad(item.stck_bsop_date, 10)} {pad(escape(item.mbcr_name or '-'), 12)} "
+                f"{pad(escape(item.invt_opnn or '-'), 8)} {pad(escape(item.rgbf_invt_opnn or '-'), 10)} "
+                f"{pad(item.hts_goal_prc, 10, 'right')} "
                 f"{pad((item.dprt or '-') + '%', 8, 'right')}"
             )
         return lines

--- a/apps/cluefin-desk/tests/unit/test_etf_analysis.py
+++ b/apps/cluefin-desk/tests/unit/test_etf_analysis.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from rich.text import Text
 from textual.app import App
 from textual.widgets import DataTable, Static
 
@@ -57,6 +58,12 @@ class TestFormatNavLines:
         assert "069500 — NAV 괴리 추이" in text
         assert "20260901" in text and "0.12%" in text
         assert "구성종목 상위" in text and "삼성전자" in text and "비중 31.2%" in text
+
+    def test_bracketed_component_name_survives_markup(self):
+        comp = _component()
+        comp.hts_kor_isnm = "[k]종목"
+        text = Text.from_markup("\n".join(EtfAnalysisScreen._format_nav_lines("069500", [], [comp]))).plain
+        assert "[k]종목" in text
 
     def test_empty_sections_say_so(self):
         text = "\n".join(EtfAnalysisScreen._format_nav_lines("069500", [], None))

--- a/apps/cluefin-desk/tests/unit/test_financial_analysis.py
+++ b/apps/cluefin-desk/tests/unit/test_financial_analysis.py
@@ -6,6 +6,8 @@
 from datetime import datetime
 from types import SimpleNamespace
 
+from rich.text import Text
+
 from cluefin_desk.screens.financial_analysis import FinancialAnalysisScreen
 
 
@@ -134,6 +136,13 @@ class TestFormatShareholderLines:
         text = "\n".join(FinancialAnalysisScreen._format_shareholder_lines([item], "2025"))
         assert "이재용" in text
         assert "1.63%" in text
+
+    def test_bracketed_name_survives_markup(self):
+        item = SimpleNamespace(
+            nm="[x]펀드", relate="[/특별관계자]", trmend_posesn_stock_co="1", trmend_posesn_stock_qota_rt="1"
+        )
+        text = Text.from_markup("\n".join(FinancialAnalysisScreen._format_shareholder_lines([item], "2025"))).plain
+        assert "[x]펀드" in text and "[/특별관계자]" in text
 
     def test_missing_relation_renders_as_dash(self):
         item = SimpleNamespace(nm="홍길동", relate=None, trmend_posesn_stock_co=None, trmend_posesn_stock_qota_rt=None)

--- a/apps/cluefin-desk/tests/unit/test_guard.py
+++ b/apps/cluefin-desk/tests/unit/test_guard.py
@@ -1,0 +1,21 @@
+"""screens/_guard.py — 실패 문구가 Rich 마크업으로 깨지지 않는지."""
+
+from types import SimpleNamespace
+
+from rich.text import Text
+
+from cluefin_desk.screens import _guard
+
+
+def test_guarded_failure_message_escapes_markup(monkeypatch):
+    """pydantic ValidationError 메시지는 "[type=string_too_long, ...]" 를 담는다 — 그대로 넣으면 태그로 읽혀 사라진다."""
+    shown: dict[str, str] = {}
+    monkeypatch.setattr(_guard, "set_text", lambda screen, selector, text: shown.__setitem__(selector, text))
+    screen = SimpleNamespace(is_attached=True)
+
+    def boom():
+        raise ValueError("1 validation error [type=string_too_long, input_value='x']")
+
+    _guard.guarded(screen, "#panel", "뉴스", boom)
+    plain = Text.from_markup(shown["#panel"]).plain
+    assert "[type=string_too_long, input_value='x']" in plain

--- a/apps/cluefin-desk/tests/unit/test_market_overview.py
+++ b/apps/cluefin-desk/tests/unit/test_market_overview.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 from loguru import logger
 from rich.cells import cell_len
+from rich.text import Text
 from textual.app import App
 from textual.widgets import Static
 
@@ -51,6 +52,10 @@ class TestMoverLines:
 
     def test_empty_says_so(self):
         assert MarketOverviewScreen._format_mover_lines("급등", [], positive=True)[1].strip() == "데이터 없음"
+
+    def test_bracketed_stock_name_survives_markup(self):
+        lines = MarketOverviewScreen._format_mover_lines("급등", [_mover("[a]종목", "10", "1.0")], positive=True)
+        assert "[a]종목" in Text.from_markup(lines[1]).plain
 
 
 class TestKisLines:

--- a/apps/cluefin-desk/tests/unit/test_stock_detail.py
+++ b/apps/cluefin-desk/tests/unit/test_stock_detail.py
@@ -40,6 +40,15 @@ class TestFormatBrokerLines:
         assert "매수사1" in text and "매도사5" in text
 
 
+class TestFormatBrokerMarkup:
+    def test_bracketed_names_survive_markup(self):
+        body = _broker_body()
+        body.stk_nm = "[kr]테스트"
+        body.buy_trde_ori_nm_1 = "[jp]모간"
+        rendered = Text.from_markup("\n".join(StockDetailScreen._format_broker_lines(body))).plain
+        assert "[kr]테스트" in rendered and "[jp]모간" in rendered
+
+
 class TestFormatMarginLines:
     def test_empty_says_so(self):
         assert StockDetailScreen._format_margin_lines([]) == ["신용거래 추이 데이터 없음"]
@@ -79,6 +88,19 @@ class TestFormatOpinionLines:
         )
         text = "\n".join(StockDetailScreen._format_opinion_lines([item]))
         assert "None" not in text
+
+    def test_bracketed_broker_name_survives_markup(self):
+        """증권사명도 뉴스 제목과 같은 경로로 마크업에 들어간다 — 소문자 대괄호는 태그로 먹힌다."""
+        item = SimpleNamespace(
+            stck_bsop_date="20260220",
+            mbcr_name="[nh]투자증권",
+            invt_opnn="[/매수]",
+            rgbf_invt_opnn="-",
+            hts_goal_prc="95,000",
+            dprt=None,
+        )
+        rendered = Text.from_markup("\n".join(StockDetailScreen._format_opinion_lines([item]))).plain
+        assert "[nh]투자증권" in rendered and "[/매수]" in rendered
 
 
 def _news_item(title="TCL, 삼성전자 제소", provider="9", dorg="뉴스핌", dt="20260902", tm="212221"):


### PR DESCRIPTION
## 관련 이슈

_(관련 이슈 없음)_ — #95 리뷰 후속 핸드오프(`docs/desk-news-tab-followups-handoff.md`) 4건 처리

## 변경 사항

#95 는 뉴스 제목만 `escape` 로 감쌌다. 그런데 증권사명·종목명·주주명·계정명·XBRL 라벨처럼
외부에서 오는 문자열이 같은 경로로 Rich 마크업에 들어가는 자리가 4개 화면에 더 있었고,
소문자 대괄호 접두어(`[nh]…`)는 태그로 먹혀 사라지고 `[/…]` 는 MarkupError 로 탭을 죽인다.

- **포매터 전부 이스케이프**: market_overview · etf_analysis · financial_analysis · stock_detail
  의 외부 문자열과 두 화면의 타이틀바. 포매터별 회귀 테스트 추가
- **`_guard.guarded` 실패 문구도 이스케이프**: pydantic ValidationError 메시지는 `[type=…]` 을
  담아, 응답 모델 거부로 탭이 실패하면 그 이유가 화면에서 지워지고 있었다. `test_guard.py` 신설
- **KIS 래퍼 강등 로그 debug→warning** (17곳): `KISAPIError`·`ValidationError` 를 `[]` 로
  강등하면 화면은 "데이터 없음"과 구분하지 못한다. None/[] 구분은 호출부 전체를 만져야 해
  미루고, 로그에서라도 구분되게 한다
- 종목 상세 docstring "4 tabs" → 실제 7탭

## 변경 유형

- [x] 버그 수정 (`fix`)
- [x] 테스트 추가/수정 (`test`)
- [ ] 새로운 기능 추가 (`feat`)
- [ ] 기존 기능 개선 (`feat`)
- [ ] 리팩토링 (`refactor`)
- [ ] 문서 수정 (`docs`)
- [ ] 의존성 업데이트 (`chore`)
- [ ] CI/CD (`ci`)

## 영향 범위

- [ ] cluefin-openapi
- [ ] cluefin-ta
- [ ] cluefin-xbrl
- [x] cluefin-desk
- [ ] 루트 프로젝트 설정

## 테스트

- [x] 단위 테스트 통과 (`uv run pytest apps/cluefin-desk -m "not integration and not slow"`, 190 passed)
- [ ] 통합 테스트 통과 — 네트워크 무관 변경으로 미실행
- [ ] 테스트 불필요
- 실화면 확인: `uv run cluefin-desk` → 005930 → 뉴스·투자의견 탭 (작성자 수동 확인)

## 체크리스트

- [x] `uv run ruff format . && uv run ruff check . --fix` 실행
- [x] 커밋 메시지가 컨벤션을 따름 (`type(scope): 설명`)
- [x] `.env`, 시크릿, 인증 정보 미포함
- [x] 관련 문서 업데이트 완료 — 완료된 핸드오프 문서는 untracked 상태였어 삭제만 함

## 참고 사항 (선택)

Rich 태그 정규식은 `[a-z#/@]` 로 시작하는 대괄호만 잡는다(대소문자 구분). 그래서 `[특징주]`·`[IR]`
은 무사하고 `[fnRASSI]`·`[e공시]` 만 사라졌다 — 회귀 테스트가 이 경계를 고정한다.
